### PR TITLE
FreeSurfer metadata file as ContentType

### DIFF
--- a/instances/latest/contentTypes/application_vnd.freesurfer.metadata+json.jsonld
+++ b/instances/latest/contentTypes/application_vnd.freesurfer.metadata+json.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.freesurfer.metadata+json",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".json"
+  ],
+  "name": "application/vnd.freesurfer.metadata+json",
+  "relatedMediaType": "https://www.iana.org/assignments/media-types/application/json",
+  "specification": null,
+  "synonym": [
+    "FreeSurfer Metadata File"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.freesurfer.metadata+json.jsonld
+++ b/instances/latest/contentTypes/application_vnd.freesurfer.metadata+json.jsonld
@@ -1,9 +1,9 @@
 {
   "@context": {
-    "@vocab": "https://openminds.ebrains.eu/vocab/"
+    "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.freesurfer.metadata+json",
-  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.freesurfer.metadata+json",
+  "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": null,
   "displayLabel": null,


### PR DESCRIPTION
From https://github.com/openMetadataInitiative/openMINDS_core/pull/382. 

@lzehl requested review from @apdavison. I think the instance looked fine. I just updated it to the new schema specification, updated the content to the new convention, added a synonym (in accordance with other FreeSufer CoTy) and added the related IANA type (in accordance with other "+json" ContentTypes).   