### PR TITLE
Invertebrate related UBERON terms

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodNeurohemalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "description": "A system of neurons that has the specialized function to produce and secrete hormones, and that constitutes, in whole or in part, an endocrine organ or system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001053#arthropod-neurohemal-organ",
+  "name": "arthropod neurohemal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001053",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodOpticLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Arthropod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "A region of the adult brain that processes the visual information from the compound eyes.",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795) ('is_a' and 'relationship')]",
+  "description": "A region of the adult brain that processes the visual information from the compound eyes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0732637",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006795#arthropod-optic-lobe",
   "name": "arthropod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006795",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/arthropodSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/arthropodSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536) ('is_a' and 'relationship')]",
+  "description": "Sense organ embedded in the integument and consisting of one or a cluster of sensory neurons and associated sensory structures, support cells and glial cells forming a single organised unit with a largely bona-fide boundary. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002536#arthropod-sensillum",
+  "name": "arthropod sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002536",
+  "synonym": [
+    "sensillum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/headSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/headSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/headSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000963)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000963#head-sensillum",
+  "name": "head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000963",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain. Is part of the insect adult central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624) ('is_a' and 'relationship')]",
+  "description": "Brain of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003624#adult-brain",
+  "name": "insect adult brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003624",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCentralComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil block. Is part of the insect adult protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632) ('is_a' and 'relationship')]",
+  "description": "A midline crossing complex of 4 synaptic neuropil domains of the adult brain: the ellipsoid body, the fan-shaped body, the paired noduli, and the protocerebral bridge. It is closely associated with another paired synaptic neuropil domain, the lateral complex. It lies in the middle of the brain between the pedunculi of the mushroom bodies and is bounded ventrally by the esophagus, dorsally by the pars intercerebralis and laterally by the antenno-glomerular tracts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003632#adult-central-complex",
+  "name": "insect adult central complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003632",
+  "synonym": [
+    "adult central body complex",
+    "CX"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect adult nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003623#adult-central-nervous-system",
+  "name": "insect adult central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003623",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCerebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect supraesophageal ganglion. Is part of the insect adult brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the adult brain located above, around and partially below the esophagus, including the optic lobes. It excludes the gnathal ganglion. Developmentally, it comprises three fused neuromeres: protocerebrum, deutocerebrum, and tritocerebrum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6110636#adult-cerebral-ganglion",
+  "name": "insect adult cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6110636",
+  "synonym": [
+    "CRG"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003559)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003559#adult-nervous-system",
+  "name": "insect adult nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003559",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultProtocerebrum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect adult cerebral ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the adult brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007145#adult-protocerebrum",
+  "name": "insect adult protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007145",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectBolwigOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect internal sensillum and insect embryonic/larval head sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "description": "Visual organ of the larva. It consists of a dense cluster of 12 ciliated photoreceptor neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005805#bolwig-organ",
+  "name": "insect Bolwig organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005805",
+  "synonym": [
+    "Bolwig's organ",
+    "embryonic Bolwig's organ",
+    "embryonic visual system",
+    "larval Bolwig's organ"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil domain. Is part of the insect embryonic/larval protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070) ('is_a' and 'relationship')]",
+  "description": "A synaptic neuropil domain of the larval brain located posterior to the medial lobe of the mushroom body. It is separated from the centro-lateral compartment by the peduncle, and from the centro-posterior intermediate compartment by the antenno-cerebral tract to which it is connected via a branch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007070#centro-posterior-medial-synaptic-neuropil-domain",
+  "name": "insect centro-posterior medial synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007070",
+  "synonym": [
+    "centro-posterior medial neuropil",
+    "centro-posterior medial synaptic neuropil domain",
+    "larval central complex"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectChaeta.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectChaeta.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectChaeta",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect eo-type sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "description": "A sensillum with a long, unicellular, setiform outgrowth that is strongly chitinized. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005177#chaeta",
+  "name": "insect chaeta",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005177",
+  "synonym": [
+    "sensillum chaeticum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "description": "Brain of the embryo. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001060#insect-embryonic-brain",
+  "name": "insect embryonic brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001060",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain and ganglion of central nervous system. Is part of the insect embryonic/larval central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920) ('is_a' and 'relationship')]",
+  "description": "Brain of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001920#insect-embryonic-larval-brain",
+  "name": "insect embryonic/larval brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001920",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect embryonic/larval nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001919#embryonic-larval-central-nervous-system",
+  "name": "insect embryonic/larval central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001919",
+  "synonym": [
+    "larval central nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalHeadSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a head sensillum and insect embryonic/larval sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larval head (UBERON:6001730). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007242#embryonic-larval-head-sensillum",
+  "name": "insect embryonic/larval head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007242",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "description": "Nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001911#insect-embryonic-larval-nervous-system",
+  "name": "insect embryonic/larval nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001911",
+  "synonym": [
+    "larval nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalProtocerebrum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect embryonic/larval brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001925#embryonic-larval-protocerebrum",
+  "name": "insect embryonic/larval protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001925",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larva (UBERON:6001727). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007240#embryonic-larval-sensillum",
+  "name": "insect embryonic/larval sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007240",
+  "synonym": [
+    "larval sensillum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEoTypeSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect external sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "description": "Sensillum with innervated external cuticular sensory structure consisting of one or more bipolar sensory neurons, and 3 support cells: a trichogen cell which makes the external cuticular sensory structure, a thecogen cell which makes the socket that holds the base of the external sensory structure and a tormogen cell which makes the cuticular matrix (cap) at the tip of the innervating dendrite(s). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007232#eo-type-sensillum",
+  "name": "insect eo-type sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007232",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectExternalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "description": "Sensillum which is embedded in the body wall and has a specific cuticular structure involved in the transduction of some sensory signal as a part. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007231#external-sensillum",
+  "name": "insect external sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007231",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectInternalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "description": "Sensillum that is internal to the animal - i.e. having no part that is part of the cuticle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007233#internal-sensillum",
+  "name": "insect internal sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007233",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectProtocerebrum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Insect protocerebrum' is a segmental subdivision of nervous system. It is part of the insect supraesophageal ganglion.",
-  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies.",
+  "definition": "Is a segmental subdivision of nervous system. Is part of the insect supraesophageal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627) ('is_a' and 'relationship')]",
+  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726810",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003627#protocerebrum",
   "name": "insect protocerebrum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003627",
-  "synonym": null
+  "synonym": [
+    "protocerebral neuromere"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectStomatogastricNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "description": "A group of small, interconnected ganglia situated posterior to and between the two brain hemispheres and associated with the pharynx, esophagus and aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005096#stomatogastric-nervous-system",
+  "name": "insect stomatogastric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005096",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSupraesophagealGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Insect supraesophageal ganglion' is a ganglion of central nervous system. It is part of the brain.",
-  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head.",
+  "definition": "Is a ganglion of central nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735712",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003626#supraesophageal-ganglion",
   "name": "insect supraesophageal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003626",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropil",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "description": "The part of the neuropil consisting largely of synapsing neuron projections. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040005#synaptic-neuropil",
+  "name": "insect synaptic neuropil",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040005",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropilBlock",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the insect synaptic neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "description": "A closely associated group of synaptic neuropil domains. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6041000#synaptic-neuropil-block",
+  "name": "insect synaptic neuropil block",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6041000",
+  "synonym": [
+    "level 1 neuropil"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropilDomain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the insect synaptic neuropil. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007) ('is_a' and 'relationship')]",
+  "description": "Region of synaptic neuropil whose boundaries are largely discontinuities in the density of presynaptic terminals: high density in the synaptic neuropil domain, lower or zero density outside this region. These boundaries often correspond to a boundary with glial sheath, tract neuropil or cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040007#synaptic-neuropil-domain",
+  "name": "insect synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040007",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mushroomBody.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mushroomBody.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mushroomBody",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Mushroom body' is a material entity and anatomical entity. It is part of the brain.",
-  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory[MESH] Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes.",
+  "definition": "Is a material entity and anatomical entity. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058) ('is_a' and 'relationship')]",
+  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724282",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001058#mushroom-body",
   "name": "mushroom body",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001058",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/arthropodNeurohemalOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "description": "A system of neurons that has the specialized function to produce and secrete hormones, and that constitutes, in whole or in part, an endocrine organ or system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001053#arthropod-neurohemal-organ",
+  "name": "arthropod neurohemal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001053",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/arthropodOpticLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Arthropod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "A region of the adult brain that processes the visual information from the compound eyes.",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795) ('is_a' and 'relationship')]",
+  "description": "A region of the adult brain that processes the visual information from the compound eyes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0732637",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006795#arthropod-optic-lobe",
   "name": "arthropod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006795",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/arthropodSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/arthropodSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/arthropodSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536) ('is_a' and 'relationship')]",
