### PR TITLE
Blood related UBERON terms (addition)

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetinalArtery",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a retina blood vessel. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "description": "The central retinal artery (retinal artery) branches off the ophthalmic artery, running inferior to the optic nerve within its dural sheath to the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001620#central-retinal-artery",
+  "name": "central retinal artery",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001620",
+  "synonym": [
+    "central artery of retina",
+    "retinal artery",
+    "Zinn's artery"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralRetinalVein.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetinalVein",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the cavernous sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "description": "The central retinal vein (retinal vein) is a short vein that runs through the optic nerve and drains blood from the capillaries of the retina into the larger veins outside the eye. The anatomy of the veins of the orbit of the eye varies between individuals, and in some the central retinal vein drains into the superior ophthalmic vein, and in some it drains directly into the cavernous sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001673#central-retinal-vein",
+  "name": "central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001673",
+  "synonym": [
+    "retinal vein"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinaBloodVessel",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vasculature of retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "description": "A blood vessel that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003501#retina-blood-vessel",
+  "name": "retina blood vessel",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003501",
+  "synonym": [
+    "blood vessel of inner layer of eyeball",
+    "blood vessel of retina",
+    "blood vessel of tunica interna of eyeball",
+    "inner layer of eyeball blood vessel",
+    "retinal blood vessel",
+    "tunica interna of eyeball blood vessel"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tributaryOfCentralRetinalVein",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central retinal vein. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036300)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036300#tributary-of-central-retinal-vein",
+  "name": "tributary of central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036300",
+  "synonym": [
+    "central retinal venous tributary"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vasculatureOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "description": "A vasculature that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004864#vasculature-of-retina",
+  "name": "vasculature of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004864",
+  "synonym": [
+    "retina vasculature",
+    "retina vasculature of camera-type eye",
+    "retinal blood vessels",
+    "retinal blood vessels set",
+    "retinal vasculature",
+    "set of blood vessels of retina",
+    "set of retinal blood vessels",
+    "vasa sanguinea retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vessel.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vessel.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vessel",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'vessel' is an anatomical conduit.",
-  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph.",
+  "definition": "Is an anatomical conduit. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
+  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731576",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000055#vessel",
   "name": "vessel",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000055",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/bloodcerebrospinalFluidBarrier.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/bloodcerebrospinalFluidBarrier.jsonld
@@ -14,3 +14,4 @@
     "blood-CSF barrier"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/brainBloodVessel.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/brainBloodVessel.jsonld
@@ -14,3 +14,4 @@
     "blood vessel of brain"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralRetinalArtery",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a retina blood vessel. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "description": "The central retinal artery (retinal artery) branches off the ophthalmic artery, running inferior to the optic nerve within its dural sheath to the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001620#central-retinal-artery",
+  "name": "central retinal artery",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001620",
+  "synonym": [
+    "central artery of retina",
+    "retinal artery",
+    "Zinn's artery"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralRetinalVein.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralRetinalVein",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the cavernous sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "description": "The central retinal vein (retinal vein) is a short vein that runs through the optic nerve and drains blood from the capillaries of the retina into the larger veins outside the eye. The anatomy of the veins of the orbit of the eye varies between individuals, and in some the central retinal vein drains into the superior ophthalmic vein, and in some it drains directly into the cavernous sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001673#central-retinal-vein",
+  "name": "central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001673",
+  "synonym": [
+    "retinal vein"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cerebellumVasculature.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cerebellumVasculature.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006694",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cerebralBloodVessel.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cerebralBloodVessel.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016565",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/hindbrainVenousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/hindbrainVenousSystem.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005720",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/retinaBloodVessel",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the vasculature of retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "description": "A blood vessel that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003501#retina-blood-vessel",
+  "name": "retina blood vessel",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003501",
+  "synonym": [
+    "blood vessel of inner layer of eyeball",
+    "blood vessel of retina",
+    "blood vessel of tunica interna of eyeball",
+    "inner layer of eyeball blood vessel",
+    "retinal blood vessel",
+    "tunica interna of eyeball blood vessel"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tributaryOfCentralRetinalVein",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central retinal vein. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036300)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036300#tributary-of-central-retinal-vein",
+  "name": "tributary of central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036300",
+  "synonym": [
+    "central retinal venous tributary"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vasculatureOfBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vasculatureOfBrain.jsonld
@@ -16,3 +16,4 @@
     "intracerebral vasculature"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vasculatureOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "description": "A vasculature that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004864#vasculature-of-retina",
+  "name": "vasculature of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004864",
+  "synonym": [
+    "retina vasculature",
+    "retina vasculature of camera-type eye",
+    "retinal blood vessels",
+    "retinal blood vessels set",
+    "retinal vasculature",
+    "set of blood vessels of retina",
+    "set of retinal blood vessels",
+    "vasa sanguinea retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/venousSystemOfBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/venousSystemOfBrain.jsonld
@@ -14,3 +14,4 @@
     "brain venous system"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vessel.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vessel.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vessel",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'vessel' is an anatomical conduit.",
-  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph.",
+  "definition": "Is an anatomical conduit. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
+  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731576",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000055#vessel",
   "name": "vessel",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000055",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/bloodcerebrospinalFluidBarrier.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/bloodcerebrospinalFluidBarrier.jsonld
@@ -14,3 +14,4 @@
     "blood-CSF barrier"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/brainBloodVessel.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/brainBloodVessel.jsonld
@@ -14,3 +14,4 @@
     "blood vessel of brain"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralRetinalArtery.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetinalArtery",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a retina blood vessel. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "description": "The central retinal artery (retinal artery) branches off the ophthalmic artery, running inferior to the optic nerve within its dural sheath to the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001620#central-retinal-artery",
+  "name": "central retinal artery",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001620",
+  "synonym": [
+    "central artery of retina",
+    "retinal artery",
+    "Zinn's artery"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralRetinalVein.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetinalVein",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the cavernous sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "description": "The central retinal vein (retinal vein) is a short vein that runs through the optic nerve and drains blood from the capillaries of the retina into the larger veins outside the eye. The anatomy of the veins of the orbit of the eye varies between individuals, and in some the central retinal vein drains into the superior ophthalmic vein, and in some it drains directly into the cavernous sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001673)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001673#central-retinal-vein",
+  "name": "central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001673",
+  "synonym": [
+    "retinal vein"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cerebellumVasculature.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cerebellumVasculature.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006694",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cerebralBloodVessel.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cerebralBloodVessel.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016565",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/hindbrainVenousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/hindbrainVenousSystem.jsonld
@@ -12,3 +12,4 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005720",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/retinaBloodVessel.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinaBloodVessel",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vasculature of retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "description": "A blood vessel that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003501#retina-blood-vessel",
+  "name": "retina blood vessel",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003501",
+  "synonym": [
+    "blood vessel of inner layer of eyeball",
+    "blood vessel of retina",
+    "blood vessel of tunica interna of eyeball",
+    "inner layer of eyeball blood vessel",
+    "retinal blood vessel",
+    "tunica interna of eyeball blood vessel"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tributaryOfCentralRetinalVein.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tributaryOfCentralRetinalVein",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central retinal vein. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036300)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036300#tributary-of-central-retinal-vein",
+  "name": "tributary of central retinal vein",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036300",
+  "synonym": [
+    "central retinal venous tributary"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vasculatureOfBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vasculatureOfBrain.jsonld
@@ -16,3 +16,4 @@
     "intracerebral vasculature"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vasculatureOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vasculatureOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "description": "A vasculature that is part of a retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004864)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004864#vasculature-of-retina",
+  "name": "vasculature of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004864",
+  "synonym": [
+    "retina vasculature",
+    "retina vasculature of camera-type eye",
+    "retinal blood vessels",
+    "retinal blood vessels set",
+    "retinal vasculature",
+    "set of blood vessels of retina",
+    "set of retinal blood vessels",
+    "vasa sanguinea retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/venousSystemOfBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/venousSystemOfBrain.jsonld
@@ -14,3 +14,4 @@
     "brain venous system"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vessel.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vessel.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vessel",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'vessel' is an anatomical conduit.",
-  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph.",
+  "definition": "Is an anatomical conduit. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
+  "description": "A tubular structure that contains, conveys body fluid, such as blood or lymph. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000055)",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731576",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000055#vessel",
   "name": "vessel",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000055",
   "synonym": null
 }
+


### PR DESCRIPTION
Due to changes in my order of grouping terms, blood and eye related terms were added to this group. 

generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

**(still) Filtering:**
any term with "vein", "venous", "artery", "arterial", "vasculature", "blood", "barrier" or "vessel" in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.