### PR TITLE
UBERON terms with 'future' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureBrainVesicle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013150) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013150#future-brain-vesicle",
+  "name": "future brain vesicle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013150",
+  "synonym": [
+    "early brain vesicle",
+    "primitive brain vesicle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureFacialNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "description": "A gray matter that has the potential to develop into a facial nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010123#future-facial-nucleus",
+  "name": "future facial nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010123",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureHindbrainMeninx",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future hindbrain meninx' is a future meninx. It is part of the hindbrain.",
-  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain.",
+  "definition": "Is a future meninx. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091) ('is_a' and 'relationship')]",
+  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736728",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010091#future-hindbrain-meninx",
   "name": "future hindbrain meninx",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010091",
-  "synonym": null
+  "synonym": [
+    "future hindbrain meninges"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureInferiorSalivatoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "description": "A gray matter that has the potential to develop into a inferior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010124#future-inferior-salivatory-nucleus",
+  "name": "future inferior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010124",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureMeninx.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureMeninx.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMeninx",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the meningeal cluster. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "description": "A developing mesenchymal capsule that covers the developing brain and spinal cord and is the precursor of the meningeal cluster. In mammals this gives rise to the arachnoid mater, pia mater and dura mater. In cyclostomes and fishes, the future meninx gives rise to a single meningeal layer, the primitive meninx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007645#future-meninx",
+  "name": "future meninx",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007645",
+  "synonym": [
+    "primary meninx"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureMetencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureMetencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMetencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future metencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a metencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
+  "description": "A developing anatomical structure that has the potential to develop into a metencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735157",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010092#future-metencephalon",
   "name": "future metencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010092",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMyelencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future myelencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
+  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727209",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010096#future-myelencephalon",
   "name": "future myelencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010096",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureNeurohypophysis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "description": "The outgrowth of neuroectoderm located on the floor of the embryonic hypothalamus that gives rise to the neurohypophysis (posterior lobe) of the pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034876#future-neurohypophysis",
+  "name": "future neurohypophysis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034876",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureNucleusAmbiguus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "description": "A gray matter that has the potential to develop into a nucleus ambiguus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010126#future-nucleus-ambiguus",
+  "name": "future nucleus ambiguus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010126",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -17,7 +17,6 @@
     "future palatine ganglion",
     "future pterygopalatine ganglia",
     "future sphenopalatine ganglion",
-    "future sphenopalatine parasympathetic ganglion",
     "future sphenopalatine parasympathetic ganglion"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futurePterygopalatineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "description": "A ganglion that has the potential to develop into a pterygopalatine ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010128#future-pterygopalatine-ganglion",
+  "name": "future pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010128",
+  "synonym": [
+    "future Meckel ganglion",
+    "future Meckel's ganglion",
+    "future nasal ganglion",
+    "future palatine ganglion",
+    "future pterygopalatine ganglia",
+    "future sphenopalatine ganglion",
+    "future sphenopalatine parasympathetic ganglion",
+    "future sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006241#future-spinal-cord",
+  "name": "future spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006241",
+  "synonym": [
+    "presumptive spinal cord",
+    "presumptive spinal cord neural keel",
+    "presumptive spinal cord neural plate",
+    "presumptive spinal cord neural rod"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureSuperiorSalivatoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "description": "A gray matter that has the potential to develop into a superior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010125#future-superior-salivatory-nucleus",
+  "name": "future superior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010125",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureBrainVesicle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013150) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013150#future-brain-vesicle",
+  "name": "future brain vesicle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013150",
+  "synonym": [
+    "early brain vesicle",
+    "primitive brain vesicle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureFacialNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "description": "A gray matter that has the potential to develop into a facial nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010123#future-facial-nucleus",
+  "name": "future facial nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010123",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureHindbrainMeninx",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Future hindbrain meninx' is a future meninx. It is part of the hindbrain.",
-  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain.",
+  "definition": "Is a future meninx. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091) ('is_a' and 'relationship')]",
+  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736728",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010091#future-hindbrain-meninx",
   "name": "future hindbrain meninx",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010091",
-  "synonym": null
+  "synonym": [
+    "future hindbrain meninges"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureInferiorSalivatoryNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "description": "A gray matter that has the potential to develop into a inferior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010124#future-inferior-salivatory-nucleus",
+  "name": "future inferior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010124",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureMeninx.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureMeninx.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureMeninx",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the meningeal cluster. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "description": "A developing mesenchymal capsule that covers the developing brain and spinal cord and is the precursor of the meningeal cluster. In mammals this gives rise to the arachnoid mater, pia mater and dura mater. In cyclostomes and fishes, the future meninx gives rise to a single meningeal layer, the primitive meninx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007645#future-meninx",
+  "name": "future meninx",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007645",
+  "synonym": [
+    "primary meninx"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureMetencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureMetencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureMetencephalon",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Future metencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a metencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
+  "description": "A developing anatomical structure that has the potential to develop into a metencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735157",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010092#future-metencephalon",
   "name": "future metencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010092",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureMyelencephalon",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Future myelencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
+  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727209",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010096#future-myelencephalon",
   "name": "future myelencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010096",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureNeurohypophysis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "description": "The outgrowth of neuroectoderm located on the floor of the embryonic hypothalamus that gives rise to the neurohypophysis (posterior lobe) of the pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034876#future-neurohypophysis",
+  "name": "future neurohypophysis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034876",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureNucleusAmbiguus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "description": "A gray matter that has the potential to develop into a nucleus ambiguus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010126#future-nucleus-ambiguus",
+  "name": "future nucleus ambiguus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010126",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futurePterygopalatineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "description": "A ganglion that has the potential to develop into a pterygopalatine ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010128#future-pterygopalatine-ganglion",
+  "name": "future pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010128",
+  "synonym": [
+    "future Meckel ganglion",
+    "future Meckel's ganglion",
+    "future nasal ganglion",
+    "future palatine ganglion",
+    "future pterygopalatine ganglia",
+    "future sphenopalatine ganglion",
+    "future sphenopalatine parasympathetic ganglion",
+    "future sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -17,7 +17,6 @@
     "future palatine ganglion",
     "future pterygopalatine ganglia",
     "future sphenopalatine ganglion",
-    "future sphenopalatine parasympathetic ganglion",
     "future sphenopalatine parasympathetic ganglion"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/futureSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006241#future-spinal-cord",
+  "name": "future spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006241",
+  "synonym": [
+    "presumptive spinal cord",
+    "presumptive spinal cord neural keel",
+    "presumptive spinal cord neural plate",
+    "presumptive spinal cord neural rod"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/futureSuperiorSalivatoryNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "description": "A gray matter that has the potential to develop into a superior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010125#future-superior-salivatory-nucleus",
+  "name": "future superior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010125",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureBrainVesicle.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureBrainVesicle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013150) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013150#future-brain-vesicle",
+  "name": "future brain vesicle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013150",
+  "synonym": [
+    "early brain vesicle",
+    "primitive brain vesicle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureFacialNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureFacialNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "description": "A gray matter that has the potential to develop into a facial nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010123)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010123#future-facial-nucleus",
+  "name": "future facial nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010123",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureHindbrainMeninx.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureHindbrainMeninx",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future hindbrain meninx' is a future meninx. It is part of the hindbrain.",
-  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain.",
+  "definition": "Is a future meninx. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091) ('is_a' and 'relationship')]",
+  "description": "A multi-tissue structure that has the potential to develop into a meninx of hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736728",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010091#future-hindbrain-meninx",
   "name": "future hindbrain meninx",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010091",
-  "synonym": null
+  "synonym": [
+    "future hindbrain meninges"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureInferiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureInferiorSalivatoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "description": "A gray matter that has the potential to develop into a inferior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010124)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010124#future-inferior-salivatory-nucleus",
+  "name": "future inferior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010124",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureMeninx.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureMeninx.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMeninx",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the meningeal cluster. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "description": "A developing mesenchymal capsule that covers the developing brain and spinal cord and is the precursor of the meningeal cluster. In mammals this gives rise to the arachnoid mater, pia mater and dura mater. In cyclostomes and fishes, the future meninx gives rise to a single meningeal layer, the primitive meninx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007645#future-meninx",
+  "name": "future meninx",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007645",
+  "synonym": [
+    "primary meninx"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureMetencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureMetencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMetencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future metencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a metencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
+  "description": "A developing anatomical structure that has the potential to develop into a metencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010092)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735157",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010092#future-metencephalon",
   "name": "future metencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010092",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureMyelencephalon.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureMyelencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Future myelencephalon' is part of the hindbrain.",
-  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon.",
+  "definition": "Is part of the hindbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
+  "description": "A developing anatomical structure that has the potential to develop into a myelencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010096)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727209",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010096#future-myelencephalon",
   "name": "future myelencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010096",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureNeurohypophysis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureNeurohypophysis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "description": "The outgrowth of neuroectoderm located on the floor of the embryonic hypothalamus that gives rise to the neurohypophysis (posterior lobe) of the pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034876)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034876#future-neurohypophysis",
+  "name": "future neurohypophysis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034876",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureNucleusAmbiguus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureNucleusAmbiguus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "description": "A gray matter that has the potential to develop into a nucleus ambiguus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010126#future-nucleus-ambiguus",
+  "name": "future nucleus ambiguus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010126",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -17,7 +17,6 @@
     "future palatine ganglion",
     "future pterygopalatine ganglia",
     "future sphenopalatine ganglion",
-    "future sphenopalatine parasympathetic ganglion",
     "future sphenopalatine parasympathetic ganglion"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futurePterygopalatineGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futurePterygopalatineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "description": "A ganglion that has the potential to develop into a pterygopalatine ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010128)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010128#future-pterygopalatine-ganglion",
+  "name": "future pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010128",
+  "synonym": [
+    "future Meckel ganglion",
+    "future Meckel's ganglion",
+    "future nasal ganglion",
+    "future palatine ganglion",
+    "future pterygopalatine ganglia",
+    "future sphenopalatine ganglion",
+    "future sphenopalatine parasympathetic ganglion",
+    "future sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006241#future-spinal-cord",
+  "name": "future spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006241",
+  "synonym": [
+    "presumptive spinal cord",
+    "presumptive spinal cord neural keel",
+    "presumptive spinal cord neural plate",
+    "presumptive spinal cord neural rod"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/futureSuperiorSalivatoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/futureSuperiorSalivatoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "description": "A gray matter that has the potential to develop into a superior salivatory nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010125)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010125#future-superior-salivatory-nucleus",
+  "name": "future superior salivatory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010125",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'future' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.