### PR TITLE
Swanson Brain Maps - Fix typo in types

### DIFF
--- a/instances/latest/brainAtlasVersions/SwansonBM/SwansonBM_3rd-ed.jsonld
+++ b/instances/latest/brainAtlasVersions/SwansonBM/SwansonBM_3rd-ed.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
   "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/SwansonBM_3rd-ed",
-  "@type": "https://openminds.ebrains.eu/core/BrainAtlasVersion",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
   "abbreviation": "SwansonBM",
   "accessibility": {
     "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"

--- a/instances/latest/brainAtlases/SwansonBM.jsonld
+++ b/instances/latest/brainAtlases/SwansonBM.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
   "@id": "https://openminds.ebrains.eu/instances/brainAtlas/SwansonBM",
-  "@type": "https://openminds.ebrains.eu/core/BrainAtlas",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlas",
   "abbreviation": "SwansonBM",
   "author": null,
   "custodian": null,

--- a/instances/latest/commonCoordinateSpaceVersions/SwansonSRB/SwansonSRB_v1992.jsonld
+++ b/instances/latest/commonCoordinateSpaceVersions/SwansonSRB/SwansonSRB_v1992.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
   "@id": "https://openminds.ebrains.eu/instances/commonCoordinateSpaceVersion/SwansonSRB_v1992",
-  "@type": "https://openminds.ebrains.eu/core/CommonCoordinateSpaceVersion",
+  "@type": "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion",
   "abbreviation": "SwansonSRB",
   "accessibility": {
     "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"

--- a/instances/latest/commonCoordinateSpaces/SwansonSRB.jsonld
+++ b/instances/latest/commonCoordinateSpaces/SwansonSRB.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
   "@id": "https://openminds.ebrains.eu/instances/commonCoordinateSpace/SwansonSRB",
-  "@type": "https://openminds.ebrains.eu/core/CommonCoordinateSpace",
+  "@type": "https://openminds.ebrains.eu/sands/CommonCoordinateSpace",
   "abbreviation": "SwansonSRB",
   "author": null,
   "custodian": null,


### PR DESCRIPTION
We found a typo in the at_types of BrainAtlas, BrainAtlasVersion, CommonCoordinateSpace and CommonCoordinateSpaceVersion for the Swanson atlas.

My script made the types `https://openminds.ebrains.eu/core/[...]` instead of "sands".