### PR TITLE
Add "parasagittal plane" as a synonym to longitudinalPlane.jsonld

### DIFF
--- a/instances/latest/terminologies/anatomicalPlane/longitudinalPlane.jsonld
+++ b/instances/latest/terminologies/anatomicalPlane/longitudinalPlane.jsonld
@@ -11,6 +11,7 @@
   "name": "longitudinal plane",
   "preferredOntologyIdentifier": null,
   "synonym": [
-    "sagittal plane"
+    "sagittal plane",
+    "parasagittal plane"
   ]
 }


### PR DESCRIPTION
I also note that the definition of longitudinal plane mentions "median plane", but we do not define this as a term.