+  "description": "Sense organ embedded in the integument and consisting of one or a cluster of sensory neurons and associated sensory structures, support cells and glial cells forming a single organised unit with a largely bona-fide boundary. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002536#arthropod-sensillum",
+  "name": "arthropod sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002536",
+  "synonym": [
+    "sensillum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/headSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/headSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/headSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000963)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000963#head-sensillum",
+  "name": "head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000963",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultBrain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain. Is part of the insect adult central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624) ('is_a' and 'relationship')]",
+  "description": "Brain of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003624#adult-brain",
+  "name": "insect adult brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003624",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultCentralComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil block. Is part of the insect adult protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632) ('is_a' and 'relationship')]",
+  "description": "A midline crossing complex of 4 synaptic neuropil domains of the adult brain: the ellipsoid body, the fan-shaped body, the paired noduli, and the protocerebral bridge. It is closely associated with another paired synaptic neuropil domain, the lateral complex. It lies in the middle of the brain between the pedunculi of the mushroom bodies and is bounded ventrally by the esophagus, dorsally by the pars intercerebralis and laterally by the antenno-glomerular tracts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003632#adult-central-complex",
+  "name": "insect adult central complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003632",
+  "synonym": [
+    "adult central body complex",
+    "CX"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect adult nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003623#adult-central-nervous-system",
+  "name": "insect adult central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003623",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultCerebralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect supraesophageal ganglion. Is part of the insect adult brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the adult brain located above, around and partially below the esophagus, including the optic lobes. It excludes the gnathal ganglion. Developmentally, it comprises three fused neuromeres: protocerebrum, deutocerebrum, and tritocerebrum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6110636#adult-cerebral-ganglion",
+  "name": "insect adult cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6110636",
+  "synonym": [
+    "CRG"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003559)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003559#adult-nervous-system",
+  "name": "insect adult nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003559",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectAdultProtocerebrum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect adult cerebral ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the adult brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007145#adult-protocerebrum",
+  "name": "insect adult protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007145",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectBolwigOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect internal sensillum and insect embryonic/larval head sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "description": "Visual organ of the larva. It consists of a dense cluster of 12 ciliated photoreceptor neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005805#bolwig-organ",
+  "name": "insect Bolwig organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005805",
+  "synonym": [
+    "Bolwig's organ",
+    "embryonic Bolwig's organ",
+    "embryonic visual system",
+    "larval Bolwig's organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil domain. Is part of the insect embryonic/larval protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070) ('is_a' and 'relationship')]",
+  "description": "A synaptic neuropil domain of the larval brain located posterior to the medial lobe of the mushroom body. It is separated from the centro-lateral compartment by the peduncle, and from the centro-posterior intermediate compartment by the antenno-cerebral tract to which it is connected via a branch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007070#centro-posterior-medial-synaptic-neuropil-domain",
+  "name": "insect centro-posterior medial synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007070",
+  "synonym": [
+    "centro-posterior medial neuropil",
+    "centro-posterior medial synaptic neuropil domain",
+    "larval central complex"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectChaeta.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectChaeta.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectChaeta",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect eo-type sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "description": "A sensillum with a long, unicellular, setiform outgrowth that is strongly chitinized. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005177#chaeta",
+  "name": "insect chaeta",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005177",
+  "synonym": [
+    "sensillum chaeticum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicBrain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "description": "Brain of the embryo. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001060#insect-embryonic-brain",
+  "name": "insect embryonic brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001060",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalBrain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain and ganglion of central nervous system. Is part of the insect embryonic/larval central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920) ('is_a' and 'relationship')]",
+  "description": "Brain of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001920#insect-embryonic-larval-brain",
+  "name": "insect embryonic/larval brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001920",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect embryonic/larval nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001919#embryonic-larval-central-nervous-system",
+  "name": "insect embryonic/larval central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001919",
+  "synonym": [
+    "larval central nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalHeadSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a head sensillum and insect embryonic/larval sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larval head (UBERON:6001730). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007242#embryonic-larval-head-sensillum",
+  "name": "insect embryonic/larval head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007242",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "description": "Nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001911#insect-embryonic-larval-nervous-system",
+  "name": "insect embryonic/larval nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001911",
+  "synonym": [
+    "larval nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalProtocerebrum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect embryonic/larval brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001925#embryonic-larval-protocerebrum",
+  "name": "insect embryonic/larval protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001925",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEmbryonicLarvalSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larva (UBERON:6001727). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007240#embryonic-larval-sensillum",
+  "name": "insect embryonic/larval sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007240",
+  "synonym": [
+    "larval sensillum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectEoTypeSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an insect external sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "description": "Sensillum with innervated external cuticular sensory structure consisting of one or more bipolar sensory neurons, and 3 support cells: a trichogen cell which makes the external cuticular sensory structure, a thecogen cell which makes the socket that holds the base of the external sensory structure and a tormogen cell which makes the cuticular matrix (cap) at the tip of the innervating dendrite(s). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007232#eo-type-sensillum",
+  "name": "insect eo-type sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007232",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectExternalSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "description": "Sensillum which is embedded in the body wall and has a specific cuticular structure involved in the transduction of some sensory signal as a part. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007231#external-sensillum",
+  "name": "insect external sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007231",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectInternalSensillum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "description": "Sensillum that is internal to the animal - i.e. having no part that is part of the cuticle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007233#internal-sensillum",
+  "name": "insect internal sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007233",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectProtocerebrum",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Insect protocerebrum' is a segmental subdivision of nervous system. It is part of the insect supraesophageal ganglion.",
-  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies.",
+  "definition": "Is a segmental subdivision of nervous system. Is part of the insect supraesophageal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627) ('is_a' and 'relationship')]",
+  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726810",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003627#protocerebrum",
   "name": "insect protocerebrum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003627",
-  "synonym": null
+  "synonym": [
+    "protocerebral neuromere"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectStomatogastricNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "description": "A group of small, interconnected ganglia situated posterior to and between the two brain hemispheres and associated with the pharynx, esophagus and aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005096#stomatogastric-nervous-system",
+  "name": "insect stomatogastric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005096",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectSupraesophagealGanglion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Insect supraesophageal ganglion' is a ganglion of central nervous system. It is part of the brain.",
-  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head.",
+  "definition": "Is a ganglion of central nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735712",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003626#supraesophageal-ganglion",
   "name": "insect supraesophageal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003626",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectSynapticNeuropil",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "description": "The part of the neuropil consisting largely of synapsing neuron projections. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040005#synaptic-neuropil",
+  "name": "insect synaptic neuropil",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040005",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectSynapticNeuropilBlock",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the insect synaptic neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "description": "A closely associated group of synaptic neuropil domains. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6041000#synaptic-neuropil-block",
+  "name": "insect synaptic neuropil block",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6041000",
+  "synonym": [
+    "level 1 neuropil"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insectSynapticNeuropilDomain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the insect synaptic neuropil. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007) ('is_a' and 'relationship')]",
+  "description": "Region of synaptic neuropil whose boundaries are largely discontinuities in the density of presynaptic terminals: high density in the synaptic neuropil domain, lower or zero density outside this region. These boundaries often correspond to a boundary with glial sheath, tract neuropil or cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040007#synaptic-neuropil-domain",
+  "name": "insect synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040007",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mushroomBody.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mushroomBody.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mushroomBody",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Mushroom body' is a material entity and anatomical entity. It is part of the brain.",
-  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory[MESH] Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes.",
+  "definition": "Is a material entity and anatomical entity. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058) ('is_a' and 'relationship')]",
+  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724282",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001058#mushroom-body",
   "name": "mushroom body",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001058",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/arthropodNeurohemalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodNeurohemalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "description": "A system of neurons that has the specialized function to produce and secrete hormones, and that constitutes, in whole or in part, an endocrine organ or system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001053#arthropod-neurohemal-organ",
+  "name": "arthropod neurohemal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001053",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/arthropodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodOpticLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Arthropod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "A region of the adult brain that processes the visual information from the compound eyes.",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795) ('is_a' and 'relationship')]",
+  "description": "A region of the adult brain that processes the visual information from the compound eyes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006795)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0732637",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006795#arthropod-optic-lobe",
   "name": "arthropod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006795",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/arthropodSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/arthropodSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arthropodSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536) ('is_a' and 'relationship')]",
+  "description": "Sense organ embedded in the integument and consisting of one or a cluster of sensory neurons and associated sensory structures, support cells and glial cells forming a single organised unit with a largely bona-fide boundary. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002536#arthropod-sensillum",
+  "name": "arthropod sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002536",
+  "synonym": [
+    "sensillum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/headSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/headSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/headSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000963)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000963#head-sensillum",
+  "name": "head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000963",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain. Is part of the insect adult central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624) ('is_a' and 'relationship')]",
+  "description": "Brain of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003624)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003624#adult-brain",
+  "name": "insect adult brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003624",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultCentralComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCentralComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil block. Is part of the insect adult protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632) ('is_a' and 'relationship')]",
+  "description": "A midline crossing complex of 4 synaptic neuropil domains of the adult brain: the ellipsoid body, the fan-shaped body, the paired noduli, and the protocerebral bridge. It is closely associated with another paired synaptic neuropil domain, the lateral complex. It lies in the middle of the brain between the pedunculi of the mushroom bodies and is bounded ventrally by the esophagus, dorsally by the pars intercerebralis and laterally by the antenno-glomerular tracts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003632)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003632#adult-central-complex",
+  "name": "insect adult central complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003632",
+  "synonym": [
+    "adult central body complex",
+    "CX"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultCentralNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect adult nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the adult. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003623#adult-central-nervous-system",
+  "name": "insect adult central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003623",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultCerebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect supraesophageal ganglion. Is part of the insect adult brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the adult brain located above, around and partially below the esophagus, including the optic lobes. It excludes the gnathal ganglion. Developmentally, it comprises three fused neuromeres: protocerebrum, deutocerebrum, and tritocerebrum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6110636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6110636#adult-cerebral-ganglion",
+  "name": "insect adult cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6110636",
+  "synonym": [
+    "CRG"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003559)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003559#adult-nervous-system",
+  "name": "insect adult nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003559",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectAdultProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectAdultProtocerebrum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect adult cerebral ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the adult brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007145#adult-protocerebrum",
+  "name": "insect adult protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007145",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectBolwigOrgan.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectBolwigOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect internal sensillum and insect embryonic/larval head sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "description": "Visual organ of the larva. It consists of a dense cluster of 12 ciliated photoreceptor neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005805#bolwig-organ",
+  "name": "insect Bolwig organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005805",
+  "synonym": [
+    "Bolwig's organ",
+    "embryonic Bolwig's organ",
+    "embryonic visual system",
+    "larval Bolwig's organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectCentroPosteriorMedialSynapticNeuropilDomain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect synaptic neuropil domain. Is part of the insect embryonic/larval protocerebrum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070) ('is_a' and 'relationship')]",
+  "description": "A synaptic neuropil domain of the larval brain located posterior to the medial lobe of the mushroom body. It is separated from the centro-lateral compartment by the peduncle, and from the centro-posterior intermediate compartment by the antenno-cerebral tract to which it is connected via a branch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007070)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007070#centro-posterior-medial-synaptic-neuropil-domain",
+  "name": "insect centro-posterior medial synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007070",
+  "synonym": [
+    "centro-posterior medial neuropil",
+    "centro-posterior medial synaptic neuropil domain",
+    "larval central complex"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectChaeta.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectChaeta.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectChaeta",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect eo-type sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "description": "A sensillum with a long, unicellular, setiform outgrowth that is strongly chitinized. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005177)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005177#chaeta",
+  "name": "insect chaeta",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005177",
+  "synonym": [
+    "sensillum chaeticum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "description": "Brain of the embryo. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001060)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001060#insect-embryonic-brain",
+  "name": "insect embryonic brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001060",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain and ganglion of central nervous system. Is part of the insect embryonic/larval central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920) ('is_a' and 'relationship')]",
+  "description": "Brain of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001920)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001920#insect-embryonic-larval-brain",
+  "name": "insect embryonic/larval brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001920",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system. Is part of the insect embryonic/larval nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919) ('is_a' and 'relationship')]",
+  "description": "Central nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001919)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001919#embryonic-larval-central-nervous-system",
+  "name": "insect embryonic/larval central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001919",
+  "synonym": [
+    "larval central nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalHeadSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalHeadSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a head sensillum and insect embryonic/larval sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larval head (UBERON:6001730). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007242)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007242#embryonic-larval-head-sensillum",
+  "name": "insect embryonic/larval head sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007242",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "description": "Nervous system of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001911)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001911#insect-embryonic-larval-nervous-system",
+  "name": "insect embryonic/larval nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001911",
+  "synonym": [
+    "larval nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalProtocerebrum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalProtocerebrum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect protocerebrum. Is part of the insect embryonic/larval brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925) ('is_a' and 'relationship')]",
+  "description": "Protocerebrum of the embryo/larva. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6001925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6001925#embryonic-larval-protocerebrum",
+  "name": "insect embryonic/larval protocerebrum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6001925",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEmbryonicLarvalSensillum.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEmbryonicLarvalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "description": "Any sensillum (UBERON:6007152) that is part of some larva (UBERON:6001727). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007240#embryonic-larval-sensillum",
+  "name": "insect embryonic/larval sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007240",
+  "synonym": [
+    "larval sensillum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectEoTypeSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectEoTypeSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an insect external sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "description": "Sensillum with innervated external cuticular sensory structure consisting of one or more bipolar sensory neurons, and 3 support cells: a trichogen cell which makes the external cuticular sensory structure, a thecogen cell which makes the socket that holds the base of the external sensory structure and a tormogen cell which makes the cuticular matrix (cap) at the tip of the innervating dendrite(s). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007232)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007232#eo-type-sensillum",
+  "name": "insect eo-type sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007232",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectExternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectExternalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "description": "Sensillum which is embedded in the body wall and has a specific cuticular structure involved in the transduction of some sensory signal as a part. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007231)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007231#external-sensillum",
+  "name": "insect external sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007231",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectInternalSensillum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectInternalSensillum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arthropod sensillum. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "description": "Sensillum that is internal to the animal - i.e. having no part that is part of the cuticle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6007233)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6007233#internal-sensillum",
+  "name": "insect internal sensillum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6007233",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectProtocerebrum.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectProtocerebrum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Insect protocerebrum' is a segmental subdivision of nervous system. It is part of the insect supraesophageal ganglion.",
-  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies.",
+  "definition": "Is a segmental subdivision of nervous system. Is part of the insect supraesophageal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627) ('is_a' and 'relationship')]",
+  "description": "The most anterior of the segmental subdivisions of the insect CNS; thought to represent the first pre-oral segment of the brain. The protocerebrum comprises many discrete neuropil regions including the central body complex and mushroom bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003627)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726810",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003627#protocerebrum",
   "name": "insect protocerebrum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003627",
-  "synonym": null
+  "synonym": [
+    "protocerebral neuromere"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectStomatogastricNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectStomatogastricNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "description": "A group of small, interconnected ganglia situated posterior to and between the two brain hemispheres and associated with the pharynx, esophagus and aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6005096)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6005096#stomatogastric-nervous-system",
+  "name": "insect stomatogastric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6005096",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectSupraesophagealGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSupraesophagealGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Insect supraesophageal ganglion' is a ganglion of central nervous system. It is part of the brain.",
-  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head.",
+  "definition": "Is a ganglion of central nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626) ('is_a' and 'relationship')]",
+  "description": "The pre-oral neuropils of the brain located above and some of it below the esophagus, comprising three fused ganglia (protocerebrum, deutocerebrum, and tritocerebrum) in the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6003626)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735712",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6003626#supraesophageal-ganglion",
   "name": "insect supraesophageal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6003626",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropil.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropil",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "description": "The part of the neuropil consisting largely of synapsing neuron projections. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040005#synaptic-neuropil",
+  "name": "insect synaptic neuropil",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040005",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropilBlock.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropilBlock",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the insect synaptic neuropil. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "description": "A closely associated group of synaptic neuropil domains. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6041000)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6041000#synaptic-neuropil-block",
+  "name": "insect synaptic neuropil block",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6041000",
+  "synonym": [
+    "level 1 neuropil"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/insectSynapticNeuropilDomain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insectSynapticNeuropilDomain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the insect synaptic neuropil. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007) ('is_a' and 'relationship')]",
+  "description": "Region of synaptic neuropil whose boundaries are largely discontinuities in the density of presynaptic terminals: high density in the synaptic neuropil domain, lower or zero density outside this region. These boundaries often correspond to a boundary with glial sheath, tract neuropil or cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_6040007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:6040007#synaptic-neuropil-domain",
+  "name": "insect synaptic neuropil domain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_6040007",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mushroomBody.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mushroomBody.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mushroomBody",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Mushroom body' is a material entity and anatomical entity. It is part of the brain.",
-  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory[MESH] Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes.",
+  "definition": "Is a material entity and anatomical entity. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058) ('is_a' and 'relationship')]",
+  "description": "Prominent lobed neuropils found in annelids and all arthropods except crustaceans. They are thought to be involved in olfactory associative learning and memory Mushroom body neuropils are divided into calyces, pedunculus, and its subsequent lobes. In Drosophila these are the alpha, beta, and gamma lobes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001058)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724282",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001058#mushroom-body",
   "name": "mushroom body",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001058",
   "synonym": null
 }
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'insect', 'sensillum', 'arthropod' and 'mushroom' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.