### PR TITLE
UBERON terms with specific references in their names

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006099)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006099#brodmann-1909-area-1-1",
+  "name": "Brodmann (1909) area 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006099",
+  "synonym": [
+    "area 1 of Brodmann",
+    "area 1 of Brodmann-1909",
+    "area postcentralis intermedia",
+    "B09-1",
+    "BA1",
+    "Brodmann (1909) area 1",
+    "Brodmann area 1",
+    "Brodmann's area 1",
+    "intermediate postcentral",
+    "intermediate postcentral area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area10",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 10, or BA10, is part of the frontal cortex in the human brain. BA10 encompasses the most anterior part of the frontal cortex, known as the frontopolar region. This area is believed to play a part in strategic processes involved in memory retrieval and executive function. This area is also called frontopolar area 10, and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. It occupies the most rostral portions of the superior frontal gyrus and the middle frontal gyrus. In humans, on the medial aspect of the hemisphere it is bounded ventrally by the superior rostral sulcus (H). It does not extend as far as the cingulate sulcus. Cytoarchitecturally it is bounded dorsally by the granular frontal area 9, caudally by the middle frontal area 46, and ventrally by the orbital area 47 and by the rostral area 12 or, in an early version of Brodmann's cortical map (Brodmann-1909), the prefrontal Brodmann area 11-1909. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013541#brodmann-1909-area-10-1",
+  "name": "Brodmann (1909) area 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013541",
+  "synonym": [
+    "area 10 of Brodmann",
+    "area 10 of Brodmann-1909",
+    "area frontopolaris",
+    "B09-10",
+    "Brodmann (1909) area 10",
+    "Brodmann area 10",
+    "Brodmann area 10, frontoplar",
+    "lateral orbital area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area11",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "description": "Brodmann area 11 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning, reasoning, and decision making. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013528#brodmann-1909-area-11-1",
+  "name": "Brodmann (1909) area 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013528",
+  "synonym": [
+    "area 11 of Brodmann",
+    "area 11 of Brodmann-1909",
+    "B09-11",
+    "Brodmann (1909) area 11",
+    "Brodmann area 11, prefrontal",
+    "medial orbital area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area12",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "description": "Brodmann area 12 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It occupies the most rostral portion of the frontal lobe. Brodmann-1909 did not regard it as homologous, either topographically or cytoarchitecturally, to rostral area 12 of the human. Distinctive features (Brodmann-1905): a quite distinct internal granular layer (IV) separates slender pyramidal cells of the external pyramidal layer (III) and the internal pyramidal layer (V); the multiform layer (VI) is expanded, contains widely dispersed spindle cells and merges gradually with the underlying cortical white matter; all cells, including the pyramidal cells of the external and internal pyramidal layers are inordinately small; the internal pyramidal layer (V) also contains spindle cells in groups of two to five located close to its border with the internal granular layer (IV). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013543#brodmann-1909-area-12-1",
+  "name": "Brodmann (1909) area 12",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013543",
+  "synonym": [
+    "area 12 of Brodmann",
+    "area 12 of Brodmann-1909",
+    "area praefrontalis",
+    "B09-12",
+    "Brodmann (1909) area 12",
+    "Brodmann area 12",
+    "Brodmann area 12, prefrontal",
+    "frontopolar area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area13",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "description": "Brodmann area 13 is a subdivision of the cerebral cortex as defined on the guenon monkey and on the basis of cytoarchitecture. Brodmann area 13 is found in humans, however it seems to act as a bridge between the lateral and medial layers of the brain. Thus it is sometimes misidentified as not being a Brodmann area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013544#brodmann-1909-area-13-1",
+  "name": "Brodmann (1909) area 13",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013544",
+  "synonym": [
+    "area 13 of Brodmann-1909",
+    "B09-13",
+    "Brodmann (1909) area 13",
+    "Brodmann area 13"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area14",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545) ('is_a' and 'relationship')]",
+  "description": "Brodmann Area 14 is one of Brodmann's subdivisions of the cerebral cortex in the brain. It was defined by Brodmann in the guenon monkey. No equivalent structure exists in humans. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013545#brodmann-1909-area-14-1",
+  "name": "Brodmann (1909) area 14",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013545",
+  "synonym": [
+    "area 14 of Brodmann-1909",
+    "B09-14",
+    "Brodmann (1909) area 14",
+    "Brodmann area 14"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area15",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "description": "Brodmann Area 15 is one of Brodmann's subdivisions of the cerebral cortex in the brain. Area 15 was defined by Brodmann in the guenon monkey, but he found no equivalent structure in humans. However, functional imaging experiments have found structures that may be homologous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013546#brodmann-1909-area-15-1",
+  "name": "Brodmann (1909) area 15",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013546",
+  "synonym": [
+    "area 15 of Brodmann-1909",
+    "B09-15",
+    "Brodmann (1909) area 15",
+    "Brodmann area 15"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area16",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "description": "Brodmann area 16 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It is a relatively undifferentiated cortical area that Brodmann regarded as part of the insula because of the relation of its innermost multiform layer (VI) with the claustrum (VICl). The laminar organization of cortex is almost totally lacking. The molecular layer (I) is wide as in area 15 of Brodmann-1905. The space between layer I and layer VI is composed of a mixture of pyramidal cells and spindle cells with no significant number of granule cells. Pyramidal cells clump in the outer part to form glomeruli similar to those seen in some of the primary olfactory areas (Brodmann-1905). This term also refers to an area known as peripaleocortical claustral - a cytoarchitecturally defined (agranular) portion of the insula at its rostral extreme where it approaches most closely the claustrum and the prepyriform area (Stephan-76). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013547#brodmann-1909-area-16-1",
+  "name": "Brodmann (1909) area 16",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013547",
+  "synonym": [
+    "area 16 of Brodmann",
+    "area 16 of Brodmann-1909",
+    "B09-16",
+    "Brodmann (1909) area 16",
+    "Brodmann area 16"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area18",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006473) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006473#brodmann-1909-area-18-1",
+  "name": "Brodmann (1909) area 18",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006473",
+  "synonym": [
+    "area 18 of Brodmann",
+    "area 18 of Brodmann-1909",
+    "area parastriata",
+    "area parastriata",
+    "B09-18",
+    "BA18",
+    "Brodmann (1909) area 18",
+    "Brodmann area 18",
+    "Brodmann area 18, parastriate",
+    "Brodmann's area 18",
+    "parastriate area 18",
+    "secondary visual area",
+    "visual area II"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area19",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 19, or BA19, is part of the occipital lobe cortex in the human brain. Along with area 18, it comprises the extrastriate (or peristriate) cortex. In normally-sighted humans, extrastriate cortex is a visual association area, with feature-extracting, shape recognition, attentional, and multimodal integrating functions. This area is also known as peristriate area 19, and it refers to a subdivision of the cytoarchitecturally defined occipital region of cerebral cortex. In the human it is located in parts of the lingual gyrus, the cuneus, the lateral occipital gyrus (H) and the superior occipital gyrus (H) of the occipital lobe where it is bounded approximately by the parieto-occipital sulcus. Cytoarchitecturally it is bounded on one side by the parastriate area 18 which it surrounds. Rostrally it is bounded by the angular area 39 (H) and the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013550#brodmann-1909-area-19-1",
+  "name": "Brodmann (1909) area 19",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013550",
+  "synonym": [
+    "area 19 of Brodmann",
+    "area 19 of Brodmann-1909",
+    "area peristriata",
+    "B09-19",
+    "Brodmann (1909) area 19",
+    "Brodmann area 19",
+    "Brodmann area 19, peristriate",
+    "Brodmann's area 19",
+    "preoccipital area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013533)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013533#brodmann-1909-area-2-1",
+  "name": "Brodmann (1909) area 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013533",
+  "synonym": [
+    "area 2 of Brodmann",
+    "area 2 of Brodmann-1909",
+    "area postcentralis caudalis",
+    "B09-2",
+    "Brodmann (1909) area 2",
+    "Brodmann area 2",
+    "Brodmann area 2, caudal postcentral",
+    "Brodmann's area 2",
+    "caudal postcentral area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area20",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "description": "Brodmann area 20, or BA20, is part of the temporal cortex in the human brain. The region encompasses most of the ventral temporal cortex, a region believed to play a part in high-level visual processing and recognition memory. This area is also known as inferior temporal area 20, and it refers to a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the inferior temporal gyrus. Cytoarchitecturally it is bounded medially by the ectorhinal area 36 (H), laterally by the middle temporal area 21, rostrally by the temporopolar area 38 (H) and caudally by the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013551#brodmann-1909-area-20-1",
+  "name": "Brodmann (1909) area 20",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013551",
+  "synonym": [
+    "area 20 of Brodmann",
+    "area 20 of Brodmann-1909",
+    "area temporalis inferior",
+    "B09-20",
+    "Brodmann (1909) area 20",
+    "Brodmann area 20",
+    "Brodmann area 20, inferior temporal",
+    "inferior temporal area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area21",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the temporal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 21, or BA21, is part of the temporal cortex in the human brain. The region encompasses most of the lateral temporal cortex, a region believed to play a part in auditory processing and language. Language function is left lateralized in most individuals. BA21 is superior to BA20 and inferior to BA40 and BA41. This area is also known as middle temporal area 21. It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the middle temporal gyrus. It is bounded rostrally by the temporopolar area 38 (H), ventrally by the inferior temporal area 20, caudally by the occipitotemporal area 37 (H), and dorsally by the superior temporal area 22 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013552#brodmann-1909-area-21-1",
+  "name": "Brodmann (1909) area 21",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013552",
+  "synonym": [
+    "area 21 of Brodmann",
+    "area 21 of Brodmann-1909",
+    "B09-21",
+    "BA21",
+    "Brodmann (1909) area 21",
+    "Brodmann area 21",
+    "Brodmann area 21, middle temporal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area22",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "description": "Brodmann area 22 is one of Brodmann's cytologically defined regions of the brain. It is involved in auditory processing. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013553#brodmann-1909-area-22-1",
+  "name": "Brodmann (1909) area 22",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013553",
+  "synonym": [
+    "area 22 of Brodmann",
+    "area 22 of Brodmann-1909",
+    "area temporalis superior",
+    "area temporalis superior",
+    "B09-22",
+    "Brodmann (1909) area 22",
+    "Brodmann area 22",
+    "Brodmann area 22, superior temporal",
+    "Superior temporal area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area23",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "description": "The term area 23 of Brodmann-1909 refers to a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. Brodmann regarded it as topographically and cytoarchitecturally homologous to the combined ventral posterior cingulate area 23 and dorsal posterior cingulate area 31 of the human (Brodmann-1909). Distinctive Features (Brodmann-1905): the cortex is relatively thin; smaller cells predominate; the cell density of the multiform layer (VI) is great, producing a distinct boundary with the subcortical white matter; the internal granular layer (IV) is rather well developed; the internal pyramidal layer (V) contains a dense population of round, medium-sized ganglion cells concentrated at the border with layer IV; layers V and VI are narrow with a distinct mutual boundary.nn* Definition Source NeuroNames. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013554#brodmann-1909-area-23-1",
+  "name": "Brodmann (1909) area 23",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013554",
+  "synonym": [
+    "area 23 of Brodmann",
+    "area 23 of Brodmann-1909",
+    "area cingularis posterior ventralis",
+    "area cingularis posterior ventralis",
+    "B09-23",
+    "Brodmann (1909) area 23",
+    "Brodmann area 23",
+    "Brodmann area 23, ventral posterior cingulate",
+    "granular cingulate area",
+    "posterior cingulate area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area24",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the anterior cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006101) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006101#brodmann-1909-area-24-1",
+  "name": "Brodmann (1909) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006101",
+  "synonym": [
+    "area 24 of Brodmann",
+    "area 24 of Brodmann-1909",
+    "area cingularis anterior ventralis",
+    "B09-24",
+    "BA24",
+    "Brodmann (1909) area 24",
+    "Brodmann area 24",
+    "ventral anterior cingulate"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area25",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "description": "Brodmann area 25 (BA25) is an area in the cerebral cortex of the brain and delineated based on its cytoarchitectonic characteristics. It is also called the subgenual area or area subgenualis. It is the 25th 'Brodmann area' defined by Korbinian Brodmann (thus its name). BA25 is located in the cingulate region as a narrow band in the caudal portion of the subcallosal area adjacent to the paraterminal gyrus. The posterior parolfactory sulcus separates the paraterminal gyrus from BA25. Rostrally it is bound by the prefrontal area 11 of Brodmann. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013556#brodmann-1909-area-25-1",
+  "name": "Brodmann (1909) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013556",
+  "synonym": [
+    "area 25 of Brodmann",
+    "area 25 of Brodmann-1909",
+    "area subgenualis",
+    "B09-25",
+    "Brodmann (1909) area 25",
+    "Brodmann area 25",
+    "Brodmann area 25, subgenual",
+    "Brodmann's area 25"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area26",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004718)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004718#brodmann-1909-area-26-1",
+  "name": "Brodmann (1909) area 26",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004718",
+  "synonym": [
+    "area 26 of Brodmann",
+    "area 26 of Brodmann-1909",
+    "area ectosplenialis",
+    "B09-26",
+    "Brodmann (1909) area 26",
+    "Brodmann area 26",
+    "Brodmann area 26, ectosplenial",
+    "ectosplenial area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area27",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the presubiculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558) ('is_a' and 'relationship')]",
+  "description": "Area 27 of Brodmann-1909 is a cytoarchitecturally defined cortical area that is a rostral part of the parahippocampal gyrus of the guenon (Brodmann-1909). It is commonly regarded as a synonym of presubiculum (Crosby-62). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013558#brodmann-1909-area-27-1",
+  "name": "Brodmann (1909) area 27",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013558",
+  "synonym": [
+    "area 27",
+    "area 27 of Brodmann",
+    "area 27 of Brodmann-1909",
+    "area praesubicularis",
+    "B09-27",
+    "BA27",
+    "Brodmann (1909) area 27",
+    "Brodmann area 26, presubicular",
+    "Brodmann area 27",
+    "presubicular area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area28",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the secondary olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013559) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013559#brodmann-1909-area-28-1",
+  "name": "Brodmann (1909) area 28",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013559",
+  "synonym": [
+    "area 28 of Brodmann",
+    "area 28 of Brodmann (Crosby)",
+    "area 28 of Brodmann-1909",
+    "area entorhinalis",
+    "area entorhinalis ventralis",
+    "B09-28",
+    "BA28",
+    "Brodmann (1909) area 28",
+    "Brodmann area 28",
+    "Brodmann area 28, entorhinal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area29",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "description": "Brodmann area 29, also known as granular retrolimbic area 29 or granular retrosplenial cortex, is a cytoarchitecturally defined portion of the retrosplenial region of the cerebral cortex. In the human it is a narrow band located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the ectosplenial area 26 and externally by the agranular retrolimbic area 30 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004717#brodmann-1909-area-29-1",
+  "name": "Brodmann (1909) area 29",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004717",
+  "synonym": [
+    "area 29 of Brodmann",
+    "area 29 of Brodmann-1909",
+    "area retrolimbica granularis",
+    "B09-29",
+    "Brodmann (1909) area 29",
+    "Brodmann area 29",
+    "Brodmann area 29, granular retrolimbic",
+    "Brodmann's area 29"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006100)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006100#brodmann-1909-area-3-1",
+  "name": "Brodmann (1909) area 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006100",
+  "synonym": [
+    "area 3 of Brodmann",
+    "area 3 of Brodmann-1909",
+    "area postcentralis oralis",
+    "B09-3",
+    "BA3",
+    "Brodmann (1909) area 3",
+    "Brodmann area 3",
+    "Brodmann's area 3",
+    "rostral postcentral",
+    "rostral postcentral area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area30",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "description": "Brodmann area 30, also known as agranular retrolimbic area 30, is a subdivision of the cytoarchitecturally defined retrosplenial region of the cerebral cortex. In the human it is located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the granular retrolimbic area 29, dorsally by the ventral posterior cingulate area 23 and ventrolaterally by the ectorhinal area 36 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006474#brodmann-1909-area-30-1",
+  "name": "Brodmann (1909) area 30",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006474",
+  "synonym": [
+    "agranular retrolimbic area 30",
+    "area 30 of Brodmann",
+    "area 30 of Brodmann-1909",
+    "area retrolimbica agranularis",
+    "area retrosplenialis agranularis",
+    "B09-30",
+    "BA30",
+    "Brodmann (1909) area 30",
+    "Brodmann area 30",
+    "Brodmann area 30, agranular retrolimbic",
+    "Brodmann's area 30"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area31",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "description": "Brodmann area 31, also known as dorsal posterior cingulate area 31, is a subdivision of the cytoarchitecturally defined cingulate region of the cerebral cortex. In the human it occupies portions of the posterior cingulate gyrus and medial aspect of the parietal lobe. Approximate boundaries are the cingulate sulcus dorsally and the parieto-occipital sulcus caudally. It partially surrounds the subparietal sulcus, the ventral continuation of the cingulate sulcus in the parietal lobe. Cytoarchitecturally it is bounded rostrally by the ventral anterior cingulate area 24, ventrally by the ventral posterior cingulate area 23, dorsally by the gigantopyramidal area 4 and preparietal area 5 and caudally by the superior parietal area 7 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006475#brodmann-1909-area-31-1",
+  "name": "Brodmann (1909) area 31",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006475",
+  "synonym": [
+    "area 31 of Brodmann",
+    "area 31 of Brodmann-1909",
+    "area cingularis posterior dorsalis",
+    "area cingularis posterior dorsalis",
+    "B09-31",
+    "BA31",
+    "Brodmann (1909) area 31",
+    "Brodmann area 31",
+    "Brodmann area 31, dorsal posterior cingulate",
+    "Brodmann's area 31",
+    "cinguloparietal transition area",
+    "dorsal posterior cingulate area 31"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area32",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "description": "The Brodmann area 32, also known in the human brain as the dorsal anterior cingulate area 32, refers to a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. In the human it forms an outer arc around the anterior cingulate gyrus. The cingulate sulcus defines approximately its inner boundary and the superior rostral sulcus (H) its ventral boundary; rostrally it extends almost to the margin of the frontal lobe. Cytoarchitecturally it is bounded internally by the ventral anterior cingulate area 24, externally by medial margins of the agranular frontal area 6, intermediate frontal area 8, granular frontal area 9, frontopolar area 10, and prefrontal area 11-1909. (Brodmann19-09). Dorsal region of anterior cingulate gyrus is associated with rational thought processes, most notably active during the Stroop task. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013560#brodmann-1909-area-32-1",
+  "name": "Brodmann (1909) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013560",
+  "synonym": [
+    "area 32 of Brodmann",
+    "area 32 of Brodmann-1909",
+    "area cingularis anterior dorsalis",
+    "area cingularis anterior dorsalis",
+    "B09-32",
+    "Brodmann (1909) area 32",
+    "Brodmann area 32",
+    "Brodmann area 32, dorsal anterior cingulate",
+    "Prelimbic area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area33",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 33, also known as pregenual area 33, is a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. It is a narrow band located in the anterior cingulate gyrus adjacent to the supracallosal gyrus in the depth of the callosal sulcus, near the genu of the corpus callosum. Cytoarchitecturally it is bounded by the ventral anterior cingulate area 24 and the supracallosal gyrus (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006476#brodmann-1909-area-33-1",
+  "name": "Brodmann (1909) area 33",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006476",
+  "synonym": [
+    "area 33 of Brodmann",
+    "area 33 of Brodmann-1909",
+    "area praegenualis",
+    "area praegenualis",
+    "B09-33",
+    "BA33",
+    "Brodmann (1909) area 33",
+    "Brodmann area 33",
+    "Brodmann area 33, pregenual",
+    "Brodmann's area 33",
+    "pregenual area 33"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area34",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "description": "Brodmann area 34 is a part of the brain. It has been described as part of the entorhinal area. It has been described as part of the superior temporal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006477#brodmann-1909-area-34-1",
+  "name": "Brodmann (1909) area 34",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006477",
+  "synonym": [
+    "area 34 of Brodmann",
+    "area 34 of Brodmann-1909",
+    "area entorhinalis dorsalis",
+    "area entorhinalis dorsalis",
+    "B09-34",
+    "BA34",
+    "Brodmann (1909) area 34",
+    "Brodmann area 34",
+    "Brodmann area 34, dorsal entorhinal",
+    "dorsal entorhinal area 34"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area35",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 35, together with Brodmann area 36, is most frequently referred to as perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006102#brodmann-1909-area-35-1",
+  "name": "Brodmann (1909) area 35",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006102",
+  "synonym": [
+    "area 35 of Brodmann",
+    "area 35 of Brodmann-1909",
+    "area perirhinalis",
+    "B09-35",
+    "BA35",
+    "Brodmann (1909) area 35",
+    "Brodmann area 35",
+    "Brodmann area 35, perirhinal",
+    "Brodmann's area 35",
+    "perirhinal area 35"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area36",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104) ('is_a' and 'relationship')]",
+  "description": "Ectorhinal area 36 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. With its medial boundary corresponding approximately to the rhinal sulcus it is located primarily in the fusiform gyrus. Cytoarchitecturally it is bounded laterally and caudally by the inferior temporal area 20, medially by the perirhinal area 35 and rostrally by the temporopolar area 38 (H) (Brodmann-1909). Together with Brodmann area 35, it comprises the perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006104#brodmann-1909-area-36-1",
+  "name": "Brodmann (1909) area 36",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006104",
+  "synonym": [
+    "area 36 of Brodmann",
+    "area 36 of Brodmann-1909",
+    "area ectorhinalis",
+    "B09-36",
+    "BA36",
+    "Brodmann (1909) area 36",
+    "Brodmann area 36",
+    "ectorhinal",
+    "ectorhinal area 36"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area37",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "description": "Brodmann area 37, or BA37, is part of the temporal cortex in the human brain. This area is known as occipitotemporal area 37 (H). It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the caudal portions of the fusiform gyrus and inferior temporal gyrus on the mediobasal and lateral surfaces at the caudal extreme of the temporal lobe. Cytoarchitecturally it is bounded caudally by the peristriate Brodmann area 19, rostrally by the inferior temporal area 20 and middle temporal area 21 and dorsally on the lateral aspect of the hemisphere by the angular area 39 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006478#brodmann-1909-area-37-1",
+  "name": "Brodmann (1909) area 37",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006478",
+  "synonym": [
+    "area 37 0f brodmann",
+    "area 37 of Brodmann-1909",
+    "area occipitotemporalis",
+    "area occipitotemporalis",
+    "B09-37",
+    "BA37",
+    "Brodmann (1909) area 37",
+    "Brodmann area 37",
+    "Brodmann area 37, occipitotemporal",
+    "occipitotemporal area 37"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area38",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "description": "Brodmann area 38, also BA38 or temporopolar area 38 (H), is part of the temporal cortex in the human brain. BA 38 is at the anterior end of the temporal lobe, known as the temporal pole. BA38 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the most rostral portions of the superior temporal gyrus and the middle temporal gyrus. Cytoarchitecturally it is bounded caudally by the inferior temporal area 20, the middle temporal area 21, the superior temporal area 22 and the ectorhinal area 36 (Brodmann-1909). Cytoarchitectonic and chemoarchitectonic studies find that it contains at least seven subareas, one of which, TG, is unique to humans. 'The functional significance of this area TG is not known, but it may bind complex, highly processed perceptual inputs to visceral emotional responses.' This area is among the earliest affected by Alzheimer's disease and the earliest involved at the start of temporal lobe seizures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006479#brodmann-1909-area-38-1",
+  "name": "Brodmann (1909) area 38",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006479",
+  "synonym": [
+    "area 38 of Brodmann",
+    "area 38 of Brodmann-1909",
+    "area temporopolaris",
+    "B09-38",
+    "BA38",
+    "Brodmann (1909) area 38",
+    "Brodmann area 38",
+    "Brodmann area 38, temporopolar",
+    "temporopolar area 38"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area39",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006480)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006480#brodmann-1909-area-39-1",
+  "name": "Brodmann (1909) area 39",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006480",
+  "synonym": [
+    "angular area 39",
+    "area 39 of Brodmann",
+    "area 39 of Brodmann-1909",
+    "area angularis",
+    "B09-39",
+    "BA39",
+    "Brodmann (1909) area 39",
+    "Brodmann area 39",
+    "Brodmann area 39, angular"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the primary motor cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535) ('is_a' and 'relationship')]",
+  "description": "The term area 4 of Brodmann-1909 refers to a cytoarchitecturally defined portion of the frontal lobe of the guenon. It is located predominantly in the precentral gyrus. Brodmann-1909 regarded it as topographically and cytoarchitecturally homologous to the human gigantopyramidal area 4 and noted that it occupies a much greater fraction of the frontal lobe in the monkey than in the human. Distinctive features (Brodmann-1905): the cortex is unusually thick; the layers are not distinct; the cells are relatively sparsely distributed; giant pyramidal (Betz) cells are present in the internal pyramidal layer (V); lack of an internal granular layer (IV) such that the boundary between the external pyramidal layer (III) and the internal pyramidal layer (V) is indistinct; lack of a distinct external granular layer (II); a gradual transition from the multiform layer (VI) to the subcortical white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013535#brodmann-1909-area-4-1",
+  "name": "Brodmann (1909) area 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013535",
+  "synonym": [
+    "area 4 of Brodmann",
+    "area 4 of Brodmann-1909",
+    "area gigantopyramidalis",
+    "B09-4",
+    "Brodmann (1909) area 4",
+    "Brodmann area 4",
+    "Brodmann area 4, gigantopyramidal",
+    "Brodmann's area 4",
+    "giant pyramidal area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area40",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the supramarginal gyrus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 40, or BA40, is part of the parietal cortex in the human brain. The inferior part of BA40 is in the area of the supramarginal gyrus, which lies at the posterior end of the lateral fissure, in the inferior lateral part of the parietal lobe. It is bounded approximately by the intraparietal sulcus, the inferior postcentral sulcus, the posterior subcentral sulcus and the lateral sulcus. Cytoarchitecturally it is bounded caudally by the angular area 39 (H), rostrally and dorsally by the caudal postcentral area 2, and ventrally by the subcentral area 43 and the superior temporal area 22 (Brodmann-1909). Cytoarchitectonically defined subregions of rostral BA40/the supramarginal gyrus are PF, PFcm, PFm, PFop, and PFt. Area PF is the homologue to macaque area PF, part of the mirror neuron system, and active in humans during imitation. The supramarginal gyrus part of Brodmann area 40 is the region in the inferior parietal lobe that is involved in reading both in regards to meaning and phonology. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013573#brodmann-1909-area-40-1",
+  "name": "Brodmann (1909) area 40",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013573",
+  "synonym": [
+    "area 40 of Brodmann",
+    "area 40 of Brodmann-1909",
+    "area supramarginalis",
+    "B09-40",
+    "Brodmann (1909) area 40",
+    "Brodmann area 40",
+    "Brodmann area 40, supramarginal",
+    "Supramarginal area 40"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area43",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "description": "Brodmann area 43 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It was described (but not labeled) on the map of cortical areas in Brodmann-1909, and it was regarded as cytoarchitecturally homologous to area 30 of Mauss in 1908 in the guenon and subcentral area 43 of the human (Brodmann-1909). The Vogts found no distinctive architectonic area of the corresponding location in the guenon (Vogts-1919). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013561#brodmann-1909-area-43-1",
+  "name": "Brodmann (1909) area 43",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013561",
+  "synonym": [
+    "area 43 of brodmann",
+    "area 43 of Brodmann-1909",
+    "area subcentralis",
+    "B09-43",
+    "Brodmann (1909) area 43",
+    "Brodmann area 43",
+    "Brodmann area 43, subcentral"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area44",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "description": "Brodmann area 44, or BA44, is part of the frontal cortex in the human brain. Situated just anterior to premotor cortex and on the lateral surface, inferior to BA9. This area is also known as pars opercularis (of the inferior frontal gyrus), and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. In the human it corresponds approximately to the opercular part of inferior frontal gyrus (H). Thus, it is bounded caudally by the inferior precentral sulcus (H) and rostrally by the anterior ascending limb of lateral sulcus (H). It surrounds the diagonal sulcus (H). In the depth of the lateral sulcus it borders on the insula. Cytoarchitectonically it is bounded caudally and dorsally by the agranular frontal area 6, dorsally by the granular frontal area 9 and rostrally by the triangular area 45 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006481#brodmann-1909-area-44-1",
+  "name": "Brodmann (1909) area 44",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006481",
+  "synonym": [
+    "area 44 of Brodmann",
+    "area 44 of Brodmann-1909",
+    "area opercularis",
+    "B09-44",
+    "BA44",
+    "Brodmann (1909) area 44",
+    "Brodmann area 44",
+    "Brodmann area 44, opercular",
+    "opercular area 44"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area45",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the frontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482) ('is_a' and 'relationship')]",
+  "description": "Part of the cytoarchitecturally defined frontal region of cerebral cortex. In the human, it occupies the triangular part of the inferior frontal gyrus (human) and, surrounding the anterior horizontal limb of the lateral sulcus (human), a portion of the orbital part of the inferior frontal gyrus (human). Bounded caudally by the anterior ascending limb of the lateral sulcus (human), it borders on the insula in the depth of the lateral sulcus. Cytoarchitectonically it is bounded caudally by the opercular area 44, rostrodorsally by the area 46 of Brodmann (human) and ventrally by the area 47 of Brodmann (human) (Brodmann-1909) (Adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006482#brodmann-1909-area-45-1",
+  "name": "Brodmann (1909) area 45",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006482",
+  "synonym": [
+    "area 45 of Brodmann",
+    "area 45 of Brodmann-1909",
+    "area triangularis",
+    "area triangularis",
+    "B09-45",
+    "BA45",
+    "Brodmann (1909) area 45",
+    "Brodmann area 45",
+    "Brodmann area 45, triangular",
+    "triangular area 45"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area46",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "description": "Brodmann area 46, or BA46, is part of the frontal cortex in the human brain. It is between BA10 and BA45. BA46 is known as middle frontal area 46. In the human it occupies approximately the middle third of the middle frontal gyrus and the most rostral portion of the inferior frontal gyrus. Brodmann area 46 roughly corresponds with the dorsolateral prefrontal cortex (DLPFC), although the borders of area 46 are based on cytoarchitecture rather than function. The DLPFC also encompasses part of granular frontal area 9, directly adjacent on the dorsal surface of the cortex. Cytoarchitecturally, BA46 is bounded dorsally by the granular frontal area 9, rostroventrally by the frontopolar area 10 and caudally by the triangular area 45 (Brodmann-1909). There is some discrepancy between the extent of BA8 (Brodmann-1905) and the same area as described by Walker (1940) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006483#brodmann-1909-area-46-1",
+  "name": "Brodmann (1909) area 46",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006483",
+  "synonym": [
+    "area 46 of Brodmann",
+    "area 46 of Brodmann-1909",
+    "area frontalis media",
+    "B09-46",
+    "BA46",
+    "Brodmann (1909) area 46",
+    "Brodmann area 46",
+    "Brodmann area 46, middle frontal",
+    "middle frontal area 46"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area47",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "description": "Brodmann area 47, or BA47, is part of the frontal cortex in the human brain. Curving from the lateral surface of the frontal lobe into the ventral (orbital) frontal cortex. It is below areas BA10 and BA45, and beside BA11. This area is also known as orbital area 47. In the human, on the orbital surface it surrounds the caudal portion of the orbital sulcus (H) from which it extends laterally into the orbital part of inferior frontal gyrus (H). Cytoarchitectonically it is bounded caudally by the triangular area 45, medially by the prefrontal area 11 of Brodmann-1909, and rostrally by the frontopolar area 10 (Brodmann-1909). It incorporates the region that Brodmann identified as 'Area 12' in the monkey, and therefore, following the suggestion of Michael Petrides, some contemporary neuroscientists refer to the region as 'BA47/12. ' BA47 has been implicated in the processing of syntax in spoken and signed languages, and more recently in musical syntax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006484#brodmann-1909-area-47-1",
+  "name": "Brodmann (1909) area 47",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006484",
+  "synonym": [
+    "area 47 of Brodmann",
+    "area 47 of Brodmann-1909",
+    "area orbitalis",
+    "area orbitalis",
+    "B09-47",
+    "BA47",
+    "Brodmann (1909) area 47",
+    "Brodmann area 47",
+    "Brodmann area 47, orbital",
+    "orbital area 47"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area48",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "description": "Retrosubicular area 48 is a subdivision of the cytoarchitecturally defined hippocampal region of the cerebral cortex. In the human it is located on the medial surface of the temporal lobe. Cytoarchitectually it is bounded rostrally by the perirhinal area 35 and medially by the presubiculum. While described by Brodmann (Brodmann-1909), it was not included in his areal maps of human cortex (Brodmann-1909; Brodmann-1910). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006485#brodmann-1909-area-48-1",
+  "name": "Brodmann (1909) area 48",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006485",
+  "synonym": [
+    "area 48 of Brodmann",
+    "area retrosubicularis",
+    "B09-48",
+    "BA48",
+    "Brodmann (1909) area 48",
+    "Brodmann area 48",
+    "Brodmann area 48, retrosubicular",
+    "Brodmann's area 48",
+    "retrosubicular area 48"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "description": "Brodmann area 5 is one of Brodmann's cytologically defined regions of the brain. It is involved in somatosensory processing and association. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006471#brodmann-1909-area-5-1",
+  "name": "Brodmann (1909) area 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006471",
+  "synonym": [
+    "area 5 of Brodmann-1909",
+    "area praeparietalis",
+    "B09-5",
+    "BA5",
+    "Brodmann (1909) area 5",
+    "Brodmann area 5",
+    "Brodmann area 5, preparietal",
+    "preparietal area 5"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area52",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "description": "Parainsular area 52 (H) is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located in the bank of the lateral sulcus on the dorsal surface of the temporal lobe. Its medial boundary corresponds approximately to the junction between the temporal lobe and the insula. Cytoarchitecturally it is bounded laterally by the anterior transverse temporal area 42 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006486#brodmann-1909-area-52-1",
+  "name": "Brodmann (1909) area 52",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006486",
+  "synonym": [
+    "area 52 of Brodmann",
+    "area parainsularis",
+    "B09-52",
+    "BA52",
+    "Brodmann (1909) area 52",
+    "Brodmann area 52",
+    "Brodmann area 52, parainsular",
+    "parainsular area 52"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area6",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "description": "Brodmann area 6, or BA6, is part of the frontal cortex in the human brain. Situated just anterior to the primary motor cortex, it is composed of the premotor cortex and, medially, the supplementary motor area, or SMA. This large area of the frontal cortex is believed to play a role in the planning of complex, coordinated movements. Brodmann area 6 is also called agranular frontal area 6 in humans because it lacks an internal granular cortical layer (layer IV). It is a subdivision of the cytoarchitecturally defined precentral region of cerebral cortex. In the human brain, it is located on the portions of the precentral gyrus that are not occupied by the gigantopyramidal area 4; furthermore, BA6 extends onto the caudal portions of the superior frontal and middle frontal gyri. It extends from the cingulate sulcus on the medial aspect of the hemisphere to the lateral sulcus on the lateral aspect. It is bounded rostrally by the granular frontal region and caudally by the gigantopyramidal area 4 (Brodmann, 1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006472#brodmann-1909-area-6-1",
+  "name": "Brodmann (1909) area 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006472",
+  "synonym": [
+    "agranular frontal area 6",
+    "area 6 of Brodmann",
+    "area 6 of Brodmann-1909",
+    "area frontalis agranularis",
+    "B09-6",
+    "BA6",
+    "Brodmann (1909) area 6",
+    "Brodmann area 6",
+    "Brodmann area 6, agranular frontal",
+    "frontal belt"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "description": "Brodmann area 7 is one of Brodmann's cytologically defined regions of the brain. It is involved in locating objects in space. It serves as a point of convergence between vision and proprioception to determine where objects are in relation to parts of the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013538#brodmann-1909-area-7-1",
+  "name": "Brodmann (1909) area 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013538",
+  "synonym": [
+    "area 7 of Brodmann",
+    "area 7 of Brodmann-1909",
+    "area parietalis superior",
+    "area parietalis superior",
+    "B09-7",
+    "Brodmann (1909) area 7",
+    "Brodmann area 7",
+    "Brodmann area 7, superior parietal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "description": "Brodmann area 8 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning complex movements. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013539#brodmann-1909-area-8-1",
+  "name": "Brodmann (1909) area 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013539",
+  "synonym": [
+    "area 8 of Brodmann",
+    "area 8 of Brodmann-1909",
+    "area frontalis intermedia",
+    "area frontalis intermedia",
+    "B09-8",
+    "Brodmann (1909) area 8",
+    "Brodmann area 8",
+    "Brodmann area 8, intermediate frontal",
+    "intermediate frontal area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area8a",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013562)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013562#brodmann-1909-area-8a-1",
+  "name": "Brodmann (1909) area 8a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013562",
+  "synonym": [
+    "area 8a of Brodmann-1909",
+    "B09-8a",
+    "Brodmann (1909) area 8a",
+    "Brodmann area 8a"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the dorsolateral prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013540) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013540#brodmann-1909-area-9-1",
+  "name": "Brodmann (1909) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013540",
+  "synonym": [
+    "area 9 of Brodmann",
+    "area 9 of Brodmann-1909",
+    "area frontalis granularis",
+    "area frontalis granularis",
+    "B09-9",
+    "Brodmann (1909) area 9",
+    "Brodmann area 9",
+    "Brodmann area 9, granular frontal",
+    "granular frontal area"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/BrodmannArea.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/BrodmannArea.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/BrodmannArea",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebral cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529) ('is_a' and 'relationship')]",
+  "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture as described in Brodmann-1905, Brodmann-1909 and Brodmann-10. Maps for several species were presented. NeuroNames includes only areas in the human and in Old World monkeys. Of the latter, Brodmann studied representatives of several species including guenons (one Cercopithecus mona, one Cercocebus torquatus, and one Cercopithecus otherwise unspecified), which are all closely related African species, and one macaque (Macaca mulatta) an Asian species (Brodmann-1905). The legend to the summary map in Brodmann-1909 ascribes the areas simply to Cercopithecus. Brodmann referenced the areas by name and number. The same area number in humans and monkeys did not necessarily refer to topologically or cytoarchitecturally homologous structures. In NeuroNames the standard term for human areas consists of the English translation of Brodmann's Latin name followed by the number he assigned, e.g., agranular frontal area 6; the standard terms for monkey areas are in the format: area 6 of Brodmann-1909. He mapped a portion of areas limited to the banks of sulci, e.g., area 3 of Brodmann-1909 (Brodmann-1909) onto the adjacent, visible surface. This accounts for the fact that some areas appear larger on his surface map than on maps of other authors, e.g., area 3 of Vogts-1919. (Adapted from NeuroNames) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013529#brodmann-partition-scheme-region",
+  "name": "Brodmann area",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013529",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028398)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028398#hadjikhani-et-al-1998-visuotopic-area-v1d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028398",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1d",
+    "Hadjikhani et al. (1998) visuotopic area v1d"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028399)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028399#hadjikhani-et-al-1998-visuotopic-area-v1v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028399",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1v",
+    "Hadjikhani et al. (1998) visuotopic area v1v"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006487)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006487#hadjikhani-et-al-1998-visuotopic-area-v2d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006487",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2d"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028401#hadjikhani-et-al-1998-visuotopic-area-v2v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028401",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2v",
+    "Hadjikhani et al. (1998) visuotopic area v2v"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028402)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028402#hadjikhani-et-al-1998-visuotopic-area-v3-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028402",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3",
+    "Hadjikhani et al. (1998) visuotopic area v3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028403)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028403#hadjikhani-et-al-1998-visuotopic-area-v3a-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3A",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028403",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3a",
+    "Hadjikhani et al. (1998) visuotopic area v3a"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028405)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028405#hadjikhani-et-al-1998-visuotopic-area-v4v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V4v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028405",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v4v",
+    "Hadjikhani et al. (1998) visuotopic area v4v"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028406)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028406#hadjikhani-et-al-1998-visuotopic-area-v8-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028406",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v8",
+    "Hadjikhani et al. (1998) visuotopic area v8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028404)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028404#hadjikhani-et-al-1998-visuotopic-area-vp-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area VP",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028404",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area vp",
+    "Hadjikhani et al. (1998) visuotopic area vp"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026765) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026765#hadjikhani-et-al-1998-visuotopic-partition-scheme-region-1",
+  "name": "Hadjikhani et al. (1998) visuotopic partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026765",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic partition scheme region",
+    "Hadjikhani et al. (1998) visuotopic partition scheme region"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028437)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028437#ongur-price-and-ferry-2003-area-10l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028437",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10l",
+    "ongur, price, and ferry (2003) area 10l"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "description": "Area 10m is a cortical area in the frontal lobe defined on multiple architectonic criteria. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028415#ongur-price-and-ferry-2003-area-10m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028415",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10m",
+    "ongur, price, and ferry (2003) area 10m"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10o",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028414)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028414#ongur-price-and-ferry-2003-area-10o-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10o",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028414",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10o",
+    "ongur, price, and ferry (2003) area 10o"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10p",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028412)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028412#ongur-price-and-ferry-2003-area-10p-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10p",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028412",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10p",
+    "ongur, price, and ferry (2003) area 10p"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028413)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028413#ongur-price-and-ferry-2003-area-10r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028413",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10r",
+    "ongur, price, and ferry (2003) area 10r"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area11l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028427)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028427#ongur-price-and-ferry-2003-area-11l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028427",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11l",
+    "ongur, price, and ferry (2003) area 11l"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area11m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028416)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028416#ongur-price-and-ferry-2003-area-11m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028416",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11m",
+    "ongur, price, and ferry (2003) area 11m"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13a",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028419)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028419#ongur-price-and-ferry-2003-area-13a-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028419",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13a",
+    "ongur, price, and ferry (2003) area 13a"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13b",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028418)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028418#ongur-price-and-ferry-2003-area-13b-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13b",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028418",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13b",
+    "ongur, price, and ferry (2003) area 13b"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028429)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028429#ongur-price-and-ferry-2003-area-13l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028429",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13l",
+    "ongur, price, and ferry (2003) area 13l"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028428)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028428#ongur-price-and-ferry-2003-area-13m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028428",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13m",
+    "ongur, price, and ferry (2003) area 13m"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area14c",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028421)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028421#ongur-price-and-ferry-2003-area-14c-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14c",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028421",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14c",
+    "ongur, price, and ferry (2003) area 14c"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area14r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028420)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028420#ongur-price-and-ferry-2003-area-14r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028420",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14r",
+    "ongur, price, and ferry (2003) area 14r"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area24",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028422)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028422#ongur-price-and-ferry-2003-area-24-1",
+  "name": "Ongur, Price, and Ferry (2003) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028422",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 24",
+    "ongur, price, and ferry (2003) area 24"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area25",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028423)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028423#ongur-price-and-ferry-2003-area-25-1",
+  "name": "Ongur, Price, and Ferry (2003) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028423",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 25",
+    "ongur, price, and ferry (2003) area 25"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area32",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028424)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028424#ongur-price-and-ferry-2003-area-32-1",
+  "name": "Ongur, Price, and Ferry (2003) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028424",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 32",
+    "ongur, price, and ferry (2003) area 32"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028430#ongur-price-and-ferry-2003-area-47l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028430",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47l",
+    "ongur, price, and ferry (2003) area 47l"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028431)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028431#ongur-price-and-ferry-2003-area-47m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028431",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47m",
+    "ongur, price, and ferry (2003) area 47m"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028432)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028432#ongur-price-and-ferry-2003-area-47r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028432",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47r",
+    "ongur, price, and ferry (2003) area 47r"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47s",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028417)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028417#ongur-price-and-ferry-2003-area-47s-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47s",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028417",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47s",
+    "ongur, price, and ferry (2003) area 47s"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028436)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028436#ongur-price-and-ferry-2003-area-9-1",
+  "name": "Ongur, Price, and Ferry (2003) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028436",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 9",
+    "ongur, price, and ferry (2003) area 9"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaAON",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028440)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028440#ongur-price-and-ferry-2003-area-aon-1",
+  "name": "Ongur, Price, and Ferry (2003) area AON",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028440",
+  "synonym": [
+    "ongur, price, and ferry (2003) area aon",
+    "ongur, price, and ferry (2003) area aon"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaG",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028425)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028425#ongur-price-and-ferry-2003-area-g-1",
+  "name": "Ongur, Price, and Ferry (2003) area G",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028425",
+  "synonym": [
+    "ongur, price, and ferry (2003) area g",
+    "ongur, price, and ferry (2003) area g"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIai",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028435)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028435#ongur-price-and-ferry-2003-area-iai-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iai",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028435",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iai",
+    "ongur, price, and ferry (2003) area iai"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "description": "Insula agranular lateral area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028434#ongur-price-and-ferry-2003-area-ial-1",
+  "name": "Ongur, Price, and Ferry (2003) area Ial",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028434",
+  "synonym": [
+    "ongur, price, and ferry (2003) area ial",
+    "ongur, price, and ferry (2003) area ial"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIam",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028433)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028433#ongur-price-and-ferry-2003-area-iam-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iam",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028433",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iam",
+    "ongur, price, and ferry (2003) area iam"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIapm",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028439)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028439#ongur-price-and-ferry-2003-area-iapm-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iapm",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028439",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iapm",
+    "ongur, price, and ferry (2003) area iapm"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028426)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028426#ongur-price-and-ferry-2003-area-prco-1",
+  "name": "Ongur, Price, and Ferry (2003) area PrCO",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028426",
+  "synonym": [
+    "ongur, price, and ferry (2003) area prco",
+    "ongur, price, and ferry (2003) area prco"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026777) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026777#ongur-price-and-ferry-2003-prefrontal-cortical-partition-scheme-region-1",
+  "name": "Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026777",
+  "synonym": [
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region",
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026776) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026776#press-brewer-dougherty-wade-and-wandell-2001-visuotopic-area-v7-1",
+  "name": "Press, Brewer, Dougherty, Wade and Wandell (2001) visuotopic area V7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026776",
+  "synonym": [
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7",
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775) ('is_a' and 'relationship')]",
+  "description": "Cortical parcel in occipital cortex of human according to Tootell and Hadjikhani 2001 that is activated preferentially by more peripheral stimuli compared to the adjacent lateral occipital central parcel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026775#tootell-and-hadjikhani-2001-loc-lop-complex-1",
+  "name": "Tootell and Hadjikhani (2001) LOC/LOP complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026775",
+  "synonym": [
+    "tootell and Hadjikhani (2001) loc/lop complex",
+    "tootell and Hadjikhani (2001) loc/lop complex"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/basalGangliaOfRodent",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a collection of basal ganglia. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "description": "The basal ganglia of the rodent. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023920#basal-ganglia-of-rodent-1",
+  "name": "basal ganglia of rodent",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023920",
+  "synonym": [
+    "basal ganglia of rodent"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "description": "Rostral portion of the parahippocampal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023936#perirhinal-cortex-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023936",
+  "synonym": [
+    "perirhinal cortex of burwell et al 1995"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "description": "Cortical region near the rhinal sulcus in primate encompassing Brodmann's areas 35 and 36. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025581#perirhinal-cortex-of-primate-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of primate of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025581",
+  "synonym": [
+    "perirhinal cortex of primate of burwell et al 1995"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "description": "Cortical region surrounding the posterior rhinal sulcus in the rat, encompassing areas 35 and 36 in the rat. Rostraly, it abuts the posterior insular cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025584#perirhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025584",
+  "synonym": [
+    "perirhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928) ('is_a' and 'relationship')]",
+  "description": "Cortical region lying caudal to the perirhinal cortex in the rat. It encompasses the caudal levels of area 35 and the caudal portion of area 36 (ectorhinal cortex). It is bordered medially by agranular retrosplenial cortex and ventrally by the entorhinal cortex (with the exception of the caudomedial portion). The authors note that the ventral portion of the postrhinal cortex in rat may by homologous with the parahippocampal cortex in the monkey. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023928#postrhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "postrhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023928",
+  "synonym": [
+    "postrhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area1",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006099)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006099#brodmann-1909-area-1-1",
+  "name": "Brodmann (1909) area 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006099",
+  "synonym": [
+    "area 1 of Brodmann",
+    "area 1 of Brodmann-1909",
+    "area postcentralis intermedia",
+    "B09-1",
+    "BA1",
+    "Brodmann (1909) area 1",
+    "Brodmann area 1",
+    "Brodmann's area 1",
+    "intermediate postcentral",
+    "intermediate postcentral area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area10",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 10, or BA10, is part of the frontal cortex in the human brain. BA10 encompasses the most anterior part of the frontal cortex, known as the frontopolar region. This area is believed to play a part in strategic processes involved in memory retrieval and executive function. This area is also called frontopolar area 10, and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. It occupies the most rostral portions of the superior frontal gyrus and the middle frontal gyrus. In humans, on the medial aspect of the hemisphere it is bounded ventrally by the superior rostral sulcus (H). It does not extend as far as the cingulate sulcus. Cytoarchitecturally it is bounded dorsally by the granular frontal area 9, caudally by the middle frontal area 46, and ventrally by the orbital area 47 and by the rostral area 12 or, in an early version of Brodmann's cortical map (Brodmann-1909), the prefrontal Brodmann area 11-1909. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013541#brodmann-1909-area-10-1",
+  "name": "Brodmann (1909) area 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013541",
+  "synonym": [
+    "area 10 of Brodmann",
+    "area 10 of Brodmann-1909",
+    "area frontopolaris",
+    "B09-10",
+    "Brodmann (1909) area 10",
+    "Brodmann area 10",
+    "Brodmann area 10, frontoplar",
+    "lateral orbital area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area11",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "description": "Brodmann area 11 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning, reasoning, and decision making. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013528#brodmann-1909-area-11-1",
+  "name": "Brodmann (1909) area 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013528",
+  "synonym": [
+    "area 11 of Brodmann",
+    "area 11 of Brodmann-1909",
+    "B09-11",
+    "Brodmann (1909) area 11",
+    "Brodmann area 11, prefrontal",
+    "medial orbital area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area12",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "description": "Brodmann area 12 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It occupies the most rostral portion of the frontal lobe. Brodmann-1909 did not regard it as homologous, either topographically or cytoarchitecturally, to rostral area 12 of the human. Distinctive features (Brodmann-1905): a quite distinct internal granular layer (IV) separates slender pyramidal cells of the external pyramidal layer (III) and the internal pyramidal layer (V); the multiform layer (VI) is expanded, contains widely dispersed spindle cells and merges gradually with the underlying cortical white matter; all cells, including the pyramidal cells of the external and internal pyramidal layers are inordinately small; the internal pyramidal layer (V) also contains spindle cells in groups of two to five located close to its border with the internal granular layer (IV). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013543#brodmann-1909-area-12-1",
+  "name": "Brodmann (1909) area 12",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013543",
+  "synonym": [
+    "area 12 of Brodmann",
+    "area 12 of Brodmann-1909",
+    "area praefrontalis",
+    "B09-12",
+    "Brodmann (1909) area 12",
+    "Brodmann area 12",
+    "Brodmann area 12, prefrontal",
+    "frontopolar area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area13",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "description": "Brodmann area 13 is a subdivision of the cerebral cortex as defined on the guenon monkey and on the basis of cytoarchitecture. Brodmann area 13 is found in humans, however it seems to act as a bridge between the lateral and medial layers of the brain. Thus it is sometimes misidentified as not being a Brodmann area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013544#brodmann-1909-area-13-1",
+  "name": "Brodmann (1909) area 13",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013544",
+  "synonym": [
+    "area 13 of Brodmann-1909",
+    "B09-13",
+    "Brodmann (1909) area 13",
+    "Brodmann area 13"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area14",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545) ('is_a' and 'relationship')]",
+  "description": "Brodmann Area 14 is one of Brodmann's subdivisions of the cerebral cortex in the brain. It was defined by Brodmann in the guenon monkey. No equivalent structure exists in humans. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013545#brodmann-1909-area-14-1",
+  "name": "Brodmann (1909) area 14",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013545",
+  "synonym": [
+    "area 14 of Brodmann-1909",
+    "B09-14",
+    "Brodmann (1909) area 14",
+    "Brodmann area 14"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area15",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "description": "Brodmann Area 15 is one of Brodmann's subdivisions of the cerebral cortex in the brain. Area 15 was defined by Brodmann in the guenon monkey, but he found no equivalent structure in humans. However, functional imaging experiments have found structures that may be homologous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013546#brodmann-1909-area-15-1",
+  "name": "Brodmann (1909) area 15",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013546",
+  "synonym": [
+    "area 15 of Brodmann-1909",
+    "B09-15",
+    "Brodmann (1909) area 15",
+    "Brodmann area 15"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area16",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "description": "Brodmann area 16 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It is a relatively undifferentiated cortical area that Brodmann regarded as part of the insula because of the relation of its innermost multiform layer (VI) with the claustrum (VICl). The laminar organization of cortex is almost totally lacking. The molecular layer (I) is wide as in area 15 of Brodmann-1905. The space between layer I and layer VI is composed of a mixture of pyramidal cells and spindle cells with no significant number of granule cells. Pyramidal cells clump in the outer part to form glomeruli similar to those seen in some of the primary olfactory areas (Brodmann-1905). This term also refers to an area known as peripaleocortical claustral - a cytoarchitecturally defined (agranular) portion of the insula at its rostral extreme where it approaches most closely the claustrum and the prepyriform area (Stephan-76). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013547#brodmann-1909-area-16-1",
+  "name": "Brodmann (1909) area 16",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013547",
+  "synonym": [
+    "area 16 of Brodmann",
+    "area 16 of Brodmann-1909",
+    "B09-16",
+    "Brodmann (1909) area 16",
+    "Brodmann area 16"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area18",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006473) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006473#brodmann-1909-area-18-1",
+  "name": "Brodmann (1909) area 18",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006473",
+  "synonym": [
+    "area 18 of Brodmann",
+    "area 18 of Brodmann-1909",
+    "area parastriata",
+    "area parastriata",
+    "B09-18",
+    "BA18",
+    "Brodmann (1909) area 18",
+    "Brodmann area 18",
+    "Brodmann area 18, parastriate",
+    "Brodmann's area 18",
+    "parastriate area 18",
+    "secondary visual area",
+    "visual area II"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area19",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 19, or BA19, is part of the occipital lobe cortex in the human brain. Along with area 18, it comprises the extrastriate (or peristriate) cortex. In normally-sighted humans, extrastriate cortex is a visual association area, with feature-extracting, shape recognition, attentional, and multimodal integrating functions. This area is also known as peristriate area 19, and it refers to a subdivision of the cytoarchitecturally defined occipital region of cerebral cortex. In the human it is located in parts of the lingual gyrus, the cuneus, the lateral occipital gyrus (H) and the superior occipital gyrus (H) of the occipital lobe where it is bounded approximately by the parieto-occipital sulcus. Cytoarchitecturally it is bounded on one side by the parastriate area 18 which it surrounds. Rostrally it is bounded by the angular area 39 (H) and the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013550#brodmann-1909-area-19-1",
+  "name": "Brodmann (1909) area 19",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013550",
+  "synonym": [
+    "area 19 of Brodmann",
+    "area 19 of Brodmann-1909",
+    "area peristriata",
+    "B09-19",
+    "Brodmann (1909) area 19",
+    "Brodmann area 19",
+    "Brodmann area 19, peristriate",
+    "Brodmann's area 19",
+    "preoccipital area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area2",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013533)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013533#brodmann-1909-area-2-1",
+  "name": "Brodmann (1909) area 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013533",
+  "synonym": [
+    "area 2 of Brodmann",
+    "area 2 of Brodmann-1909",
+    "area postcentralis caudalis",
+    "B09-2",
+    "Brodmann (1909) area 2",
+    "Brodmann area 2",
+    "Brodmann area 2, caudal postcentral",
+    "Brodmann's area 2",
+    "caudal postcentral area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area20",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "description": "Brodmann area 20, or BA20, is part of the temporal cortex in the human brain. The region encompasses most of the ventral temporal cortex, a region believed to play a part in high-level visual processing and recognition memory. This area is also known as inferior temporal area 20, and it refers to a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the inferior temporal gyrus. Cytoarchitecturally it is bounded medially by the ectorhinal area 36 (H), laterally by the middle temporal area 21, rostrally by the temporopolar area 38 (H) and caudally by the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013551#brodmann-1909-area-20-1",
+  "name": "Brodmann (1909) area 20",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013551",
+  "synonym": [
+    "area 20 of Brodmann",
+    "area 20 of Brodmann-1909",
+    "area temporalis inferior",
+    "B09-20",
+    "Brodmann (1909) area 20",
+    "Brodmann area 20",
+    "Brodmann area 20, inferior temporal",
+    "inferior temporal area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area21",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the temporal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 21, or BA21, is part of the temporal cortex in the human brain. The region encompasses most of the lateral temporal cortex, a region believed to play a part in auditory processing and language. Language function is left lateralized in most individuals. BA21 is superior to BA20 and inferior to BA40 and BA41. This area is also known as middle temporal area 21. It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the middle temporal gyrus. It is bounded rostrally by the temporopolar area 38 (H), ventrally by the inferior temporal area 20, caudally by the occipitotemporal area 37 (H), and dorsally by the superior temporal area 22 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013552#brodmann-1909-area-21-1",
+  "name": "Brodmann (1909) area 21",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013552",
+  "synonym": [
+    "area 21 of Brodmann",
+    "area 21 of Brodmann-1909",
+    "B09-21",
+    "BA21",
+    "Brodmann (1909) area 21",
+    "Brodmann area 21",
+    "Brodmann area 21, middle temporal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area22",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "description": "Brodmann area 22 is one of Brodmann's cytologically defined regions of the brain. It is involved in auditory processing. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013553#brodmann-1909-area-22-1",
+  "name": "Brodmann (1909) area 22",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013553",
+  "synonym": [
+    "area 22 of Brodmann",
+    "area 22 of Brodmann-1909",
+    "area temporalis superior",
+    "area temporalis superior",
+    "B09-22",
+    "Brodmann (1909) area 22",
+    "Brodmann area 22",
+    "Brodmann area 22, superior temporal",
+    "Superior temporal area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area23",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "description": "The term area 23 of Brodmann-1909 refers to a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. Brodmann regarded it as topographically and cytoarchitecturally homologous to the combined ventral posterior cingulate area 23 and dorsal posterior cingulate area 31 of the human (Brodmann-1909). Distinctive Features (Brodmann-1905): the cortex is relatively thin; smaller cells predominate; the cell density of the multiform layer (VI) is great, producing a distinct boundary with the subcortical white matter; the internal granular layer (IV) is rather well developed; the internal pyramidal layer (V) contains a dense population of round, medium-sized ganglion cells concentrated at the border with layer IV; layers V and VI are narrow with a distinct mutual boundary.nn* Definition Source NeuroNames. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013554#brodmann-1909-area-23-1",
+  "name": "Brodmann (1909) area 23",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013554",
+  "synonym": [
+    "area 23 of Brodmann",
+    "area 23 of Brodmann-1909",
+    "area cingularis posterior ventralis",
+    "area cingularis posterior ventralis",
+    "B09-23",
+    "Brodmann (1909) area 23",
+    "Brodmann area 23",
+    "Brodmann area 23, ventral posterior cingulate",
+    "granular cingulate area",
+    "posterior cingulate area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area24",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the anterior cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006101) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006101#brodmann-1909-area-24-1",
+  "name": "Brodmann (1909) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006101",
+  "synonym": [
+    "area 24 of Brodmann",
+    "area 24 of Brodmann-1909",
+    "area cingularis anterior ventralis",
+    "B09-24",
+    "BA24",
+    "Brodmann (1909) area 24",
+    "Brodmann area 24",
+    "ventral anterior cingulate"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area25",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "description": "Brodmann area 25 (BA25) is an area in the cerebral cortex of the brain and delineated based on its cytoarchitectonic characteristics. It is also called the subgenual area or area subgenualis. It is the 25th 'Brodmann area' defined by Korbinian Brodmann (thus its name). BA25 is located in the cingulate region as a narrow band in the caudal portion of the subcallosal area adjacent to the paraterminal gyrus. The posterior parolfactory sulcus separates the paraterminal gyrus from BA25. Rostrally it is bound by the prefrontal area 11 of Brodmann. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013556#brodmann-1909-area-25-1",
+  "name": "Brodmann (1909) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013556",
+  "synonym": [
+    "area 25 of Brodmann",
+    "area 25 of Brodmann-1909",
+    "area subgenualis",
+    "B09-25",
+    "Brodmann (1909) area 25",
+    "Brodmann area 25",
+    "Brodmann area 25, subgenual",
+    "Brodmann's area 25"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area26",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004718)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004718#brodmann-1909-area-26-1",
+  "name": "Brodmann (1909) area 26",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004718",
+  "synonym": [
+    "area 26 of Brodmann",
+    "area 26 of Brodmann-1909",
+    "area ectosplenialis",
+    "B09-26",
+    "Brodmann (1909) area 26",
+    "Brodmann area 26",
+    "Brodmann area 26, ectosplenial",
+    "ectosplenial area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area27",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the presubiculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558) ('is_a' and 'relationship')]",
+  "description": "Area 27 of Brodmann-1909 is a cytoarchitecturally defined cortical area that is a rostral part of the parahippocampal gyrus of the guenon (Brodmann-1909). It is commonly regarded as a synonym of presubiculum (Crosby-62). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013558#brodmann-1909-area-27-1",
+  "name": "Brodmann (1909) area 27",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013558",
+  "synonym": [
+    "area 27",
+    "area 27 of Brodmann",
+    "area 27 of Brodmann-1909",
+    "area praesubicularis",
+    "B09-27",
+    "BA27",
+    "Brodmann (1909) area 27",
+    "Brodmann area 26, presubicular",
+    "Brodmann area 27",
+    "presubicular area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area28",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the secondary olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013559) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013559#brodmann-1909-area-28-1",
+  "name": "Brodmann (1909) area 28",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013559",
+  "synonym": [
+    "area 28 of Brodmann",
+    "area 28 of Brodmann (Crosby)",
+    "area 28 of Brodmann-1909",
+    "area entorhinalis",
+    "area entorhinalis ventralis",
+    "B09-28",
+    "BA28",
+    "Brodmann (1909) area 28",
+    "Brodmann area 28",
+    "Brodmann area 28, entorhinal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area29",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "description": "Brodmann area 29, also known as granular retrolimbic area 29 or granular retrosplenial cortex, is a cytoarchitecturally defined portion of the retrosplenial region of the cerebral cortex. In the human it is a narrow band located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the ectosplenial area 26 and externally by the agranular retrolimbic area 30 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004717#brodmann-1909-area-29-1",
+  "name": "Brodmann (1909) area 29",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004717",
+  "synonym": [
+    "area 29 of Brodmann",
+    "area 29 of Brodmann-1909",
+    "area retrolimbica granularis",
+    "B09-29",
+    "Brodmann (1909) area 29",
+    "Brodmann area 29",
+    "Brodmann area 29, granular retrolimbic",
+    "Brodmann's area 29"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006100)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006100#brodmann-1909-area-3-1",
+  "name": "Brodmann (1909) area 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006100",
+  "synonym": [
+    "area 3 of Brodmann",
+    "area 3 of Brodmann-1909",
+    "area postcentralis oralis",
+    "B09-3",
+    "BA3",
+    "Brodmann (1909) area 3",
+    "Brodmann area 3",
+    "Brodmann's area 3",
+    "rostral postcentral",
+    "rostral postcentral area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area30",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "description": "Brodmann area 30, also known as agranular retrolimbic area 30, is a subdivision of the cytoarchitecturally defined retrosplenial region of the cerebral cortex. In the human it is located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the granular retrolimbic area 29, dorsally by the ventral posterior cingulate area 23 and ventrolaterally by the ectorhinal area 36 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006474#brodmann-1909-area-30-1",
+  "name": "Brodmann (1909) area 30",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006474",
+  "synonym": [
+    "agranular retrolimbic area 30",
+    "area 30 of Brodmann",
+    "area 30 of Brodmann-1909",
+    "area retrolimbica agranularis",
+    "area retrosplenialis agranularis",
+    "B09-30",
+    "BA30",
+    "Brodmann (1909) area 30",
+    "Brodmann area 30",
+    "Brodmann area 30, agranular retrolimbic",
+    "Brodmann's area 30"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area31",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "description": "Brodmann area 31, also known as dorsal posterior cingulate area 31, is a subdivision of the cytoarchitecturally defined cingulate region of the cerebral cortex. In the human it occupies portions of the posterior cingulate gyrus and medial aspect of the parietal lobe. Approximate boundaries are the cingulate sulcus dorsally and the parieto-occipital sulcus caudally. It partially surrounds the subparietal sulcus, the ventral continuation of the cingulate sulcus in the parietal lobe. Cytoarchitecturally it is bounded rostrally by the ventral anterior cingulate area 24, ventrally by the ventral posterior cingulate area 23, dorsally by the gigantopyramidal area 4 and preparietal area 5 and caudally by the superior parietal area 7 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006475#brodmann-1909-area-31-1",
+  "name": "Brodmann (1909) area 31",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006475",
+  "synonym": [
+    "area 31 of Brodmann",
+    "area 31 of Brodmann-1909",
+    "area cingularis posterior dorsalis",
+    "area cingularis posterior dorsalis",
+    "B09-31",
+    "BA31",
+    "Brodmann (1909) area 31",
+    "Brodmann area 31",
+    "Brodmann area 31, dorsal posterior cingulate",
+    "Brodmann's area 31",
+    "cinguloparietal transition area",
+    "dorsal posterior cingulate area 31"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area32",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "description": "The Brodmann area 32, also known in the human brain as the dorsal anterior cingulate area 32, refers to a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. In the human it forms an outer arc around the anterior cingulate gyrus. The cingulate sulcus defines approximately its inner boundary and the superior rostral sulcus (H) its ventral boundary; rostrally it extends almost to the margin of the frontal lobe. Cytoarchitecturally it is bounded internally by the ventral anterior cingulate area 24, externally by medial margins of the agranular frontal area 6, intermediate frontal area 8, granular frontal area 9, frontopolar area 10, and prefrontal area 11-1909. (Brodmann19-09). Dorsal region of anterior cingulate gyrus is associated with rational thought processes, most notably active during the Stroop task. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013560#brodmann-1909-area-32-1",
+  "name": "Brodmann (1909) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013560",
+  "synonym": [
+    "area 32 of Brodmann",
+    "area 32 of Brodmann-1909",
+    "area cingularis anterior dorsalis",
+    "area cingularis anterior dorsalis",
+    "B09-32",
+    "Brodmann (1909) area 32",
+    "Brodmann area 32",
+    "Brodmann area 32, dorsal anterior cingulate",
+    "Prelimbic area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area33",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 33, also known as pregenual area 33, is a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. It is a narrow band located in the anterior cingulate gyrus adjacent to the supracallosal gyrus in the depth of the callosal sulcus, near the genu of the corpus callosum. Cytoarchitecturally it is bounded by the ventral anterior cingulate area 24 and the supracallosal gyrus (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006476#brodmann-1909-area-33-1",
+  "name": "Brodmann (1909) area 33",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006476",
+  "synonym": [
+    "area 33 of Brodmann",
+    "area 33 of Brodmann-1909",
+    "area praegenualis",
+    "area praegenualis",
+    "B09-33",
+    "BA33",
+    "Brodmann (1909) area 33",
+    "Brodmann area 33",
+    "Brodmann area 33, pregenual",
+    "Brodmann's area 33",
+    "pregenual area 33"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area34",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "description": "Brodmann area 34 is a part of the brain. It has been described as part of the entorhinal area. It has been described as part of the superior temporal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006477#brodmann-1909-area-34-1",
+  "name": "Brodmann (1909) area 34",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006477",
+  "synonym": [
+    "area 34 of Brodmann",
+    "area 34 of Brodmann-1909",
+    "area entorhinalis dorsalis",
+    "area entorhinalis dorsalis",
+    "B09-34",
+    "BA34",
+    "Brodmann (1909) area 34",
+    "Brodmann area 34",
+    "Brodmann area 34, dorsal entorhinal",
+    "dorsal entorhinal area 34"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area35",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 35, together with Brodmann area 36, is most frequently referred to as perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006102#brodmann-1909-area-35-1",
+  "name": "Brodmann (1909) area 35",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006102",
+  "synonym": [
+    "area 35 of Brodmann",
+    "area 35 of Brodmann-1909",
+    "area perirhinalis",
+    "B09-35",
+    "BA35",
+    "Brodmann (1909) area 35",
+    "Brodmann area 35",
+    "Brodmann area 35, perirhinal",
+    "Brodmann's area 35",
+    "perirhinal area 35"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area36",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104) ('is_a' and 'relationship')]",
+  "description": "Ectorhinal area 36 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. With its medial boundary corresponding approximately to the rhinal sulcus it is located primarily in the fusiform gyrus. Cytoarchitecturally it is bounded laterally and caudally by the inferior temporal area 20, medially by the perirhinal area 35 and rostrally by the temporopolar area 38 (H) (Brodmann-1909). Together with Brodmann area 35, it comprises the perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006104#brodmann-1909-area-36-1",
+  "name": "Brodmann (1909) area 36",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006104",
+  "synonym": [
+    "area 36 of Brodmann",
+    "area 36 of Brodmann-1909",
+    "area ectorhinalis",
+    "B09-36",
+    "BA36",
+    "Brodmann (1909) area 36",
+    "Brodmann area 36",
+    "ectorhinal",
+    "ectorhinal area 36"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area37",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "description": "Brodmann area 37, or BA37, is part of the temporal cortex in the human brain. This area is known as occipitotemporal area 37 (H). It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the caudal portions of the fusiform gyrus and inferior temporal gyrus on the mediobasal and lateral surfaces at the caudal extreme of the temporal lobe. Cytoarchitecturally it is bounded caudally by the peristriate Brodmann area 19, rostrally by the inferior temporal area 20 and middle temporal area 21 and dorsally on the lateral aspect of the hemisphere by the angular area 39 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006478#brodmann-1909-area-37-1",
+  "name": "Brodmann (1909) area 37",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006478",
+  "synonym": [
+    "area 37 0f brodmann",
+    "area 37 of Brodmann-1909",
+    "area occipitotemporalis",
+    "area occipitotemporalis",
+    "B09-37",
+    "BA37",
+    "Brodmann (1909) area 37",
+    "Brodmann area 37",
+    "Brodmann area 37, occipitotemporal",
+    "occipitotemporal area 37"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area38",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "description": "Brodmann area 38, also BA38 or temporopolar area 38 (H), is part of the temporal cortex in the human brain. BA 38 is at the anterior end of the temporal lobe, known as the temporal pole. BA38 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the most rostral portions of the superior temporal gyrus and the middle temporal gyrus. Cytoarchitecturally it is bounded caudally by the inferior temporal area 20, the middle temporal area 21, the superior temporal area 22 and the ectorhinal area 36 (Brodmann-1909). Cytoarchitectonic and chemoarchitectonic studies find that it contains at least seven subareas, one of which, TG, is unique to humans. 'The functional significance of this area TG is not known, but it may bind complex, highly processed perceptual inputs to visceral emotional responses.' This area is among the earliest affected by Alzheimer's disease and the earliest involved at the start of temporal lobe seizures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006479#brodmann-1909-area-38-1",
+  "name": "Brodmann (1909) area 38",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006479",
+  "synonym": [
+    "area 38 of Brodmann",
+    "area 38 of Brodmann-1909",
+    "area temporopolaris",
+    "B09-38",
+    "BA38",
+    "Brodmann (1909) area 38",
+    "Brodmann area 38",
+    "Brodmann area 38, temporopolar",
+    "temporopolar area 38"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area39",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006480)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006480#brodmann-1909-area-39-1",
+  "name": "Brodmann (1909) area 39",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006480",
+  "synonym": [
+    "angular area 39",
+    "area 39 of Brodmann",
+    "area 39 of Brodmann-1909",
+    "area angularis",
+    "B09-39",
+    "BA39",
+    "Brodmann (1909) area 39",
+    "Brodmann area 39",
+    "Brodmann area 39, angular"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area4",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the primary motor cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535) ('is_a' and 'relationship')]",
+  "description": "The term area 4 of Brodmann-1909 refers to a cytoarchitecturally defined portion of the frontal lobe of the guenon. It is located predominantly in the precentral gyrus. Brodmann-1909 regarded it as topographically and cytoarchitecturally homologous to the human gigantopyramidal area 4 and noted that it occupies a much greater fraction of the frontal lobe in the monkey than in the human. Distinctive features (Brodmann-1905): the cortex is unusually thick; the layers are not distinct; the cells are relatively sparsely distributed; giant pyramidal (Betz) cells are present in the internal pyramidal layer (V); lack of an internal granular layer (IV) such that the boundary between the external pyramidal layer (III) and the internal pyramidal layer (V) is indistinct; lack of a distinct external granular layer (II); a gradual transition from the multiform layer (VI) to the subcortical white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013535#brodmann-1909-area-4-1",
+  "name": "Brodmann (1909) area 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013535",
+  "synonym": [
+    "area 4 of Brodmann",
+    "area 4 of Brodmann-1909",
+    "area gigantopyramidalis",
+    "B09-4",
+    "Brodmann (1909) area 4",
+    "Brodmann area 4",
+    "Brodmann area 4, gigantopyramidal",
+    "Brodmann's area 4",
+    "giant pyramidal area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area40",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the supramarginal gyrus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 40, or BA40, is part of the parietal cortex in the human brain. The inferior part of BA40 is in the area of the supramarginal gyrus, which lies at the posterior end of the lateral fissure, in the inferior lateral part of the parietal lobe. It is bounded approximately by the intraparietal sulcus, the inferior postcentral sulcus, the posterior subcentral sulcus and the lateral sulcus. Cytoarchitecturally it is bounded caudally by the angular area 39 (H), rostrally and dorsally by the caudal postcentral area 2, and ventrally by the subcentral area 43 and the superior temporal area 22 (Brodmann-1909). Cytoarchitectonically defined subregions of rostral BA40/the supramarginal gyrus are PF, PFcm, PFm, PFop, and PFt. Area PF is the homologue to macaque area PF, part of the mirror neuron system, and active in humans during imitation. The supramarginal gyrus part of Brodmann area 40 is the region in the inferior parietal lobe that is involved in reading both in regards to meaning and phonology. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013573#brodmann-1909-area-40-1",
+  "name": "Brodmann (1909) area 40",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013573",
+  "synonym": [
+    "area 40 of Brodmann",
+    "area 40 of Brodmann-1909",
+    "area supramarginalis",
+    "B09-40",
+    "Brodmann (1909) area 40",
+    "Brodmann area 40",
+    "Brodmann area 40, supramarginal",
+    "Supramarginal area 40"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area43",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "description": "Brodmann area 43 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It was described (but not labeled) on the map of cortical areas in Brodmann-1909, and it was regarded as cytoarchitecturally homologous to area 30 of Mauss in 1908 in the guenon and subcentral area 43 of the human (Brodmann-1909). The Vogts found no distinctive architectonic area of the corresponding location in the guenon (Vogts-1919). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013561#brodmann-1909-area-43-1",
+  "name": "Brodmann (1909) area 43",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013561",
+  "synonym": [
+    "area 43 of brodmann",
+    "area 43 of Brodmann-1909",
+    "area subcentralis",
+    "B09-43",
+    "Brodmann (1909) area 43",
+    "Brodmann area 43",
+    "Brodmann area 43, subcentral"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area44",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "description": "Brodmann area 44, or BA44, is part of the frontal cortex in the human brain. Situated just anterior to premotor cortex and on the lateral surface, inferior to BA9. This area is also known as pars opercularis (of the inferior frontal gyrus), and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. In the human it corresponds approximately to the opercular part of inferior frontal gyrus (H). Thus, it is bounded caudally by the inferior precentral sulcus (H) and rostrally by the anterior ascending limb of lateral sulcus (H). It surrounds the diagonal sulcus (H). In the depth of the lateral sulcus it borders on the insula. Cytoarchitectonically it is bounded caudally and dorsally by the agranular frontal area 6, dorsally by the granular frontal area 9 and rostrally by the triangular area 45 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006481#brodmann-1909-area-44-1",
+  "name": "Brodmann (1909) area 44",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006481",
+  "synonym": [
+    "area 44 of Brodmann",
+    "area 44 of Brodmann-1909",
+    "area opercularis",
+    "B09-44",
+    "BA44",
+    "Brodmann (1909) area 44",
+    "Brodmann area 44",
+    "Brodmann area 44, opercular",
+    "opercular area 44"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area45",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the frontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482) ('is_a' and 'relationship')]",
+  "description": "Part of the cytoarchitecturally defined frontal region of cerebral cortex. In the human, it occupies the triangular part of the inferior frontal gyrus (human) and, surrounding the anterior horizontal limb of the lateral sulcus (human), a portion of the orbital part of the inferior frontal gyrus (human). Bounded caudally by the anterior ascending limb of the lateral sulcus (human), it borders on the insula in the depth of the lateral sulcus. Cytoarchitectonically it is bounded caudally by the opercular area 44, rostrodorsally by the area 46 of Brodmann (human) and ventrally by the area 47 of Brodmann (human) (Brodmann-1909) (Adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006482#brodmann-1909-area-45-1",
+  "name": "Brodmann (1909) area 45",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006482",
+  "synonym": [
+    "area 45 of Brodmann",
+    "area 45 of Brodmann-1909",
+    "area triangularis",
+    "area triangularis",
+    "B09-45",
+    "BA45",
+    "Brodmann (1909) area 45",
+    "Brodmann area 45",
+    "Brodmann area 45, triangular",
+    "triangular area 45"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area46",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "description": "Brodmann area 46, or BA46, is part of the frontal cortex in the human brain. It is between BA10 and BA45. BA46 is known as middle frontal area 46. In the human it occupies approximately the middle third of the middle frontal gyrus and the most rostral portion of the inferior frontal gyrus. Brodmann area 46 roughly corresponds with the dorsolateral prefrontal cortex (DLPFC), although the borders of area 46 are based on cytoarchitecture rather than function. The DLPFC also encompasses part of granular frontal area 9, directly adjacent on the dorsal surface of the cortex. Cytoarchitecturally, BA46 is bounded dorsally by the granular frontal area 9, rostroventrally by the frontopolar area 10 and caudally by the triangular area 45 (Brodmann-1909). There is some discrepancy between the extent of BA8 (Brodmann-1905) and the same area as described by Walker (1940) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006483#brodmann-1909-area-46-1",
+  "name": "Brodmann (1909) area 46",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006483",
+  "synonym": [
+    "area 46 of Brodmann",
+    "area 46 of Brodmann-1909",
+    "area frontalis media",
+    "B09-46",
+    "BA46",
+    "Brodmann (1909) area 46",
+    "Brodmann area 46",
+    "Brodmann area 46, middle frontal",
+    "middle frontal area 46"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area47",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "description": "Brodmann area 47, or BA47, is part of the frontal cortex in the human brain. Curving from the lateral surface of the frontal lobe into the ventral (orbital) frontal cortex. It is below areas BA10 and BA45, and beside BA11. This area is also known as orbital area 47. In the human, on the orbital surface it surrounds the caudal portion of the orbital sulcus (H) from which it extends laterally into the orbital part of inferior frontal gyrus (H). Cytoarchitectonically it is bounded caudally by the triangular area 45, medially by the prefrontal area 11 of Brodmann-1909, and rostrally by the frontopolar area 10 (Brodmann-1909). It incorporates the region that Brodmann identified as 'Area 12' in the monkey, and therefore, following the suggestion of Michael Petrides, some contemporary neuroscientists refer to the region as 'BA47/12. ' BA47 has been implicated in the processing of syntax in spoken and signed languages, and more recently in musical syntax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006484#brodmann-1909-area-47-1",
+  "name": "Brodmann (1909) area 47",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006484",
+  "synonym": [
+    "area 47 of Brodmann",
+    "area 47 of Brodmann-1909",
+    "area orbitalis",
+    "area orbitalis",
+    "B09-47",
+    "BA47",
+    "Brodmann (1909) area 47",
+    "Brodmann area 47",
+    "Brodmann area 47, orbital",
+    "orbital area 47"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area48",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "description": "Retrosubicular area 48 is a subdivision of the cytoarchitecturally defined hippocampal region of the cerebral cortex. In the human it is located on the medial surface of the temporal lobe. Cytoarchitectually it is bounded rostrally by the perirhinal area 35 and medially by the presubiculum. While described by Brodmann (Brodmann-1909), it was not included in his areal maps of human cortex (Brodmann-1909; Brodmann-1910). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006485#brodmann-1909-area-48-1",
+  "name": "Brodmann (1909) area 48",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006485",
+  "synonym": [
+    "area 48 of Brodmann",
+    "area retrosubicularis",
+    "B09-48",
+    "BA48",
+    "Brodmann (1909) area 48",
+    "Brodmann area 48",
+    "Brodmann area 48, retrosubicular",
+    "Brodmann's area 48",
+    "retrosubicular area 48"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area5",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "description": "Brodmann area 5 is one of Brodmann's cytologically defined regions of the brain. It is involved in somatosensory processing and association. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006471#brodmann-1909-area-5-1",
+  "name": "Brodmann (1909) area 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006471",
+  "synonym": [
+    "area 5 of Brodmann-1909",
+    "area praeparietalis",
+    "B09-5",
+    "BA5",
+    "Brodmann (1909) area 5",
+    "Brodmann area 5",
+    "Brodmann area 5, preparietal",
+    "preparietal area 5"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area52",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "description": "Parainsular area 52 (H) is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located in the bank of the lateral sulcus on the dorsal surface of the temporal lobe. Its medial boundary corresponds approximately to the junction between the temporal lobe and the insula. Cytoarchitecturally it is bounded laterally by the anterior transverse temporal area 42 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006486#brodmann-1909-area-52-1",
+  "name": "Brodmann (1909) area 52",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006486",
+  "synonym": [
+    "area 52 of Brodmann",
+    "area parainsularis",
+    "B09-52",
+    "BA52",
+    "Brodmann (1909) area 52",
+    "Brodmann area 52",
+    "Brodmann area 52, parainsular",
+    "parainsular area 52"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area6",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "description": "Brodmann area 6, or BA6, is part of the frontal cortex in the human brain. Situated just anterior to the primary motor cortex, it is composed of the premotor cortex and, medially, the supplementary motor area, or SMA. This large area of the frontal cortex is believed to play a role in the planning of complex, coordinated movements. Brodmann area 6 is also called agranular frontal area 6 in humans because it lacks an internal granular cortical layer (layer IV). It is a subdivision of the cytoarchitecturally defined precentral region of cerebral cortex. In the human brain, it is located on the portions of the precentral gyrus that are not occupied by the gigantopyramidal area 4; furthermore, BA6 extends onto the caudal portions of the superior frontal and middle frontal gyri. It extends from the cingulate sulcus on the medial aspect of the hemisphere to the lateral sulcus on the lateral aspect. It is bounded rostrally by the granular frontal region and caudally by the gigantopyramidal area 4 (Brodmann, 1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006472#brodmann-1909-area-6-1",
+  "name": "Brodmann (1909) area 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006472",
+  "synonym": [
+    "agranular frontal area 6",
+    "area 6 of Brodmann",
+    "area 6 of Brodmann-1909",
+    "area frontalis agranularis",
+    "B09-6",
+    "BA6",
+    "Brodmann (1909) area 6",
+    "Brodmann area 6",
+    "Brodmann area 6, agranular frontal",
+    "frontal belt"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area7",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "description": "Brodmann area 7 is one of Brodmann's cytologically defined regions of the brain. It is involved in locating objects in space. It serves as a point of convergence between vision and proprioception to determine where objects are in relation to parts of the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013538#brodmann-1909-area-7-1",
+  "name": "Brodmann (1909) area 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013538",
+  "synonym": [
+    "area 7 of Brodmann",
+    "area 7 of Brodmann-1909",
+    "area parietalis superior",
+    "area parietalis superior",
+    "B09-7",
+    "Brodmann (1909) area 7",
+    "Brodmann area 7",
+    "Brodmann area 7, superior parietal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area8",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "description": "Brodmann area 8 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning complex movements. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013539#brodmann-1909-area-8-1",
+  "name": "Brodmann (1909) area 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013539",
+  "synonym": [
+    "area 8 of Brodmann",
+    "area 8 of Brodmann-1909",
+    "area frontalis intermedia",
+    "area frontalis intermedia",
+    "B09-8",
+    "Brodmann (1909) area 8",
+    "Brodmann area 8",
+    "Brodmann area 8, intermediate frontal",
+    "intermediate frontal area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area8a",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013562)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013562#brodmann-1909-area-8a-1",
+  "name": "Brodmann (1909) area 8a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013562",
+  "synonym": [
+    "area 8a of Brodmann-1909",
+    "B09-8a",
+    "Brodmann (1909) area 8a",
+    "Brodmann area 8a"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/Brodmann1909Area9",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the dorsolateral prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013540) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013540#brodmann-1909-area-9-1",
+  "name": "Brodmann (1909) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013540",
+  "synonym": [
+    "area 9 of Brodmann",
+    "area 9 of Brodmann-1909",
+    "area frontalis granularis",
+    "area frontalis granularis",
+    "B09-9",
+    "Brodmann (1909) area 9",
+    "Brodmann area 9",
+    "Brodmann area 9, granular frontal",
+    "granular frontal area"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/BrodmannArea.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/BrodmannArea.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/BrodmannArea",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebral cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529) ('is_a' and 'relationship')]",
+  "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture as described in Brodmann-1905, Brodmann-1909 and Brodmann-10. Maps for several species were presented. NeuroNames includes only areas in the human and in Old World monkeys. Of the latter, Brodmann studied representatives of several species including guenons (one Cercopithecus mona, one Cercocebus torquatus, and one Cercopithecus otherwise unspecified), which are all closely related African species, and one macaque (Macaca mulatta) an Asian species (Brodmann-1905). The legend to the summary map in Brodmann-1909 ascribes the areas simply to Cercopithecus. Brodmann referenced the areas by name and number. The same area number in humans and monkeys did not necessarily refer to topologically or cytoarchitecturally homologous structures. In NeuroNames the standard term for human areas consists of the English translation of Brodmann's Latin name followed by the number he assigned, e.g., agranular frontal area 6; the standard terms for monkey areas are in the format: area 6 of Brodmann-1909. He mapped a portion of areas limited to the banks of sulci, e.g., area 3 of Brodmann-1909 (Brodmann-1909) onto the adjacent, visible surface. This accounts for the fact that some areas appear larger on his surface map than on maps of other authors, e.g., area 3 of Vogts-1919. (Adapted from NeuroNames) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013529#brodmann-partition-scheme-region",
+  "name": "Brodmann area",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013529",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028398)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028398#hadjikhani-et-al-1998-visuotopic-area-v1d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028398",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1d",
+    "Hadjikhani et al. (1998) visuotopic area v1d"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028399)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028399#hadjikhani-et-al-1998-visuotopic-area-v1v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028399",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1v",
+    "Hadjikhani et al. (1998) visuotopic area v1v"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006487)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006487#hadjikhani-et-al-1998-visuotopic-area-v2d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006487",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2d"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028401#hadjikhani-et-al-1998-visuotopic-area-v2v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028401",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2v",
+    "Hadjikhani et al. (1998) visuotopic area v2v"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028402)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028402#hadjikhani-et-al-1998-visuotopic-area-v3-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028402",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3",
+    "Hadjikhani et al. (1998) visuotopic area v3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028403)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028403#hadjikhani-et-al-1998-visuotopic-area-v3a-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3A",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028403",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3a",
+    "Hadjikhani et al. (1998) visuotopic area v3a"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028405)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028405#hadjikhani-et-al-1998-visuotopic-area-v4v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V4v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028405",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v4v",
+    "Hadjikhani et al. (1998) visuotopic area v4v"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028406)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028406#hadjikhani-et-al-1998-visuotopic-area-v8-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028406",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v8",
+    "Hadjikhani et al. (1998) visuotopic area v8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028404)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028404#hadjikhani-et-al-1998-visuotopic-area-vp-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area VP",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028404",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area vp",
+    "Hadjikhani et al. (1998) visuotopic area vp"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026765) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026765#hadjikhani-et-al-1998-visuotopic-partition-scheme-region-1",
+  "name": "Hadjikhani et al. (1998) visuotopic partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026765",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic partition scheme region",
+    "Hadjikhani et al. (1998) visuotopic partition scheme region"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area10l",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028437)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028437#ongur-price-and-ferry-2003-area-10l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028437",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10l",
+    "ongur, price, and ferry (2003) area 10l"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area10m",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "description": "Area 10m is a cortical area in the frontal lobe defined on multiple architectonic criteria. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028415#ongur-price-and-ferry-2003-area-10m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028415",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10m",
+    "ongur, price, and ferry (2003) area 10m"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area10o",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028414)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028414#ongur-price-and-ferry-2003-area-10o-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10o",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028414",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10o",
+    "ongur, price, and ferry (2003) area 10o"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area10p",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028412)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028412#ongur-price-and-ferry-2003-area-10p-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10p",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028412",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10p",
+    "ongur, price, and ferry (2003) area 10p"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area10r",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028413)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028413#ongur-price-and-ferry-2003-area-10r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028413",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10r",
+    "ongur, price, and ferry (2003) area 10r"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area11l",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028427)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028427#ongur-price-and-ferry-2003-area-11l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028427",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11l",
+    "ongur, price, and ferry (2003) area 11l"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area11m",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028416)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028416#ongur-price-and-ferry-2003-area-11m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028416",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11m",
+    "ongur, price, and ferry (2003) area 11m"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area13a",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028419)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028419#ongur-price-and-ferry-2003-area-13a-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028419",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13a",
+    "ongur, price, and ferry (2003) area 13a"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area13b",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028418)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028418#ongur-price-and-ferry-2003-area-13b-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13b",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028418",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13b",
+    "ongur, price, and ferry (2003) area 13b"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area13l",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028429)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028429#ongur-price-and-ferry-2003-area-13l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028429",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13l",
+    "ongur, price, and ferry (2003) area 13l"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area13m",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028428)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028428#ongur-price-and-ferry-2003-area-13m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028428",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13m",
+    "ongur, price, and ferry (2003) area 13m"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area14c",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028421)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028421#ongur-price-and-ferry-2003-area-14c-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14c",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028421",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14c",
+    "ongur, price, and ferry (2003) area 14c"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area14r",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028420)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028420#ongur-price-and-ferry-2003-area-14r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028420",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14r",
+    "ongur, price, and ferry (2003) area 14r"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area24",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028422)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028422#ongur-price-and-ferry-2003-area-24-1",
+  "name": "Ongur, Price, and Ferry (2003) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028422",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 24",
+    "ongur, price, and ferry (2003) area 24"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area25",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028423)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028423#ongur-price-and-ferry-2003-area-25-1",
+  "name": "Ongur, Price, and Ferry (2003) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028423",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 25",
+    "ongur, price, and ferry (2003) area 25"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area32",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028424)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028424#ongur-price-and-ferry-2003-area-32-1",
+  "name": "Ongur, Price, and Ferry (2003) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028424",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 32",
+    "ongur, price, and ferry (2003) area 32"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area47l",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028430#ongur-price-and-ferry-2003-area-47l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028430",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47l",
+    "ongur, price, and ferry (2003) area 47l"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area47m",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028431)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028431#ongur-price-and-ferry-2003-area-47m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028431",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47m",
+    "ongur, price, and ferry (2003) area 47m"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area47r",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028432)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028432#ongur-price-and-ferry-2003-area-47r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028432",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47r",
+    "ongur, price, and ferry (2003) area 47r"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area47s",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028417)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028417#ongur-price-and-ferry-2003-area-47s-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47s",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028417",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47s",
+    "ongur, price, and ferry (2003) area 47s"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003Area9",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028436)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028436#ongur-price-and-ferry-2003-area-9-1",
+  "name": "Ongur, Price, and Ferry (2003) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028436",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 9",
+    "ongur, price, and ferry (2003) area 9"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaAON",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028440)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028440#ongur-price-and-ferry-2003-area-aon-1",
+  "name": "Ongur, Price, and Ferry (2003) area AON",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028440",
+  "synonym": [
+    "ongur, price, and ferry (2003) area aon",
+    "ongur, price, and ferry (2003) area aon"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaG",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028425)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028425#ongur-price-and-ferry-2003-area-g-1",
+  "name": "Ongur, Price, and Ferry (2003) area G",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028425",
+  "synonym": [
+    "ongur, price, and ferry (2003) area g",
+    "ongur, price, and ferry (2003) area g"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIai",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028435)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028435#ongur-price-and-ferry-2003-area-iai-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iai",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028435",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iai",
+    "ongur, price, and ferry (2003) area iai"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "description": "Insula agranular lateral area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028434#ongur-price-and-ferry-2003-area-ial-1",
+  "name": "Ongur, Price, and Ferry (2003) area Ial",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028434",
+  "synonym": [
+    "ongur, price, and ferry (2003) area ial",
+    "ongur, price, and ferry (2003) area ial"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIam",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028433)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028433#ongur-price-and-ferry-2003-area-iam-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iam",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028433",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iam",
+    "ongur, price, and ferry (2003) area iam"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIapm",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028439)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028439#ongur-price-and-ferry-2003-area-iapm-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iapm",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028439",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iapm",
+    "ongur, price, and ferry (2003) area iapm"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028426)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028426#ongur-price-and-ferry-2003-area-prco-1",
+  "name": "Ongur, Price, and Ferry (2003) area PrCO",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028426",
+  "synonym": [
+    "ongur, price, and ferry (2003) area prco",
+    "ongur, price, and ferry (2003) area prco"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026777) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026777#ongur-price-and-ferry-2003-prefrontal-cortical-partition-scheme-region-1",
+  "name": "Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026777",
+  "synonym": [
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region",
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026776) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026776#press-brewer-dougherty-wade-and-wandell-2001-visuotopic-area-v7-1",
+  "name": "Press, Brewer, Dougherty, Wade and Wandell (2001) visuotopic area V7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026776",
+  "synonym": [
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7",
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775) ('is_a' and 'relationship')]",
+  "description": "Cortical parcel in occipital cortex of human according to Tootell and Hadjikhani 2001 that is activated preferentially by more peripheral stimuli compared to the adjacent lateral occipital central parcel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026775#tootell-and-hadjikhani-2001-loc-lop-complex-1",
+  "name": "Tootell and Hadjikhani (2001) LOC/LOP complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026775",
+  "synonym": [
+    "tootell and Hadjikhani (2001) loc/lop complex",
+    "tootell and Hadjikhani (2001) loc/lop complex"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/basalGangliaOfRodent",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a collection of basal ganglia. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "description": "The basal ganglia of the rodent. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023920#basal-ganglia-of-rodent-1",
+  "name": "basal ganglia of rodent",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023920",
+  "synonym": [
+    "basal ganglia of rodent"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a perirhinal cortex. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "description": "Rostral portion of the parahippocampal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023936#perirhinal-cortex-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023936",
+  "synonym": [
+    "perirhinal cortex of burwell et al 1995"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "description": "Cortical region near the rhinal sulcus in primate encompassing Brodmann's areas 35 and 36. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025581#perirhinal-cortex-of-primate-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of primate of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025581",
+  "synonym": [
+    "perirhinal cortex of primate of burwell et al 1995"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "description": "Cortical region surrounding the posterior rhinal sulcus in the rat, encompassing areas 35 and 36 in the rat. Rostraly, it abuts the posterior insular cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025584#perirhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025584",
+  "synonym": [
+    "perirhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928) ('is_a' and 'relationship')]",
+  "description": "Cortical region lying caudal to the perirhinal cortex in the rat. It encompasses the caudal levels of area 35 and the caudal portion of area 36 (ectorhinal cortex). It is bordered medially by agranular retrosplenial cortex and ventrally by the entorhinal cortex (with the exception of the caudomedial portion). The authors note that the ventral portion of the postrhinal cortex in rat may by homologous with the parahippocampal cortex in the monkey. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023928#postrhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "postrhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023928",
+  "synonym": [
+    "postrhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area1.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006099)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006099#brodmann-1909-area-1-1",
+  "name": "Brodmann (1909) area 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006099",
+  "synonym": [
+    "area 1 of Brodmann",
+    "area 1 of Brodmann-1909",
+    "area postcentralis intermedia",
+    "B09-1",
+    "BA1",
+    "Brodmann (1909) area 1",
+    "Brodmann area 1",
+    "Brodmann's area 1",
+    "intermediate postcentral",
+    "intermediate postcentral area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area10.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area10",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 10, or BA10, is part of the frontal cortex in the human brain. BA10 encompasses the most anterior part of the frontal cortex, known as the frontopolar region. This area is believed to play a part in strategic processes involved in memory retrieval and executive function. This area is also called frontopolar area 10, and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. It occupies the most rostral portions of the superior frontal gyrus and the middle frontal gyrus. In humans, on the medial aspect of the hemisphere it is bounded ventrally by the superior rostral sulcus (H). It does not extend as far as the cingulate sulcus. Cytoarchitecturally it is bounded dorsally by the granular frontal area 9, caudally by the middle frontal area 46, and ventrally by the orbital area 47 and by the rostral area 12 or, in an early version of Brodmann's cortical map (Brodmann-1909), the prefrontal Brodmann area 11-1909. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013541#brodmann-1909-area-10-1",
+  "name": "Brodmann (1909) area 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013541",
+  "synonym": [
+    "area 10 of Brodmann",
+    "area 10 of Brodmann-1909",
+    "area frontopolaris",
+    "B09-10",
+    "Brodmann (1909) area 10",
+    "Brodmann area 10",
+    "Brodmann area 10, frontoplar",
+    "lateral orbital area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area11.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area11",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "description": "Brodmann area 11 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning, reasoning, and decision making. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013528#brodmann-1909-area-11-1",
+  "name": "Brodmann (1909) area 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013528",
+  "synonym": [
+    "area 11 of Brodmann",
+    "area 11 of Brodmann-1909",
+    "B09-11",
+    "Brodmann (1909) area 11",
+    "Brodmann area 11, prefrontal",
+    "medial orbital area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area12.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area12",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "description": "Brodmann area 12 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It occupies the most rostral portion of the frontal lobe. Brodmann-1909 did not regard it as homologous, either topographically or cytoarchitecturally, to rostral area 12 of the human. Distinctive features (Brodmann-1905): a quite distinct internal granular layer (IV) separates slender pyramidal cells of the external pyramidal layer (III) and the internal pyramidal layer (V); the multiform layer (VI) is expanded, contains widely dispersed spindle cells and merges gradually with the underlying cortical white matter; all cells, including the pyramidal cells of the external and internal pyramidal layers are inordinately small; the internal pyramidal layer (V) also contains spindle cells in groups of two to five located close to its border with the internal granular layer (IV). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013543#brodmann-1909-area-12-1",
+  "name": "Brodmann (1909) area 12",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013543",
+  "synonym": [
+    "area 12 of Brodmann",
+    "area 12 of Brodmann-1909",
+    "area praefrontalis",
+    "B09-12",
+    "Brodmann (1909) area 12",
+    "Brodmann area 12",
+    "Brodmann area 12, prefrontal",
+    "frontopolar area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area13.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area13",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "description": "Brodmann area 13 is a subdivision of the cerebral cortex as defined on the guenon monkey and on the basis of cytoarchitecture. Brodmann area 13 is found in humans, however it seems to act as a bridge between the lateral and medial layers of the brain. Thus it is sometimes misidentified as not being a Brodmann area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013544)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013544#brodmann-1909-area-13-1",
+  "name": "Brodmann (1909) area 13",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013544",
+  "synonym": [
+    "area 13 of Brodmann-1909",
+    "B09-13",
+    "Brodmann (1909) area 13",
+    "Brodmann area 13"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area14.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area14",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545) ('is_a' and 'relationship')]",
+  "description": "Brodmann Area 14 is one of Brodmann's subdivisions of the cerebral cortex in the brain. It was defined by Brodmann in the guenon monkey. No equivalent structure exists in humans. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013545)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013545#brodmann-1909-area-14-1",
+  "name": "Brodmann (1909) area 14",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013545",
+  "synonym": [
+    "area 14 of Brodmann-1909",
+    "B09-14",
+    "Brodmann (1909) area 14",
+    "Brodmann area 14"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area15.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area15",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "description": "Brodmann Area 15 is one of Brodmann's subdivisions of the cerebral cortex in the brain. Area 15 was defined by Brodmann in the guenon monkey, but he found no equivalent structure in humans. However, functional imaging experiments have found structures that may be homologous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013546#brodmann-1909-area-15-1",
+  "name": "Brodmann (1909) area 15",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013546",
+  "synonym": [
+    "area 15 of Brodmann-1909",
+    "B09-15",
+    "Brodmann (1909) area 15",
+    "Brodmann area 15"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area16.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area16",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "description": "Brodmann area 16 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It is a relatively undifferentiated cortical area that Brodmann regarded as part of the insula because of the relation of its innermost multiform layer (VI) with the claustrum (VICl). The laminar organization of cortex is almost totally lacking. The molecular layer (I) is wide as in area 15 of Brodmann-1905. The space between layer I and layer VI is composed of a mixture of pyramidal cells and spindle cells with no significant number of granule cells. Pyramidal cells clump in the outer part to form glomeruli similar to those seen in some of the primary olfactory areas (Brodmann-1905). This term also refers to an area known as peripaleocortical claustral - a cytoarchitecturally defined (agranular) portion of the insula at its rostral extreme where it approaches most closely the claustrum and the prepyriform area (Stephan-76). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013547#brodmann-1909-area-16-1",
+  "name": "Brodmann (1909) area 16",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013547",
+  "synonym": [
+    "area 16 of Brodmann",
+    "area 16 of Brodmann-1909",
+    "B09-16",
+    "Brodmann (1909) area 16",
+    "Brodmann area 16"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area18.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area18",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006473) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006473#brodmann-1909-area-18-1",
+  "name": "Brodmann (1909) area 18",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006473",
+  "synonym": [
+    "area 18 of Brodmann",
+    "area 18 of Brodmann-1909",
+    "area parastriata",
+    "area parastriata",
+    "B09-18",
+    "BA18",
+    "Brodmann (1909) area 18",
+    "Brodmann area 18",
+    "Brodmann area 18, parastriate",
+    "Brodmann's area 18",
+    "parastriate area 18",
+    "secondary visual area",
+    "visual area II"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area19.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area19",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the extrastriate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 19, or BA19, is part of the occipital lobe cortex in the human brain. Along with area 18, it comprises the extrastriate (or peristriate) cortex. In normally-sighted humans, extrastriate cortex is a visual association area, with feature-extracting, shape recognition, attentional, and multimodal integrating functions. This area is also known as peristriate area 19, and it refers to a subdivision of the cytoarchitecturally defined occipital region of cerebral cortex. In the human it is located in parts of the lingual gyrus, the cuneus, the lateral occipital gyrus (H) and the superior occipital gyrus (H) of the occipital lobe where it is bounded approximately by the parieto-occipital sulcus. Cytoarchitecturally it is bounded on one side by the parastriate area 18 which it surrounds. Rostrally it is bounded by the angular area 39 (H) and the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013550)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013550#brodmann-1909-area-19-1",
+  "name": "Brodmann (1909) area 19",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013550",
+  "synonym": [
+    "area 19 of Brodmann",
+    "area 19 of Brodmann-1909",
+    "area peristriata",
+    "B09-19",
+    "Brodmann (1909) area 19",
+    "Brodmann area 19",
+    "Brodmann area 19, peristriate",
+    "Brodmann's area 19",
+    "preoccipital area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area2.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013533)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013533#brodmann-1909-area-2-1",
+  "name": "Brodmann (1909) area 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013533",
+  "synonym": [
+    "area 2 of Brodmann",
+    "area 2 of Brodmann-1909",
+    "area postcentralis caudalis",
+    "B09-2",
+    "Brodmann (1909) area 2",
+    "Brodmann area 2",
+    "Brodmann area 2, caudal postcentral",
+    "Brodmann's area 2",
+    "caudal postcentral area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area20.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area20",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "description": "Brodmann area 20, or BA20, is part of the temporal cortex in the human brain. The region encompasses most of the ventral temporal cortex, a region believed to play a part in high-level visual processing and recognition memory. This area is also known as inferior temporal area 20, and it refers to a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the inferior temporal gyrus. Cytoarchitecturally it is bounded medially by the ectorhinal area 36 (H), laterally by the middle temporal area 21, rostrally by the temporopolar area 38 (H) and caudally by the occipitotemporal area 37 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013551)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013551#brodmann-1909-area-20-1",
+  "name": "Brodmann (1909) area 20",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013551",
+  "synonym": [
+    "area 20 of Brodmann",
+    "area 20 of Brodmann-1909",
+    "area temporalis inferior",
+    "B09-20",
+    "Brodmann (1909) area 20",
+    "Brodmann area 20",
+    "Brodmann area 20, inferior temporal",
+    "inferior temporal area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area21.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area21",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the temporal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 21, or BA21, is part of the temporal cortex in the human brain. The region encompasses most of the lateral temporal cortex, a region believed to play a part in auditory processing and language. Language function is left lateralized in most individuals. BA21 is superior to BA20 and inferior to BA40 and BA41. This area is also known as middle temporal area 21. It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. In the human it corresponds approximately to the middle temporal gyrus. It is bounded rostrally by the temporopolar area 38 (H), ventrally by the inferior temporal area 20, caudally by the occipitotemporal area 37 (H), and dorsally by the superior temporal area 22 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013552)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013552#brodmann-1909-area-21-1",
+  "name": "Brodmann (1909) area 21",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013552",
+  "synonym": [
+    "area 21 of Brodmann",
+    "area 21 of Brodmann-1909",
+    "B09-21",
+    "BA21",
+    "Brodmann (1909) area 21",
+    "Brodmann area 21",
+    "Brodmann area 21, middle temporal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area22.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area22",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "description": "Brodmann area 22 is one of Brodmann's cytologically defined regions of the brain. It is involved in auditory processing. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013553)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013553#brodmann-1909-area-22-1",
+  "name": "Brodmann (1909) area 22",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013553",
+  "synonym": [
+    "area 22 of Brodmann",
+    "area 22 of Brodmann-1909",
+    "area temporalis superior",
+    "area temporalis superior",
+    "B09-22",
+    "Brodmann (1909) area 22",
+    "Brodmann area 22",
+    "Brodmann area 22, superior temporal",
+    "Superior temporal area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area23.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area23",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "description": "The term area 23 of Brodmann-1909 refers to a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. Brodmann regarded it as topographically and cytoarchitecturally homologous to the combined ventral posterior cingulate area 23 and dorsal posterior cingulate area 31 of the human (Brodmann-1909). Distinctive Features (Brodmann-1905): the cortex is relatively thin; smaller cells predominate; the cell density of the multiform layer (VI) is great, producing a distinct boundary with the subcortical white matter; the internal granular layer (IV) is rather well developed; the internal pyramidal layer (V) contains a dense population of round, medium-sized ganglion cells concentrated at the border with layer IV; layers V and VI are narrow with a distinct mutual boundary.nn* Definition Source NeuroNames. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013554)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013554#brodmann-1909-area-23-1",
+  "name": "Brodmann (1909) area 23",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013554",
+  "synonym": [
+    "area 23 of Brodmann",
+    "area 23 of Brodmann-1909",
+    "area cingularis posterior ventralis",
+    "area cingularis posterior ventralis",
+    "B09-23",
+    "Brodmann (1909) area 23",
+    "Brodmann area 23",
+    "Brodmann area 23, ventral posterior cingulate",
+    "granular cingulate area",
+    "posterior cingulate area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area24.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area24",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the anterior cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006101) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006101#brodmann-1909-area-24-1",
+  "name": "Brodmann (1909) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006101",
+  "synonym": [
+    "area 24 of Brodmann",
+    "area 24 of Brodmann-1909",
+    "area cingularis anterior ventralis",
+    "B09-24",
+    "BA24",
+    "Brodmann (1909) area 24",
+    "Brodmann area 24",
+    "ventral anterior cingulate"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area25.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area25",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "description": "Brodmann area 25 (BA25) is an area in the cerebral cortex of the brain and delineated based on its cytoarchitectonic characteristics. It is also called the subgenual area or area subgenualis. It is the 25th 'Brodmann area' defined by Korbinian Brodmann (thus its name). BA25 is located in the cingulate region as a narrow band in the caudal portion of the subcallosal area adjacent to the paraterminal gyrus. The posterior parolfactory sulcus separates the paraterminal gyrus from BA25. Rostrally it is bound by the prefrontal area 11 of Brodmann. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013556)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013556#brodmann-1909-area-25-1",
+  "name": "Brodmann (1909) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013556",
+  "synonym": [
+    "area 25 of Brodmann",
+    "area 25 of Brodmann-1909",
+    "area subgenualis",
+    "B09-25",
+    "Brodmann (1909) area 25",
+    "Brodmann area 25",
+    "Brodmann area 25, subgenual",
+    "Brodmann's area 25"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area26.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area26",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004718)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004718#brodmann-1909-area-26-1",
+  "name": "Brodmann (1909) area 26",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004718",
+  "synonym": [
+    "area 26 of Brodmann",
+    "area 26 of Brodmann-1909",
+    "area ectosplenialis",
+    "B09-26",
+    "Brodmann (1909) area 26",
+    "Brodmann area 26",
+    "Brodmann area 26, ectosplenial",
+    "ectosplenial area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area27.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area27",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the presubiculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558) ('is_a' and 'relationship')]",
+  "description": "Area 27 of Brodmann-1909 is a cytoarchitecturally defined cortical area that is a rostral part of the parahippocampal gyrus of the guenon (Brodmann-1909). It is commonly regarded as a synonym of presubiculum (Crosby-62). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013558)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013558#brodmann-1909-area-27-1",
+  "name": "Brodmann (1909) area 27",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013558",
+  "synonym": [
+    "area 27",
+    "area 27 of Brodmann",
+    "area 27 of Brodmann-1909",
+    "area praesubicularis",
+    "B09-27",
+    "BA27",
+    "Brodmann (1909) area 27",
+    "Brodmann area 26, presubicular",
+    "Brodmann area 27",
+    "presubicular area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area28.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area28",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the secondary olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013559) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013559#brodmann-1909-area-28-1",
+  "name": "Brodmann (1909) area 28",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013559",
+  "synonym": [
+    "area 28 of Brodmann",
+    "area 28 of Brodmann (Crosby)",
+    "area 28 of Brodmann-1909",
+    "area entorhinalis",
+    "area entorhinalis ventralis",
+    "B09-28",
+    "BA28",
+    "Brodmann (1909) area 28",
+    "Brodmann area 28",
+    "Brodmann area 28, entorhinal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area29.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area29",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "description": "Brodmann area 29, also known as granular retrolimbic area 29 or granular retrosplenial cortex, is a cytoarchitecturally defined portion of the retrosplenial region of the cerebral cortex. In the human it is a narrow band located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the ectosplenial area 26 and externally by the agranular retrolimbic area 30 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004717#brodmann-1909-area-29-1",
+  "name": "Brodmann (1909) area 29",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004717",
+  "synonym": [
+    "area 29 of Brodmann",
+    "area 29 of Brodmann-1909",
+    "area retrolimbica granularis",
+    "B09-29",
+    "Brodmann (1909) area 29",
+    "Brodmann area 29",
+    "Brodmann area 29, granular retrolimbic",
+    "Brodmann's area 29"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area3.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006100)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006100#brodmann-1909-area-3-1",
+  "name": "Brodmann (1909) area 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006100",
+  "synonym": [
+    "area 3 of Brodmann",
+    "area 3 of Brodmann-1909",
+    "area postcentralis oralis",
+    "B09-3",
+    "BA3",
+    "Brodmann (1909) area 3",
+    "Brodmann area 3",
+    "Brodmann's area 3",
+    "rostral postcentral",
+    "rostral postcentral area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area30.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area30",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "description": "Brodmann area 30, also known as agranular retrolimbic area 30, is a subdivision of the cytoarchitecturally defined retrosplenial region of the cerebral cortex. In the human it is located in the isthmus of cingulate gyrus. Cytoarchitecturally it is bounded internally by the granular retrolimbic area 29, dorsally by the ventral posterior cingulate area 23 and ventrolaterally by the ectorhinal area 36 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006474)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006474#brodmann-1909-area-30-1",
+  "name": "Brodmann (1909) area 30",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006474",
+  "synonym": [
+    "agranular retrolimbic area 30",
+    "area 30 of Brodmann",
+    "area 30 of Brodmann-1909",
+    "area retrolimbica agranularis",
+    "area retrosplenialis agranularis",
+    "B09-30",
+    "BA30",
+    "Brodmann (1909) area 30",
+    "Brodmann area 30",
+    "Brodmann area 30, agranular retrolimbic",
+    "Brodmann's area 30"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area31.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area31",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "description": "Brodmann area 31, also known as dorsal posterior cingulate area 31, is a subdivision of the cytoarchitecturally defined cingulate region of the cerebral cortex. In the human it occupies portions of the posterior cingulate gyrus and medial aspect of the parietal lobe. Approximate boundaries are the cingulate sulcus dorsally and the parieto-occipital sulcus caudally. It partially surrounds the subparietal sulcus, the ventral continuation of the cingulate sulcus in the parietal lobe. Cytoarchitecturally it is bounded rostrally by the ventral anterior cingulate area 24, ventrally by the ventral posterior cingulate area 23, dorsally by the gigantopyramidal area 4 and preparietal area 5 and caudally by the superior parietal area 7 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006475#brodmann-1909-area-31-1",
+  "name": "Brodmann (1909) area 31",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006475",
+  "synonym": [
+    "area 31 of Brodmann",
+    "area 31 of Brodmann-1909",
+    "area cingularis posterior dorsalis",
+    "area cingularis posterior dorsalis",
+    "B09-31",
+    "BA31",
+    "Brodmann (1909) area 31",
+    "Brodmann area 31",
+    "Brodmann area 31, dorsal posterior cingulate",
+    "Brodmann's area 31",
+    "cinguloparietal transition area",
+    "dorsal posterior cingulate area 31"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area32.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area32",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "description": "The Brodmann area 32, also known in the human brain as the dorsal anterior cingulate area 32, refers to a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. In the human it forms an outer arc around the anterior cingulate gyrus. The cingulate sulcus defines approximately its inner boundary and the superior rostral sulcus (H) its ventral boundary; rostrally it extends almost to the margin of the frontal lobe. Cytoarchitecturally it is bounded internally by the ventral anterior cingulate area 24, externally by medial margins of the agranular frontal area 6, intermediate frontal area 8, granular frontal area 9, frontopolar area 10, and prefrontal area 11-1909. (Brodmann19-09). Dorsal region of anterior cingulate gyrus is associated with rational thought processes, most notably active during the Stroop task. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013560)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013560#brodmann-1909-area-32-1",
+  "name": "Brodmann (1909) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013560",
+  "synonym": [
+    "area 32 of Brodmann",
+    "area 32 of Brodmann-1909",
+    "area cingularis anterior dorsalis",
+    "area cingularis anterior dorsalis",
+    "B09-32",
+    "Brodmann (1909) area 32",
+    "Brodmann area 32",
+    "Brodmann area 32, dorsal anterior cingulate",
+    "Prelimbic area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area33.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area33",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the cingulate cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 33, also known as pregenual area 33, is a subdivision of the cytoarchitecturally defined cingulate region of cerebral cortex. It is a narrow band located in the anterior cingulate gyrus adjacent to the supracallosal gyrus in the depth of the callosal sulcus, near the genu of the corpus callosum. Cytoarchitecturally it is bounded by the ventral anterior cingulate area 24 and the supracallosal gyrus (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006476#brodmann-1909-area-33-1",
+  "name": "Brodmann (1909) area 33",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006476",
+  "synonym": [
+    "area 33 of Brodmann",
+    "area 33 of Brodmann-1909",
+    "area praegenualis",
+    "area praegenualis",
+    "B09-33",
+    "BA33",
+    "Brodmann (1909) area 33",
+    "Brodmann area 33",
+    "Brodmann area 33, pregenual",
+    "Brodmann's area 33",
+    "pregenual area 33"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area34.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area34",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "description": "Brodmann area 34 is a part of the brain. It has been described as part of the entorhinal area. It has been described as part of the superior temporal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006477)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006477#brodmann-1909-area-34-1",
+  "name": "Brodmann (1909) area 34",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006477",
+  "synonym": [
+    "area 34 of Brodmann",
+    "area 34 of Brodmann-1909",
+    "area entorhinalis dorsalis",
+    "area entorhinalis dorsalis",
+    "B09-34",
+    "BA34",
+    "Brodmann (1909) area 34",
+    "Brodmann area 34",
+    "Brodmann area 34, dorsal entorhinal",
+    "dorsal entorhinal area 34"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area35.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area35",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 35, together with Brodmann area 36, is most frequently referred to as perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006102)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006102#brodmann-1909-area-35-1",
+  "name": "Brodmann (1909) area 35",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006102",
+  "synonym": [
+    "area 35 of Brodmann",
+    "area 35 of Brodmann-1909",
+    "area perirhinalis",
+    "B09-35",
+    "BA35",
+    "Brodmann (1909) area 35",
+    "Brodmann area 35",
+    "Brodmann area 35, perirhinal",
+    "Brodmann's area 35",
+    "perirhinal area 35"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area36.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area36",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the perirhinal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104) ('is_a' and 'relationship')]",
+  "description": "Ectorhinal area 36 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. With its medial boundary corresponding approximately to the rhinal sulcus it is located primarily in the fusiform gyrus. Cytoarchitecturally it is bounded laterally and caudally by the inferior temporal area 20, medially by the perirhinal area 35 and rostrally by the temporopolar area 38 (H) (Brodmann-1909). Together with Brodmann area 35, it comprises the perirhinal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006104#brodmann-1909-area-36-1",
+  "name": "Brodmann (1909) area 36",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006104",
+  "synonym": [
+    "area 36 of Brodmann",
+    "area 36 of Brodmann-1909",
+    "area ectorhinalis",
+    "B09-36",
+    "BA36",
+    "Brodmann (1909) area 36",
+    "Brodmann area 36",
+    "ectorhinal",
+    "ectorhinal area 36"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area37.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area37",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "description": "Brodmann area 37, or BA37, is part of the temporal cortex in the human brain. This area is known as occipitotemporal area 37 (H). It is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the caudal portions of the fusiform gyrus and inferior temporal gyrus on the mediobasal and lateral surfaces at the caudal extreme of the temporal lobe. Cytoarchitecturally it is bounded caudally by the peristriate Brodmann area 19, rostrally by the inferior temporal area 20 and middle temporal area 21 and dorsally on the lateral aspect of the hemisphere by the angular area 39 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006478)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006478#brodmann-1909-area-37-1",
+  "name": "Brodmann (1909) area 37",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006478",
+  "synonym": [
+    "area 37 0f brodmann",
+    "area 37 of Brodmann-1909",
+    "area occipitotemporalis",
+    "area occipitotemporalis",
+    "B09-37",
+    "BA37",
+    "Brodmann (1909) area 37",
+    "Brodmann area 37",
+    "Brodmann area 37, occipitotemporal",
+    "occipitotemporal area 37"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area38.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area38",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "description": "Brodmann area 38, also BA38 or temporopolar area 38 (H), is part of the temporal cortex in the human brain. BA 38 is at the anterior end of the temporal lobe, known as the temporal pole. BA38 is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located primarily in the most rostral portions of the superior temporal gyrus and the middle temporal gyrus. Cytoarchitecturally it is bounded caudally by the inferior temporal area 20, the middle temporal area 21, the superior temporal area 22 and the ectorhinal area 36 (Brodmann-1909). Cytoarchitectonic and chemoarchitectonic studies find that it contains at least seven subareas, one of which, TG, is unique to humans. 'The functional significance of this area TG is not known, but it may bind complex, highly processed perceptual inputs to visceral emotional responses.' This area is among the earliest affected by Alzheimer's disease and the earliest involved at the start of temporal lobe seizures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006479#brodmann-1909-area-38-1",
+  "name": "Brodmann (1909) area 38",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006479",
+  "synonym": [
+    "area 38 of Brodmann",
+    "area 38 of Brodmann-1909",
+    "area temporopolaris",
+    "B09-38",
+    "BA38",
+    "Brodmann (1909) area 38",
+    "Brodmann area 38",
+    "Brodmann area 38, temporopolar",
+    "temporopolar area 38"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area39.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area39",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006480)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006480#brodmann-1909-area-39-1",
+  "name": "Brodmann (1909) area 39",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006480",
+  "synonym": [
+    "angular area 39",
+    "area 39 of Brodmann",
+    "area 39 of Brodmann-1909",
+    "area angularis",
+    "B09-39",
+    "BA39",
+    "Brodmann (1909) area 39",
+    "Brodmann area 39",
+    "Brodmann area 39, angular"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area4.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the primary motor cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535) ('is_a' and 'relationship')]",
+  "description": "The term area 4 of Brodmann-1909 refers to a cytoarchitecturally defined portion of the frontal lobe of the guenon. It is located predominantly in the precentral gyrus. Brodmann-1909 regarded it as topographically and cytoarchitecturally homologous to the human gigantopyramidal area 4 and noted that it occupies a much greater fraction of the frontal lobe in the monkey than in the human. Distinctive features (Brodmann-1905): the cortex is unusually thick; the layers are not distinct; the cells are relatively sparsely distributed; giant pyramidal (Betz) cells are present in the internal pyramidal layer (V); lack of an internal granular layer (IV) such that the boundary between the external pyramidal layer (III) and the internal pyramidal layer (V) is indistinct; lack of a distinct external granular layer (II); a gradual transition from the multiform layer (VI) to the subcortical white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013535#brodmann-1909-area-4-1",
+  "name": "Brodmann (1909) area 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013535",
+  "synonym": [
+    "area 4 of Brodmann",
+    "area 4 of Brodmann-1909",
+    "area gigantopyramidalis",
+    "B09-4",
+    "Brodmann (1909) area 4",
+    "Brodmann area 4",
+    "Brodmann area 4, gigantopyramidal",
+    "Brodmann's area 4",
+    "giant pyramidal area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area40.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area40",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the supramarginal gyrus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573) ('is_a' and 'relationship')]",
+  "description": "Brodmann area 40, or BA40, is part of the parietal cortex in the human brain. The inferior part of BA40 is in the area of the supramarginal gyrus, which lies at the posterior end of the lateral fissure, in the inferior lateral part of the parietal lobe. It is bounded approximately by the intraparietal sulcus, the inferior postcentral sulcus, the posterior subcentral sulcus and the lateral sulcus. Cytoarchitecturally it is bounded caudally by the angular area 39 (H), rostrally and dorsally by the caudal postcentral area 2, and ventrally by the subcentral area 43 and the superior temporal area 22 (Brodmann-1909). Cytoarchitectonically defined subregions of rostral BA40/the supramarginal gyrus are PF, PFcm, PFm, PFop, and PFt. Area PF is the homologue to macaque area PF, part of the mirror neuron system, and active in humans during imitation. The supramarginal gyrus part of Brodmann area 40 is the region in the inferior parietal lobe that is involved in reading both in regards to meaning and phonology. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013573#brodmann-1909-area-40-1",
+  "name": "Brodmann (1909) area 40",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013573",
+  "synonym": [
+    "area 40 of Brodmann",
+    "area 40 of Brodmann-1909",
+    "area supramarginalis",
+    "B09-40",
+    "Brodmann (1909) area 40",
+    "Brodmann area 40",
+    "Brodmann area 40, supramarginal",
+    "Supramarginal area 40"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area43.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area43",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "description": "Brodmann area 43 is a subdivision of the cerebral cortex of the guenon defined on the basis of cytoarchitecture. It was described (but not labeled) on the map of cortical areas in Brodmann-1909, and it was regarded as cytoarchitecturally homologous to area 30 of Mauss in 1908 in the guenon and subcentral area 43 of the human (Brodmann-1909). The Vogts found no distinctive architectonic area of the corresponding location in the guenon (Vogts-1919). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013561#brodmann-1909-area-43-1",
+  "name": "Brodmann (1909) area 43",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013561",
+  "synonym": [
+    "area 43 of brodmann",
+    "area 43 of Brodmann-1909",
+    "area subcentralis",
+    "B09-43",
+    "Brodmann (1909) area 43",
+    "Brodmann area 43",
+    "Brodmann area 43, subcentral"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area44.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area44",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "description": "Brodmann area 44, or BA44, is part of the frontal cortex in the human brain. Situated just anterior to premotor cortex and on the lateral surface, inferior to BA9. This area is also known as pars opercularis (of the inferior frontal gyrus), and it refers to a subdivision of the cytoarchitecturally defined frontal region of cerebral cortex. In the human it corresponds approximately to the opercular part of inferior frontal gyrus (H). Thus, it is bounded caudally by the inferior precentral sulcus (H) and rostrally by the anterior ascending limb of lateral sulcus (H). It surrounds the diagonal sulcus (H). In the depth of the lateral sulcus it borders on the insula. Cytoarchitectonically it is bounded caudally and dorsally by the agranular frontal area 6, dorsally by the granular frontal area 9 and rostrally by the triangular area 45 (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006481#brodmann-1909-area-44-1",
+  "name": "Brodmann (1909) area 44",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006481",
+  "synonym": [
+    "area 44 of Brodmann",
+    "area 44 of Brodmann-1909",
+    "area opercularis",
+    "B09-44",
+    "BA44",
+    "Brodmann (1909) area 44",
+    "Brodmann area 44",
+    "Brodmann area 44, opercular",
+    "opercular area 44"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area45.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area45",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the frontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482) ('is_a' and 'relationship')]",
+  "description": "Part of the cytoarchitecturally defined frontal region of cerebral cortex. In the human, it occupies the triangular part of the inferior frontal gyrus (human) and, surrounding the anterior horizontal limb of the lateral sulcus (human), a portion of the orbital part of the inferior frontal gyrus (human). Bounded caudally by the anterior ascending limb of the lateral sulcus (human), it borders on the insula in the depth of the lateral sulcus. Cytoarchitectonically it is bounded caudally by the opercular area 44, rostrodorsally by the area 46 of Brodmann (human) and ventrally by the area 47 of Brodmann (human) (Brodmann-1909) (Adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006482)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006482#brodmann-1909-area-45-1",
+  "name": "Brodmann (1909) area 45",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006482",
+  "synonym": [
+    "area 45 of Brodmann",
+    "area 45 of Brodmann-1909",
+    "area triangularis",
+    "area triangularis",
+    "B09-45",
+    "BA45",
+    "Brodmann (1909) area 45",
+    "Brodmann area 45",
+    "Brodmann area 45, triangular",
+    "triangular area 45"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area46.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area46",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "description": "Brodmann area 46, or BA46, is part of the frontal cortex in the human brain. It is between BA10 and BA45. BA46 is known as middle frontal area 46. In the human it occupies approximately the middle third of the middle frontal gyrus and the most rostral portion of the inferior frontal gyrus. Brodmann area 46 roughly corresponds with the dorsolateral prefrontal cortex (DLPFC), although the borders of area 46 are based on cytoarchitecture rather than function. The DLPFC also encompasses part of granular frontal area 9, directly adjacent on the dorsal surface of the cortex. Cytoarchitecturally, BA46 is bounded dorsally by the granular frontal area 9, rostroventrally by the frontopolar area 10 and caudally by the triangular area 45 (Brodmann-1909). There is some discrepancy between the extent of BA8 (Brodmann-1905) and the same area as described by Walker (1940) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006483#brodmann-1909-area-46-1",
+  "name": "Brodmann (1909) area 46",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006483",
+  "synonym": [
+    "area 46 of Brodmann",
+    "area 46 of Brodmann-1909",
+    "area frontalis media",
+    "B09-46",
+    "BA46",
+    "Brodmann (1909) area 46",
+    "Brodmann area 46",
+    "Brodmann area 46, middle frontal",
+    "middle frontal area 46"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area47.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area47",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "description": "Brodmann area 47, or BA47, is part of the frontal cortex in the human brain. Curving from the lateral surface of the frontal lobe into the ventral (orbital) frontal cortex. It is below areas BA10 and BA45, and beside BA11. This area is also known as orbital area 47. In the human, on the orbital surface it surrounds the caudal portion of the orbital sulcus (H) from which it extends laterally into the orbital part of inferior frontal gyrus (H). Cytoarchitectonically it is bounded caudally by the triangular area 45, medially by the prefrontal area 11 of Brodmann-1909, and rostrally by the frontopolar area 10 (Brodmann-1909). It incorporates the region that Brodmann identified as 'Area 12' in the monkey, and therefore, following the suggestion of Michael Petrides, some contemporary neuroscientists refer to the region as 'BA47/12. ' BA47 has been implicated in the processing of syntax in spoken and signed languages, and more recently in musical syntax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006484)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006484#brodmann-1909-area-47-1",
+  "name": "Brodmann (1909) area 47",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006484",
+  "synonym": [
+    "area 47 of Brodmann",
+    "area 47 of Brodmann-1909",
+    "area orbitalis",
+    "area orbitalis",
+    "B09-47",
+    "BA47",
+    "Brodmann (1909) area 47",
+    "Brodmann area 47",
+    "Brodmann area 47, orbital",
+    "orbital area 47"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area48.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area48",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "description": "Retrosubicular area 48 is a subdivision of the cytoarchitecturally defined hippocampal region of the cerebral cortex. In the human it is located on the medial surface of the temporal lobe. Cytoarchitectually it is bounded rostrally by the perirhinal area 35 and medially by the presubiculum. While described by Brodmann (Brodmann-1909), it was not included in his areal maps of human cortex (Brodmann-1909; Brodmann-1910). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006485)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006485#brodmann-1909-area-48-1",
+  "name": "Brodmann (1909) area 48",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006485",
+  "synonym": [
+    "area 48 of Brodmann",
+    "area retrosubicularis",
+    "B09-48",
+    "BA48",
+    "Brodmann (1909) area 48",
+    "Brodmann area 48",
+    "Brodmann area 48, retrosubicular",
+    "Brodmann's area 48",
+    "retrosubicular area 48"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area5.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "description": "Brodmann area 5 is one of Brodmann's cytologically defined regions of the brain. It is involved in somatosensory processing and association. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006471)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006471#brodmann-1909-area-5-1",
+  "name": "Brodmann (1909) area 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006471",
+  "synonym": [
+    "area 5 of Brodmann-1909",
+    "area praeparietalis",
+    "B09-5",
+    "BA5",
+    "Brodmann (1909) area 5",
+    "Brodmann area 5",
+    "Brodmann area 5, preparietal",
+    "preparietal area 5"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area52.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area52",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "description": "Parainsular area 52 (H) is a subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It is located in the bank of the lateral sulcus on the dorsal surface of the temporal lobe. Its medial boundary corresponds approximately to the junction between the temporal lobe and the insula. Cytoarchitecturally it is bounded laterally by the anterior transverse temporal area 42 (H) (Brodmann-1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006486)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006486#brodmann-1909-area-52-1",
+  "name": "Brodmann (1909) area 52",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006486",
+  "synonym": [
+    "area 52 of Brodmann",
+    "area parainsularis",
+    "B09-52",
+    "BA52",
+    "Brodmann (1909) area 52",
+    "Brodmann area 52",
+    "Brodmann area 52, parainsular",
+    "parainsular area 52"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area6.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area6",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "description": "Brodmann area 6, or BA6, is part of the frontal cortex in the human brain. Situated just anterior to the primary motor cortex, it is composed of the premotor cortex and, medially, the supplementary motor area, or SMA. This large area of the frontal cortex is believed to play a role in the planning of complex, coordinated movements. Brodmann area 6 is also called agranular frontal area 6 in humans because it lacks an internal granular cortical layer (layer IV). It is a subdivision of the cytoarchitecturally defined precentral region of cerebral cortex. In the human brain, it is located on the portions of the precentral gyrus that are not occupied by the gigantopyramidal area 4; furthermore, BA6 extends onto the caudal portions of the superior frontal and middle frontal gyri. It extends from the cingulate sulcus on the medial aspect of the hemisphere to the lateral sulcus on the lateral aspect. It is bounded rostrally by the granular frontal region and caudally by the gigantopyramidal area 4 (Brodmann, 1909). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006472)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006472#brodmann-1909-area-6-1",
+  "name": "Brodmann (1909) area 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006472",
+  "synonym": [
+    "agranular frontal area 6",
+    "area 6 of Brodmann",
+    "area 6 of Brodmann-1909",
+    "area frontalis agranularis",
+    "B09-6",
+    "BA6",
+    "Brodmann (1909) area 6",
+    "Brodmann area 6",
+    "Brodmann area 6, agranular frontal",
+    "frontal belt"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area7.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "description": "Brodmann area 7 is one of Brodmann's cytologically defined regions of the brain. It is involved in locating objects in space. It serves as a point of convergence between vision and proprioception to determine where objects are in relation to parts of the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013538#brodmann-1909-area-7-1",
+  "name": "Brodmann (1909) area 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013538",
+  "synonym": [
+    "area 7 of Brodmann",
+    "area 7 of Brodmann-1909",
+    "area parietalis superior",
+    "area parietalis superior",
+    "B09-7",
+    "Brodmann (1909) area 7",
+    "Brodmann area 7",
+    "Brodmann area 7, superior parietal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area8.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "description": "Brodmann area 8 is one of Brodmann's cytologically defined regions of the brain. It is involved in planning complex movements. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013539)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013539#brodmann-1909-area-8-1",
+  "name": "Brodmann (1909) area 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013539",
+  "synonym": [
+    "area 8 of Brodmann",
+    "area 8 of Brodmann-1909",
+    "area frontalis intermedia",
+    "area frontalis intermedia",
+    "B09-8",
+    "Brodmann (1909) area 8",
+    "Brodmann area 8",
+    "Brodmann area 8, intermediate frontal",
+    "intermediate frontal area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area8a.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area8a",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013562)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013562#brodmann-1909-area-8a-1",
+  "name": "Brodmann (1909) area 8a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013562",
+  "synonym": [
+    "area 8a of Brodmann-1909",
+    "B09-8a",
+    "Brodmann (1909) area 8a",
+    "Brodmann area 8a"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/Brodmann1909Area9.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/Brodmann1909Area9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Brodmann area. Is part of the dorsolateral prefrontal cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013540) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013540#brodmann-1909-area-9-1",
+  "name": "Brodmann (1909) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013540",
+  "synonym": [
+    "area 9 of Brodmann",
+    "area 9 of Brodmann-1909",
+    "area frontalis granularis",
+    "area frontalis granularis",
+    "B09-9",
+    "Brodmann (1909) area 9",
+    "Brodmann area 9",
+    "Brodmann area 9, granular frontal",
+    "granular frontal area"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/BrodmannArea.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/BrodmannArea.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/BrodmannArea",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebral cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529) ('is_a' and 'relationship')]",
+  "description": "A segmentation of the cerebral cortex on the basis of cytoarchitecture as described in Brodmann-1905, Brodmann-1909 and Brodmann-10. Maps for several species were presented. NeuroNames includes only areas in the human and in Old World monkeys. Of the latter, Brodmann studied representatives of several species including guenons (one Cercopithecus mona, one Cercocebus torquatus, and one Cercopithecus otherwise unspecified), which are all closely related African species, and one macaque (Macaca mulatta) an Asian species (Brodmann-1905). The legend to the summary map in Brodmann-1909 ascribes the areas simply to Cercopithecus. Brodmann referenced the areas by name and number. The same area number in humans and monkeys did not necessarily refer to topologically or cytoarchitecturally homologous structures. In NeuroNames the standard term for human areas consists of the English translation of Brodmann's Latin name followed by the number he assigned, e.g., agranular frontal area 6; the standard terms for monkey areas are in the format: area 6 of Brodmann-1909. He mapped a portion of areas limited to the banks of sulci, e.g., area 3 of Brodmann-1909 (Brodmann-1909) onto the adjacent, visible surface. This accounts for the fact that some areas appear larger on his surface map than on maps of other authors, e.g., area 3 of Vogts-1919. (Adapted from NeuroNames) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013529)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013529#brodmann-partition-scheme-region",
+  "name": "Brodmann area",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013529",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1d",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028398)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028398#hadjikhani-et-al-1998-visuotopic-area-v1d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028398",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1d",
+    "Hadjikhani et al. (1998) visuotopic area v1d"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV1v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028399)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028399#hadjikhani-et-al-1998-visuotopic-area-v1v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V1v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028399",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v1v",
+    "Hadjikhani et al. (1998) visuotopic area v1v"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2d",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006487)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006487#hadjikhani-et-al-1998-visuotopic-area-v2d-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2d",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006487",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2d"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV2v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028401#hadjikhani-et-al-1998-visuotopic-area-v2v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V2v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028401",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v2v",
+    "Hadjikhani et al. (1998) visuotopic area v2v"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028402)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028402#hadjikhani-et-al-1998-visuotopic-area-v3-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028402",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3",
+    "Hadjikhani et al. (1998) visuotopic area v3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV3A",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028403)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028403#hadjikhani-et-al-1998-visuotopic-area-v3a-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V3A",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028403",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v3a",
+    "Hadjikhani et al. (1998) visuotopic area v3a"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV4v",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028405)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028405#hadjikhani-et-al-1998-visuotopic-area-v4v-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V4v",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028405",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v4v",
+    "Hadjikhani et al. (1998) visuotopic area v4v"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaV8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028406)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028406#hadjikhani-et-al-1998-visuotopic-area-v8-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area V8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028406",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area v8",
+    "Hadjikhani et al. (1998) visuotopic area v8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicAreaVP",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a Hadjikhani et al. (1998) visuotopic partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028404)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028404#hadjikhani-et-al-1998-visuotopic-area-vp-1",
+  "name": "Hadjikhani et al. (1998) visuotopic area VP",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028404",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic area vp",
+    "Hadjikhani et al. (1998) visuotopic area vp"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/HadjikhaniEtAl1998VisuotopicPartitionSchemeRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026765) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026765#hadjikhani-et-al-1998-visuotopic-partition-scheme-region-1",
+  "name": "Hadjikhani et al. (1998) visuotopic partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026765",
+  "synonym": [
+    "Hadjikhani et al. (1998) visuotopic partition scheme region",
+    "Hadjikhani et al. (1998) visuotopic partition scheme region"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028437)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028437#ongur-price-and-ferry-2003-area-10l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028437",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10l",
+    "ongur, price, and ferry (2003) area 10l"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "description": "Area 10m is a cortical area in the frontal lobe defined on multiple architectonic criteria. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028415)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028415#ongur-price-and-ferry-2003-area-10m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028415",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10m",
+    "ongur, price, and ferry (2003) area 10m"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10o.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10o",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028414)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028414#ongur-price-and-ferry-2003-area-10o-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10o",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028414",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10o",
+    "ongur, price, and ferry (2003) area 10o"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10p.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10p",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028412)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028412#ongur-price-and-ferry-2003-area-10p-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10p",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028412",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10p",
+    "ongur, price, and ferry (2003) area 10p"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area10r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area10r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028413)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028413#ongur-price-and-ferry-2003-area-10r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 10r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028413",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 10r",
+    "ongur, price, and ferry (2003) area 10r"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area11l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028427)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028427#ongur-price-and-ferry-2003-area-11l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028427",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11l",
+    "ongur, price, and ferry (2003) area 11l"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area11m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area11m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028416)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028416#ongur-price-and-ferry-2003-area-11m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 11m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028416",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 11m",
+    "ongur, price, and ferry (2003) area 11m"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13a.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13a",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028419)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028419#ongur-price-and-ferry-2003-area-13a-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13a",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028419",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13a",
+    "ongur, price, and ferry (2003) area 13a"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13b.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13b",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028418)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028418#ongur-price-and-ferry-2003-area-13b-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13b",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028418",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13b",
+    "ongur, price, and ferry (2003) area 13b"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028429)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028429#ongur-price-and-ferry-2003-area-13l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028429",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13l",
+    "ongur, price, and ferry (2003) area 13l"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area13m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area13m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028428)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028428#ongur-price-and-ferry-2003-area-13m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 13m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028428",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 13m",
+    "ongur, price, and ferry (2003) area 13m"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14c.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area14c",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028421)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028421#ongur-price-and-ferry-2003-area-14c-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14c",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028421",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14c",
+    "ongur, price, and ferry (2003) area 14c"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area14r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area14r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028420)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028420#ongur-price-and-ferry-2003-area-14r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 14r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028420",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 14r",
+    "ongur, price, and ferry (2003) area 14r"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area24.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area24",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028422)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028422#ongur-price-and-ferry-2003-area-24-1",
+  "name": "Ongur, Price, and Ferry (2003) area 24",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028422",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 24",
+    "ongur, price, and ferry (2003) area 24"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area25.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area25",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028423)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028423#ongur-price-and-ferry-2003-area-25-1",
+  "name": "Ongur, Price, and Ferry (2003) area 25",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028423",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 25",
+    "ongur, price, and ferry (2003) area 25"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area32.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area32",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028424)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028424#ongur-price-and-ferry-2003-area-32-1",
+  "name": "Ongur, Price, and Ferry (2003) area 32",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028424",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 32",
+    "ongur, price, and ferry (2003) area 32"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47l.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47l",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028430#ongur-price-and-ferry-2003-area-47l-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47l",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028430",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47l",
+    "ongur, price, and ferry (2003) area 47l"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47m.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47m",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028431)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028431#ongur-price-and-ferry-2003-area-47m-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47m",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028431",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47m",
+    "ongur, price, and ferry (2003) area 47m"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47r.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47r",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028432)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028432#ongur-price-and-ferry-2003-area-47r-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47r",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028432",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47r",
+    "ongur, price, and ferry (2003) area 47r"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area47s.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area47s",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028417)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028417#ongur-price-and-ferry-2003-area-47s-1",
+  "name": "Ongur, Price, and Ferry (2003) area 47s",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028417",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 47s",
+    "ongur, price, and ferry (2003) area 47s"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003Area9.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003Area9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028436)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028436#ongur-price-and-ferry-2003-area-9-1",
+  "name": "Ongur, Price, and Ferry (2003) area 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028436",
+  "synonym": [
+    "ongur, price, and ferry (2003) area 9",
+    "ongur, price, and ferry (2003) area 9"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaAON.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaAON",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028440)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028440#ongur-price-and-ferry-2003-area-aon-1",
+  "name": "Ongur, Price, and Ferry (2003) area AON",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028440",
+  "synonym": [
+    "ongur, price, and ferry (2003) area aon",
+    "ongur, price, and ferry (2003) area aon"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaG.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaG",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028425)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028425#ongur-price-and-ferry-2003-area-g-1",
+  "name": "Ongur, Price, and Ferry (2003) area G",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028425",
+  "synonym": [
+    "ongur, price, and ferry (2003) area g",
+    "ongur, price, and ferry (2003) area g"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIai.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIai",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028435)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028435#ongur-price-and-ferry-2003-area-iai-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iai",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028435",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iai",
+    "ongur, price, and ferry (2003) area iai"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIal.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "description": "Insula agranular lateral area. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028434#ongur-price-and-ferry-2003-area-ial-1",
+  "name": "Ongur, Price, and Ferry (2003) area Ial",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028434",
+  "synonym": [
+    "ongur, price, and ferry (2003) area ial",
+    "ongur, price, and ferry (2003) area ial"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIam.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIam",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028433)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028433#ongur-price-and-ferry-2003-area-iam-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iam",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028433",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iam",
+    "ongur, price, and ferry (2003) area iam"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaIapm.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaIapm",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028439)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028439#ongur-price-and-ferry-2003-area-iapm-1",
+  "name": "Ongur, Price, and Ferry (2003) area Iapm",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028439",
+  "synonym": [
+    "ongur, price, and ferry (2003) area iapm",
+    "ongur, price, and ferry (2003) area iapm"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003AreaPrCO",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0028426)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0028426#ongur-price-and-ferry-2003-area-prco-1",
+  "name": "Ongur, Price, and Ferry (2003) area PrCO",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0028426",
+  "synonym": [
+    "ongur, price, and ferry (2003) area prco",
+    "ongur, price, and ferry (2003) area prco"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/OngurPriceAndFerry2003PrefrontalCorticalPartitionSchemeRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026777) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026777#ongur-price-and-ferry-2003-prefrontal-cortical-partition-scheme-region-1",
+  "name": "Ongur, Price, and Ferry (2003) prefrontal cortical partition scheme region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026777",
+  "synonym": [
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region",
+    "ongur, price, and ferry (2003) prefrontal cortical partition scheme region"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/PressBrewerDoughertyWadeAndWandell2001VisuotopicAreaV7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026776) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026776#press-brewer-dougherty-wade-and-wandell-2001-visuotopic-area-v7-1",
+  "name": "Press, Brewer, Dougherty, Wade and Wandell (2001) visuotopic area V7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026776",
+  "synonym": [
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7",
+    "press, brewer, dougherty, wade and wandell (2001) visuotopic area v7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/TootellAndHadjikhani2001LOCLOPComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775) ('is_a' and 'relationship')]",
+  "description": "Cortical parcel in occipital cortex of human according to Tootell and Hadjikhani 2001 that is activated preferentially by more peripheral stimuli compared to the adjacent lateral occipital central parcel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026775#tootell-and-hadjikhani-2001-loc-lop-complex-1",
+  "name": "Tootell and Hadjikhani (2001) LOC/LOP complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026775",
+  "synonym": [
+    "tootell and Hadjikhani (2001) loc/lop complex",
+    "tootell and Hadjikhani (2001) loc/lop complex"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/basalGangliaOfRodent.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/basalGangliaOfRodent",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a collection of basal ganglia. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "description": "The basal ganglia of the rodent. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023920#basal-ganglia-of-rodent-1",
+  "name": "basal ganglia of rodent",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023920",
+  "synonym": [
+    "basal ganglia of rodent"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "description": "Rostral portion of the parahippocampal cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023936)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023936#perirhinal-cortex-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023936",
+  "synonym": [
+    "perirhinal cortex of burwell et al 1995"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfPrimateOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "description": "Cortical region near the rhinal sulcus in primate encompassing Brodmann's areas 35 and 36. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025581#perirhinal-cortex-of-primate-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of primate of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025581",
+  "synonym": [
+    "perirhinal cortex of primate of burwell et al 1995"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perirhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a perirhinal cortex of Burwell et al 1995. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "description": "Cortical region surrounding the posterior rhinal sulcus in the rat, encompassing areas 35 and 36 in the rat. Rostraly, it abuts the posterior insular cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025584#perirhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "perirhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025584",
+  "synonym": [
+    "perirhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postrhinalCortexOfRodentOfBurwellEtAl1995",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928) ('is_a' and 'relationship')]",
+  "description": "Cortical region lying caudal to the perirhinal cortex in the rat. It encompasses the caudal levels of area 35 and the caudal portion of area 36 (ectorhinal cortex). It is bordered medially by agranular retrosplenial cortex and ventrally by the entorhinal cortex (with the exception of the caudomedial portion). The authors note that the ventral portion of the postrhinal cortex in rat may by homologous with the parahippocampal cortex in the monkey. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023928)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023928#postrhinal-cortex-of-rodent-of-burwell-et-al-1995",
+  "name": "postrhinal cortex of rodent of Burwell et al 1995",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023928",
+  "synonym": [
+    "postrhinal cortex of rodent of burwell et al 1995"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in #133 and fully-automated (with minor clean-ups here and there)

**Filtering:**
any term with 'Hadjikhani', 'Burwell', 'Brodmann', 'Dougherty', 'Ongur', 'Rodent' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.