### PR TITLE
UBERON terms with 'taste bud' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/barbelTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/barbelTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/barbelTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "description": "A taste bud that is located on a barbel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034718#barbel-taste-bud",
+  "name": "barbel taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034718",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/esophagealTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "description": "A taste bud that is located in the esophagus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034724#esophageal-taste-bud",
+  "name": "esophageal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034724",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/finTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/finTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/finTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "description": "A taste bud that is located on a fin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034723#fin-taste-bud",
+  "name": "fin taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034723",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/headTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/headTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/headTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "description": "A taste bud that is located on the skin of the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034720#head-taste-bud",
+  "name": "head taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034720",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/integumentalTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "description": "A taste bud that is located external to the digestive tube, on the head or body, as found in species such as goldfish. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034717#integumental-taste-bud",
+  "name": "integumental taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034717",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lipTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lipTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lipTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "description": "A taste bud that is located on a lip. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034719#lip-taste-bud",
+  "name": "lip taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034719",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mouthRoofTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "description": "A taste bud that is located on the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034722#mouth-roof-taste-bud",
+  "name": "mouth roof taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034722",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/palatalTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/palatalTasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palatalTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mouth roof taste bud. Is part of the gustatory epithelium of palate. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670) ('is_a' and 'relationship')]",
+  "description": "A taste bud that is located on the soft palate, in the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034670#palatal-taste-bud",
+  "name": "palatal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034670",
+  "synonym": [
+    "taste bud of palate"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "description": "A taste bud that is located in the pharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034721#pharyngeal-taste-bud",
+  "name": "pharyngeal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034721",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gustatory organ. Is part of the gustatory epithelium. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727) ('is_a' and 'relationship')]",
+  "description": "A specialized receptor organ that is a collection of cells spanning the gustatory epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001727#taste-bud-1",
+  "name": "taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001727",
+  "synonym": [
+    "tastebud"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tongueTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tongueTasteBud.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tongueTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "description": "A taste bud that is located on the tongue, situated on a gustatory papilla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014451#tongue-taste-bud",
+  "name": "tongue taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014451",
+  "synonym": [
+    "gustatory papilla taste bud",
+    "gustatory papillae taste bud"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkTasteBud.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "description": "A taste bud that is located on the skin of the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034726#trunk-taste-bud",
+  "name": "trunk taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034726",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/barbelTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/barbelTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/barbelTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "description": "A taste bud that is located on a barbel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034718#barbel-taste-bud",
+  "name": "barbel taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034718",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/esophagealTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "description": "A taste bud that is located in the esophagus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034724#esophageal-taste-bud",
+  "name": "esophageal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034724",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/finTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/finTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/finTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "description": "A taste bud that is located on a fin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034723#fin-taste-bud",
+  "name": "fin taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034723",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/headTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/headTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/headTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "description": "A taste bud that is located on the skin of the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034720#head-taste-bud",
+  "name": "head taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034720",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/integumentalTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "description": "A taste bud that is located external to the digestive tube, on the head or body, as found in species such as goldfish. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034717#integumental-taste-bud",
+  "name": "integumental taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034717",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lipTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lipTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lipTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "description": "A taste bud that is located on a lip. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034719#lip-taste-bud",
+  "name": "lip taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034719",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mouthRoofTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "description": "A taste bud that is located on the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034722#mouth-roof-taste-bud",
+  "name": "mouth roof taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034722",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/palatalTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/palatalTasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/palatalTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mouth roof taste bud. Is part of the gustatory epithelium of palate. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670) ('is_a' and 'relationship')]",
+  "description": "A taste bud that is located on the soft palate, in the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034670#palatal-taste-bud",
+  "name": "palatal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034670",
+  "synonym": [
+    "taste bud of palate"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pharyngealTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "description": "A taste bud that is located in the pharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034721#pharyngeal-taste-bud",
+  "name": "pharyngeal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034721",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gustatory organ. Is part of the gustatory epithelium. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727) ('is_a' and 'relationship')]",
+  "description": "A specialized receptor organ that is a collection of cells spanning the gustatory epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001727#taste-bud-1",
+  "name": "taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001727",
+  "synonym": [
+    "tastebud"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tongueTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tongueTasteBud.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tongueTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "description": "A taste bud that is located on the tongue, situated on a gustatory papilla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014451#tongue-taste-bud",
+  "name": "tongue taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014451",
+  "synonym": [
+    "gustatory papilla taste bud",
+    "gustatory papillae taste bud"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkTasteBud.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkTasteBud",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "description": "A taste bud that is located on the skin of the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034726#trunk-taste-bud",
+  "name": "trunk taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034726",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/barbelTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/barbelTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/barbelTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "description": "A taste bud that is located on a barbel. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034718#barbel-taste-bud",
+  "name": "barbel taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034718",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/esophagealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/esophagealTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "description": "A taste bud that is located in the esophagus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034724#esophageal-taste-bud",
+  "name": "esophageal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034724",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/finTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/finTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/finTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "description": "A taste bud that is located on a fin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034723#fin-taste-bud",
+  "name": "fin taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034723",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/headTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/headTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/headTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "description": "A taste bud that is located on the skin of the head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034720#head-taste-bud",
+  "name": "head taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034720",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/integumentalTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/integumentalTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "description": "A taste bud that is located external to the digestive tube, on the head or body, as found in species such as goldfish. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034717#integumental-taste-bud",
+  "name": "integumental taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034717",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lipTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lipTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lipTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "description": "A taste bud that is located on a lip. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034719#lip-taste-bud",
+  "name": "lip taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034719",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mouthRoofTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mouthRoofTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "description": "A taste bud that is located on the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034722#mouth-roof-taste-bud",
+  "name": "mouth roof taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034722",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/palatalTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/palatalTasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palatalTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mouth roof taste bud. Is part of the gustatory epithelium of palate. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670) ('is_a' and 'relationship')]",
+  "description": "A taste bud that is located on the soft palate, in the roof of the mouth. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034670)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034670#palatal-taste-bud",
+  "name": "palatal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034670",
+  "synonym": [
+    "taste bud of palate"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pharyngealTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "description": "A taste bud that is located in the pharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034721)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034721#pharyngeal-taste-bud",
+  "name": "pharyngeal taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034721",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tasteBud.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gustatory organ. Is part of the gustatory epithelium. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727) ('is_a' and 'relationship')]",
+  "description": "A specialized receptor organ that is a collection of cells spanning the gustatory epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001727)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001727#taste-bud-1",
+  "name": "taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001727",
+  "synonym": [
+    "tastebud"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tongueTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tongueTasteBud.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tongueTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "description": "A taste bud that is located on the tongue, situated on a gustatory papilla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014451)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014451#tongue-taste-bud",
+  "name": "tongue taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014451",
+  "synonym": [
+    "gustatory papilla taste bud",
+    "gustatory papillae taste bud"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkTasteBud.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkTasteBud.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkTasteBud",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an integumental taste bud. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "description": "A taste bud that is located on the skin of the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034726#trunk-taste-bud",
+  "name": "trunk taste bud",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034726",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'taste bud' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.