### PR TITLE
separating MRI weightings from pulse sequences

### DIFF
--- a/instances/latest/terminologies/MRIWeighting/T1Weighting.jsonld
+++ b/instances/latest/terminologies/MRIWeighting/T1Weighting.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/MRIPulseSequence/T1Weighting",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/MRIWeighting",
+  "definition": "Weighting technique in magnetic resonance imaging that allows the magnetization of the specimen or object to recover (spin-lattice relaxation) before measuring the magnetic resonance signal by changing the repetition time. [adapted from [wikipedia](https://en.wikipedia.org/wiki/MRI_sequence)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "T1 weighting",
+  "preferredOntologyIdentifier": null,
+  "synonym": [
+    "T1 weighted imaging",
+    "T1 weighted magnetic resonance imaging",
+    "T1 weighted MRI",
+    "T1w imaging",
+    "T1w magnetic resonance imaging",
+    "T1w MRI"
+  ]
+}


### PR DESCRIPTION
related to https://github.com/openMetadataInitiative/openMINDS_instances/issues/156

----> new Terminology instance "MRI weighting"
----> move T1/T2 into new terminology
----> add T2star, proton-density to new terminology