### PR TITLE
UBERON terms with 'receptor' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arterialBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "description": "Arterial baroreceptors are stretch receptors that are stimulated by distortion of the arterial wall when pressure changes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018392#arterial-baroreceptor",
+  "name": "arterial baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018392",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/baroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/baroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/baroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "description": "The sensory nerve endings in the wall of the atria of the heart, vena cava, aortic arch and carotid sinus that are sensitive to changes in blood pressure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004019#baroreceptor",
+  "name": "baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004019",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cardiacBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "description": "A baroreceptor that located in a heart. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018395#cardiac-baroreceptor",
+  "name": "cardiac baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018395",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/chemoreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/chemoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/chemoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "description": "A sensory receptor that detects chemical stimulus within the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018391#chemoreceptor",
+  "name": "chemoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018391",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/encapsulatedTactileReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "description": "A tacile mechanoreceptor that lacks a capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035969#encapsulated-tactile-receptor",
+  "name": "encapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035969",
+  "synonym": [
+    "encapsulated nerve ending"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/interoceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/interoceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/interoceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "description": "A sensory receptor that detects stimulus within the body. Examples of stimuli that would be detected by interoceptors include blood pressure and blood oxygen level. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018389#interoceptor",
+  "name": "interoceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018389",
+  "synonym": [
+    "enteroceptor",
+    "visceroceptor"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lowPressureBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "description": "Found in large systemic veins, in pulmonary vessels, and in the walls of the right atrium and ventricles of the heart (the atrial volume receptors). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018393#low-pressure-baroreceptor",
+  "name": "low-pressure baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018393",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mechanoreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mechanoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mechanoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "description": "A sensory receptor that responds to mechanical pressure or distortion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012449#mechanoreceptor",
+  "name": "mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012449",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nociceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nociceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nociceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "description": "Peripheral receptors for pain. Nociceptors include receptors which are sensitive to painful mechanical stimuli, extreme heat or cold, and chemical stimuli. All nociceptors are free nerve endings. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035017#nociceptor",
+  "name": "nociceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035017",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/photoreceptorArray.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/photoreceptorArray.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorArray",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388) ('is_a' and 'relationship')]",
+  "description": "An array of photoreceptors and any supporting cells found in an eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005388#photoreceptor-array",
+  "name": "photoreceptor array",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005388",
+  "synonym": [
+    "light-sensitive tissue"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorInnerSegmentLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina composed of the inner segments of the photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003925#photoreceptor-inner-segment-layer",
+  "name": "photoreceptor inner segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003925",
+  "synonym": [
+    "retina photoreceptor layer inner segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell receptor segments reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001787#photoreceptor-layer-of-retina",
+  "name": "photoreceptor layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001787",
+  "synonym": [
+    "retina photoreceptor layer",
+    "retinal photoreceptor layer",
+    "stratum segmentorum externorum et internorum (retina)",
+    "stratum segmentorum externorum et internorum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorOuterSegmentLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003926) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003926#photoreceptor-outer-segment-layer",
+  "name": "photoreceptor outer segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003926",
+  "synonym": [
+    "retina photoreceptor layer outer segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pulmonaryBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "description": "A baroreceptor that located in a pulmonary vascular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018396#pulmonary-baroreceptor",
+  "name": "pulmonary baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018396",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryReceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "description": "A sensory nerve ending that responds to a stimulus in the internal or external environment of an organism. In response to stimuli the sensory receptor initiates sensory transduction by creating graded potentials or action potentials in the same cell or in an adjacent one. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012451#sensory-receptor",
+  "name": "sensory receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012451",
+  "synonym": [
+    "peripheral ending of sensory neuron"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tactileMechanoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035016)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035016#tactile-mechanoreceptor",
+  "name": "tactile mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035016",
+  "synonym": [
+    "contact receptor"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thermoreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thermoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thermoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "description": "Cellular receptors which mediate the sense of temperature. Thermoreceptors in vertebrates are mostly located under the skin. In mammals there are separate types of thermoreceptors for cold and for warmth and NOCICEPTORS which detect cold or heat extreme enough to cause pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035018#thermoreceptor",
+  "name": "thermoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035018",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/unencapsulatedTactileReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "description": "Free nerve endings are widely distributed throughout the body, and are found as branches of unmyelinated, or lightly myelinated fibres grouped in bundles beneath the epithelium. As they penetrate the epithelium, they lose their myelin, and branch among the epithelial cells. Branches of one nerve may cover a wide area and overlap the territories of other nerves. The free nerve endings detect pain, touch, pressure and temperature, and are associated with C fibres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035501#unencapsulated-tactile-receptor",
+  "name": "unencapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035501",
+  "synonym": [
+    "free nerve ending",
+    "unencapsulated nerve ending"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/veinBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "description": "A baroreceptor that located in a vein. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018394#vein-baroreceptor",
+  "name": "vein baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018394",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/arterialBaroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "description": "Arterial baroreceptors are stretch receptors that are stimulated by distortion of the arterial wall when pressure changes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018392#arterial-baroreceptor",
+  "name": "arterial baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018392",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/baroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/baroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/baroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "description": "The sensory nerve endings in the wall of the atria of the heart, vena cava, aortic arch and carotid sinus that are sensitive to changes in blood pressure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004019#baroreceptor",
+  "name": "baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004019",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cardiacBaroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "description": "A baroreceptor that located in a heart. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018395#cardiac-baroreceptor",
+  "name": "cardiac baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018395",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/chemoreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/chemoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/chemoreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "description": "A sensory receptor that detects chemical stimulus within the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018391#chemoreceptor",
+  "name": "chemoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018391",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/encapsulatedTactileReceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "description": "A tacile mechanoreceptor that lacks a capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035969#encapsulated-tactile-receptor",
+  "name": "encapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035969",
+  "synonym": [
+    "encapsulated nerve ending"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/interoceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/interoceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/interoceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "description": "A sensory receptor that detects stimulus within the body. Examples of stimuli that would be detected by interoceptors include blood pressure and blood oxygen level. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018389#interoceptor",
+  "name": "interoceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018389",
+  "synonym": [
+    "enteroceptor",
+    "visceroceptor"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lowPressureBaroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "description": "Found in large systemic veins, in pulmonary vessels, and in the walls of the right atrium and ventricles of the heart (the atrial volume receptors). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018393#low-pressure-baroreceptor",
+  "name": "low-pressure baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018393",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mechanoreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mechanoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mechanoreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "description": "A sensory receptor that responds to mechanical pressure or distortion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012449#mechanoreceptor",
+  "name": "mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012449",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nociceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nociceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nociceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "description": "Peripheral receptors for pain. Nociceptors include receptors which are sensitive to painful mechanical stimuli, extreme heat or cold, and chemical stimuli. All nociceptors are free nerve endings. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035017#nociceptor",
+  "name": "nociceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035017",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/photoreceptorArray.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/photoreceptorArray.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/photoreceptorArray",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388) ('is_a' and 'relationship')]",
+  "description": "An array of photoreceptors and any supporting cells found in an eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005388#photoreceptor-array",
+  "name": "photoreceptor array",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005388",
+  "synonym": [
+    "light-sensitive tissue"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/photoreceptorInnerSegmentLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina composed of the inner segments of the photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003925#photoreceptor-inner-segment-layer",
+  "name": "photoreceptor inner segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003925",
+  "synonym": [
+    "retina photoreceptor layer inner segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/photoreceptorLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell receptor segments reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001787#photoreceptor-layer-of-retina",
+  "name": "photoreceptor layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001787",
+  "synonym": [
+    "retina photoreceptor layer",
+    "retinal photoreceptor layer",
+    "stratum segmentorum externorum et internorum (retina)",
+    "stratum segmentorum externorum et internorum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/photoreceptorOuterSegmentLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003926) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003926#photoreceptor-outer-segment-layer",
+  "name": "photoreceptor outer segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003926",
+  "synonym": [
+    "retina photoreceptor layer outer segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pulmonaryBaroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "description": "A baroreceptor that located in a pulmonary vascular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018396#pulmonary-baroreceptor",
+  "name": "pulmonary baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018396",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryReceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryReceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "description": "A sensory nerve ending that responds to a stimulus in the internal or external environment of an organism. In response to stimuli the sensory receptor initiates sensory transduction by creating graded potentials or action potentials in the same cell or in an adjacent one. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012451#sensory-receptor",
+  "name": "sensory receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012451",
+  "synonym": [
+    "peripheral ending of sensory neuron"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tactileMechanoreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035016)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035016#tactile-mechanoreceptor",
+  "name": "tactile mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035016",
+  "synonym": [
+    "contact receptor"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thermoreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thermoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thermoreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "description": "Cellular receptors which mediate the sense of temperature. Thermoreceptors in vertebrates are mostly located under the skin. In mammals there are separate types of thermoreceptors for cold and for warmth and NOCICEPTORS which detect cold or heat extreme enough to cause pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035018#thermoreceptor",
+  "name": "thermoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035018",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/unencapsulatedTactileReceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "description": "Free nerve endings are widely distributed throughout the body, and are found as branches of unmyelinated, or lightly myelinated fibres grouped in bundles beneath the epithelium. As they penetrate the epithelium, they lose their myelin, and branch among the epithelial cells. Branches of one nerve may cover a wide area and overlap the territories of other nerves. The free nerve endings detect pain, touch, pressure and temperature, and are associated with C fibres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035501#unencapsulated-tactile-receptor",
+  "name": "unencapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035501",
+  "synonym": [
+    "free nerve ending",
+    "unencapsulated nerve ending"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/veinBaroreceptor",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "description": "A baroreceptor that located in a vein. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018394#vein-baroreceptor",
+  "name": "vein baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018394",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/arterialBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/arterialBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "description": "Arterial baroreceptors are stretch receptors that are stimulated by distortion of the arterial wall when pressure changes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018392)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018392#arterial-baroreceptor",
+  "name": "arterial baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018392",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/baroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/baroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/baroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "description": "The sensory nerve endings in the wall of the atria of the heart, vena cava, aortic arch and carotid sinus that are sensitive to changes in blood pressure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004019#baroreceptor",
+  "name": "baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004019",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cardiacBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cardiacBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "description": "A baroreceptor that located in a heart. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018395#cardiac-baroreceptor",
+  "name": "cardiac baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018395",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/chemoreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/chemoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/chemoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an interoceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "description": "A sensory receptor that detects chemical stimulus within the body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018391#chemoreceptor",
+  "name": "chemoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018391",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/encapsulatedTactileReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/encapsulatedTactileReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "description": "A tacile mechanoreceptor that lacks a capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035969)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035969#encapsulated-tactile-receptor",
+  "name": "encapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035969",
+  "synonym": [
+    "encapsulated nerve ending"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/interoceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/interoceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/interoceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "description": "A sensory receptor that detects stimulus within the body. Examples of stimuli that would be detected by interoceptors include blood pressure and blood oxygen level. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018389)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018389#interoceptor",
+  "name": "interoceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018389",
+  "synonym": [
+    "enteroceptor",
+    "visceroceptor"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lowPressureBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lowPressureBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "description": "Found in large systemic veins, in pulmonary vessels, and in the walls of the right atrium and ventricles of the heart (the atrial volume receptors). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018393)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018393#low-pressure-baroreceptor",
+  "name": "low-pressure baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018393",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mechanoreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mechanoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mechanoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "description": "A sensory receptor that responds to mechanical pressure or distortion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012449)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012449#mechanoreceptor",
+  "name": "mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012449",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nociceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nociceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nociceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "description": "Peripheral receptors for pain. Nociceptors include receptors which are sensitive to painful mechanical stimuli, extreme heat or cold, and chemical stimuli. All nociceptors are free nerve endings. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035017#nociceptor",
+  "name": "nociceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035017",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/photoreceptorArray.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/photoreceptorArray.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorArray",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388) ('is_a' and 'relationship')]",
+  "description": "An array of photoreceptors and any supporting cells found in an eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005388)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005388#photoreceptor-array",
+  "name": "photoreceptor array",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005388",
+  "synonym": [
+    "light-sensitive tissue"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/photoreceptorInnerSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorInnerSegmentLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina composed of the inner segments of the photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003925#photoreceptor-inner-segment-layer",
+  "name": "photoreceptor inner segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003925",
+  "synonym": [
+    "retina photoreceptor layer inner segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/photoreceptorLayerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell receptor segments reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001787)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001787#photoreceptor-layer-of-retina",
+  "name": "photoreceptor layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001787",
+  "synonym": [
+    "retina photoreceptor layer",
+    "retinal photoreceptor layer",
+    "stratum segmentorum externorum et internorum (retina)",
+    "stratum segmentorum externorum et internorum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/photoreceptorOuterSegmentLayer.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/photoreceptorOuterSegmentLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the photoreceptor layer of retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003926) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003926#photoreceptor-outer-segment-layer",
+  "name": "photoreceptor outer segment layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003926",
+  "synonym": [
+    "retina photoreceptor layer outer segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pulmonaryBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pulmonaryBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "description": "A baroreceptor that located in a pulmonary vascular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018396)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018396#pulmonary-baroreceptor",
+  "name": "pulmonary baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018396",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryReceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryReceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "description": "A sensory nerve ending that responds to a stimulus in the internal or external environment of an organism. In response to stimuli the sensory receptor initiates sensory transduction by creating graded potentials or action potentials in the same cell or in an adjacent one. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012451#sensory-receptor",
+  "name": "sensory receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012451",
+  "synonym": [
+    "peripheral ending of sensory neuron"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tactileMechanoreceptor.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tactileMechanoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035016)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035016#tactile-mechanoreceptor",
+  "name": "tactile mechanoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035016",
+  "synonym": [
+    "contact receptor"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thermoreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thermoreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thermoreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory receptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "description": "Cellular receptors which mediate the sense of temperature. Thermoreceptors in vertebrates are mostly located under the skin. In mammals there are separate types of thermoreceptors for cold and for warmth and NOCICEPTORS which detect cold or heat extreme enough to cause pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035018#thermoreceptor",
+  "name": "thermoreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035018",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/unencapsulatedTactileReceptor.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/unencapsulatedTactileReceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tactile mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "description": "Free nerve endings are widely distributed throughout the body, and are found as branches of unmyelinated, or lightly myelinated fibres grouped in bundles beneath the epithelium. As they penetrate the epithelium, they lose their myelin, and branch among the epithelial cells. Branches of one nerve may cover a wide area and overlap the territories of other nerves. The free nerve endings detect pain, touch, pressure and temperature, and are associated with C fibres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035501#unencapsulated-tactile-receptor",
+  "name": "unencapsulated tactile receptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035501",
+  "synonym": [
+    "free nerve ending",
+    "unencapsulated nerve ending"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/veinBaroreceptor.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/veinBaroreceptor",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a low-pressure baroreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "description": "A baroreceptor that located in a vein. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018394)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018394#vein-baroreceptor",
+  "name": "vein baroreceptor",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018394",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'receptor' or just 'ceptor' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.