### PR TITLE
Add PDB ContentTypes

### DIFF
--- a/instances/latest/contentTypes/application_vnd.pdbml+xml.jsonld
+++ b/instances/latest/contentTypes/application_vnd.pdbml+xml.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.pdbml+xml",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": null,
+  "displayLabel": null,
+  "fileExtension": [
+    ".xml"
+  ],
+  "name": "application/vnd.pdbml+xml",
+  "relatedMediaType": "https://www.iana.org/assignments/media-types/text/xml",
+  "specification": "https://pdbml.wwpdb.org/",
+  "synonym": [
+    "Protein Data Bank Markup Language",
+    "PDB Markup Language",
+    "PDBML"
+  ]
+}

--- a/instances/latest/contentTypes/application_vnd.pdbml+xml.jsonld
+++ b/instances/latest/contentTypes/application_vnd.pdbml+xml.jsonld
@@ -8,7 +8,7 @@
   "description": null,
   "displayLabel": null,
   "fileExtension": [
-    ".xml"
+    ".pdbml"
   ],
   "name": "application/vnd.pdbml+xml",
   "relatedMediaType": "https://www.iana.org/assignments/media-types/text/xml",

--- a/instances/latest/contentTypes/text_x-mmcif.jsonld
+++ b/instances/latest/contentTypes/text_x-mmcif.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/text_x-mmcif",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": "A textual file format for representing macromolecular structure data.",
+  "displayLabel": null,
+  "fileExtension": [
+    ".mmcif"
+  ],
+  "name": "text/x-mmcif",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "Macromolecular Crystallographic Information File Format",
+    "mmCIF Format",
+    "PDBx/mmCIF"
+  ]
+}

--- a/instances/latest/contentTypes/text_x-pdb.jsonld
+++ b/instances/latest/contentTypes/text_x-pdb.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/text_x-pdb",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "dataType": null,
+  "description": "A textual file format describing the three-dimensional structures of molecules held in the [Protein Data Bank](https://www.rcsb.org/).",
+  "displayLabel": null,
+  "fileExtension": [
+    ".pdb"
+  ],
+  "name": "text/x-pdb",
+  "relatedMediaType": null,
+  "specification": null,
+  "synonym": [
+    "Protein Data Bank Format"
+  ]
+}


### PR DESCRIPTION
related to #6 

Resources:
- https://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format): PDB 
- https://en.wikipedia.org/wiki/Macromolecular_Crystallographic_Information_File: mmCIF which is an alternative for PDB and the new default for the PDB
- https://www.wwpdb.org/documentation/file-format: links to mmCIF, PDBML and legacy PDB format; none of them seemed to me like good "specification" pages but feel free to disagree

