### PR TITLE
Migration of missing contentTypes from core repo

### DIFF
--- a/instances/latest/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
+++ b/instances/latest/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.object-features+csv",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".csv"
+  ],
+  "name": "application/vnd.ilastik.object-features+csv",
+  "relatedMediaType": "https://www.iana.org/assignments/media-types/text/csv",
+  "specification": null,
+  "synonym": [
+    "ilastik object features CSV"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/latest/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.object-features+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".hdf5",
+    ".h5"
+  ],
+  "name": "application/vnd.ilastik.object-features+hdf5",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik object features HDF5"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
+++ b/instances/latest/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.project+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".ilp"
+  ],
+  "name": "application/vnd.ilastik.project+hdf5",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik project",
+    "ilastik project file",
+    "ILP"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.localizoom.lz.jsonld
+++ b/instances/latest/contentTypes/application_vnd.localizoom.lz.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.localizoom.lz",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".lz"
+  ],
+  "name": "application/vnd.localizoom.lz",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "LZ file"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.nest-simulator.model+python.jsonld
+++ b/instances/latest/contentTypes/application_vnd.nest-simulator.model+python.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.nest-simulator.model+python",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".py"
+  ],
+  "name": "application/vnd.nest-simulator.model+python",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "Python:NEST"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.nest-simulator.recording.jsonld
+++ b/instances/latest/contentTypes/application_vnd.nest-simulator.recording.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.nest-simulator.recording
+",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".gdf",
+    ".dat"
+  ],
+  "name": "application/vnd.nest-simulator.recording",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": null
+}

--- a/instances/latest/contentTypes/application_vnd.nestml.jsonld
+++ b/instances/latest/contentTypes/application_vnd.nestml.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.nestml",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".nestml"
+  ],
+  "name": "application/vnd.nestml",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "NESTML"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.qcalign+json.jsonld
+++ b/instances/latest/contentTypes/application_vnd.qcalign+json.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.qcalign+json",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".json"
+  ],
+  "name": "application/vnd.qcalign+json",
+  "relatedMediaType": "https://www.iana.org/assignments/media-types/application/json",
+  "specification": null,
+  "synonym": [
+    "QCAlign JavaScript Object Notation",
+    "QCAlign JSON"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.visualign.flat.jsonld
+++ b/instances/latest/contentTypes/application_vnd.visualign.flat.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.visualign.flat",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".flat"
+  ],
+  "name": "application/vnd.visualign.flat",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "VisuAlign flat file"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".hdf5",
+    ".h5"
+  ],
+  "name": "image/vnd.ilastik.pixelclassification+hdf5",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik pixel classification image (HDF5)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+n5.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+n5.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+n5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".n5"
+  ],
+  "name": "image/vnd.ilastik.pixelclassification+n5",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik pixel classification image (N5)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": null,
+  "name": "image/vnd.ilastik.pixelclassification+neuroglancer.precomputed",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik pixel classification image (neuroglancer precomputed)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.segmentation+dzi.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.segmentation+dzi.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+dzi",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".dzi",
+    ".xml"
+  ],
+  "name": "image/vnd.ilastik.segmentation+dzi",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik segmentation image (DZI)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.segmentation+dzip.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.segmentation+dzip.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+dzip",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".dzip"
+  ],
+  "name": "image/vnd.ilastik.segmentation+dzip",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik segmentation image (DZIP)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.segmentation+n5.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.segmentation+n5.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+n5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".n5"
+  ],
+  "name": "image/vnd.ilastik.segmentation+n5",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik segmentation image (N5)"
+  ]
+}

--- a/instances/latest/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed.jsonld
+++ b/instances/latest/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": null,
+  "name": "image/vnd.ilastik.segmentation+neuroglancer.precomputed",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "ilastik segmentation image (neuroglancer precomputed)"
+  ]
+}

--- a/instances/latest/contentTypes/image_x-hdf.jsonld
+++ b/instances/latest/contentTypes/image_x-hdf.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_x-hdf",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".hdf5",
+    ".h5"
+  ],
+  "name": "image/x-hdf",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "HDF5 image"
+  ]
+}


### PR DESCRIPTION
This is just a migration of the existing content with the necessary updates as described by @lzehl in issue #52:

filename: atid basename + ".jsonld"
atid basename: name with "/" replaced with "_"
name: IANA.org based naming convention

Stating specification or a description of the content types is postponed until later. This is just to complete the migration of the existing instances. An update of the instances is still required at a later point. I will make an issue to keep track of the "to-do" for the content types.