### PR TITLE
UBERON terms with 'system' in name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/autonomicNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410) ('is_a' and 'relationship')]",
+  "description": "The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002410#autonomic-nervous-system",
+  "name": "autonomic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002410",
+  "synonym": [
+    "autonomic division of peripheral nervous system",
+    "autonomic part of peripheral nervous system",
+    "divisio autonomica systematis nervosi peripherici",
+    "pars autonomica systematis nervosi peripherici",
+    "peripheral autonomic nervous system",
+    "visceral nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "description": "The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001017#central-nervous-system-1",
+  "name": "central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001017",
+  "synonym": [
+    "CNS",
+    "systema nervosum centrale"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemCellPartCluster",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215) ('is_a' and 'relationship')]",
+  "description": "A multi cell part structure that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011215#central-nervous-system-cell-part-cluster",
+  "name": "central nervous system cell part cluster",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011215",
+  "synonym": [
+    "cell part cluster of neuraxis",
+    "neuraxis layer"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemGrayMatterLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "description": "A layer of of the central nervous system that is part of gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016548#central-nervous-system-gray-matter-layer",
+  "name": "central nervous system gray matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016548",
+  "synonym": [
+    "CNS gray matter layer",
+    "CNS grey matter layer",
+    "gray matter layer of neuraxis",
+    "grey matter layer of neuraxis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemWhiteMatterLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "description": "A layer of of the central nervous system that is composed of white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016549#central-nervous-system-white-matter-layer",
+  "name": "central nervous system white matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016549",
+  "synonym": [
+    "CNS white matter layer",
+    "white matter layer of neuraxis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
-  "synonym": [
-    "circuit part of central nervous system",
-    "circuit part of central nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -5,7 +5,7 @@
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
   "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
-  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous system regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
   "interlexIdentifier": null,
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",

--- a/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
+  "name": "circuit part of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
+  "synonym": [
+    "circuit part of central nervous system",
+    "circuit part of central nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/entericNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/entericNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/entericNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "description": "The enteric nervous system is composed of two ganglionated neural plexuses in the gut wall which form one of the three major divisions of the autonomic nervous system. The enteric nervous system innervates the gastrointestinal tract, the pancreas, and the gall bladder. It contains sensory neurons, interneurons, and motor neurons. Thus the circuitry can autonomously sense the tension and the chemical environment in the gut and regulate blood vessel tone, motility, secretions, and fluid transport. The system is itself governed by the central nervous system and receives both parasympathetic and sympathetic innervation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002005#enteric-nervous-system-1",
+  "name": "enteric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002005",
+  "synonym": [
+    "enteric PNS",
+    "PNS - enteric"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/extrapyramidalTractSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the motor system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803) ('is_a' and 'relationship')]",
+  "description": "A neural network located in the brain that is part of the motor system involved in the coordination of movement that is distinct from the pyramidal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035803#extrapyramidal-tract-system",
+  "name": "extrapyramidal tract system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035803",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339) ('is_a' and 'relationship')]",
+  "description": "A ganglion that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003339#ganglion-of-central-nervous-system",
+  "name": "ganglion of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003339",
+  "synonym": [
+    "central nervous system ganglion",
+    "ganglion of neuraxis",
+    "neuraxis ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionOfPeripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "ganglion of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003338",
+  "synonym": [
+    "peripheral nervous system ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionPartOfPeripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
+  "name": "ganglion part of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
+  "synonym": [
+    "ganglion part of peripheral nervous system",
+    "ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
   "name": "ganglion part of peripheral nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
-  "synonym": [
-    "ganglion part of peripheral nervous system",
-    "ganglion part of peripheral nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/glymphaticSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glymphaticSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glymphaticSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145) ('is_a' and 'relationship')]",
+  "description": "Macroscopic waste clearance system that utilizes a unique system of perivascular tunnels, formed by astroglial cells, to promote efficient elimination of soluble proteins and metabolites from the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036145#glymphatic-system",
+  "name": "glymphatic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036145",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/limbicSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/limbicSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limbicSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the forebrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "description": "A set of midline structures surrounding the brainstem of the mammalian brain, originally described anatomically, e.g., hippocampal formation, amygdala, hypothalamus, cingulate cortex. Although the original designation was anatomical, the limbic system has come to be associated with the system in the brain subserving emotional functions. As such, it is very poorly defined and doesn't correspond closely to the anatomical meaning any longer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000349#limbic-system",
+  "name": "limbic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000349",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumenOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561) ('is_a' and 'relationship')]",
+  "description": "The cavity that is enclosed by the central nervous system. In vertebrates this is the cavity that includes as parts ventricular cavities and the central canal of the spinal cord that develops from the lumen of the neura tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002561#neuraxis-cavity",
+  "name": "lumen of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002561",
+  "synonym": [
+    "cavity of neuraxis",
+    "cavity of ventricular system of neuraxis",
+    "neuraxis cavity",
+    "neuraxis lumen"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/motorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "description": "The part of the central nervous system that is involved with movement. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
+  "name": "motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
+  "synonym": [
+    "motor system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
   "name": "motor system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
-  "synonym": [
-    "motor system"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/nervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "description": "The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organism, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001016#nervous-system-1",
+  "name": "nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001016",
+  "synonym": [
+    "neurological system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemCellPartLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303) ('is_a' and 'relationship')]",
+  "description": "Single layer of a laminar structure, identified by different density, arrangement or size of cells and processes arranged in flattened layers or lamina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022303#nervous-system-cell-part-layer",
+  "name": "nervous system cell part layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022303",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "description": "Axon tract that crosses the midline of the central nervous system. In the context of Drosophila refers to a broad band of axons connecting equivalent neuropils each side of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001020#nervous-system-commissure",
+  "name": "nervous system commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001020",
+  "synonym": [
+    "commissure of neuraxis",
+    "neuraxis commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemLemniscus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001) ('is_a' and 'relationship')]",
+  "description": "A bundle or band of sensory nerve fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003001#lemniscus",
+  "name": "nervous system lemniscus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003001",
+  "synonym": [
+    "lemniscus",
+    "neuraxis lemniscus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
   "name": "neural system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
-  "synonym": [
-    "neural system"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879) ('is_a' and 'relationship')]",
+  "description": "A set of neural structures that subserve a specific function, e.g., visual system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
+  "name": "neural system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
+  "synonym": [
+    "neural system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "description": "The parasympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system. Parasympathetic nerves emerge cranially as pre ganglionic fibers from oculomotor, facial, glossopharyngeal and vagus and from the sacral region of the spinal cord. Most neurons are cholinergic and responses are mediated by muscarinic receptors. The parasympathetic system innervates, for example: salivary glands, thoracic and abdominal viscera, bladder and genitalia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000011#parasympathetic-nervous-system-1",
+  "name": "parasympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000011",
+  "synonym": [
+    "parasympathetic part of autonomic division of nervous system",
+    "pars parasympathica divisionis autonomici systematis nervosi",
+    "PNS - parasympathetic"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -13,7 +13,6 @@
   "synonym": [
     "central nervous system parenchyma",
     "CNS parenchyma",
-    "parenchyma of central nervous system",
     "parenchyma of CNS"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parenchymaOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "description": "The functional tissue of the central nervous system consisting of neurons and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005158#parenchyma-of-central-nervous-system",
+  "name": "parenchyma of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005158",
+  "synonym": [
+    "central nervous system parenchyma",
+    "CNS parenchyma",
+    "parenchyma of central nervous system",
+    "parenchyma of CNS"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/peripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010) ('is_a' and 'relationship')]",
+  "description": "A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000010#peripheral-nervous-system-1",
+  "name": "peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000010",
+  "synonym": [
+    "pars peripherica",
+    "systema nervosum periphericum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/proprioceptiveSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "description": "The sensory system for the sense of proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
+  "name": "proprioceptive system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
+  "synonym": [
+    "proprioceptive system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
   "name": "proprioceptive system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
-  "synonym": [
-    "proprioceptive system"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/segmentalSubdivisionOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732) ('is_a' and 'relationship')]",
+  "description": "Any segmental subdivision of a nervous system. Includes metameric developmental segments, such as vertebrates neuromeres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004732#segmental-subdivision-of-nervous-system",
+  "name": "segmental subdivision of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004732",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensorimotorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025534)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025534#sensorimotor-system",
+  "name": "sensorimotor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025534",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticMotorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945) ('is_a' and 'relationship')]",
+  "description": "The neural tissue involved in the transmission of motor signals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003945#somatic-motor-system",
+  "name": "somatic motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003945",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012) ('is_a' and 'relationship')]",
+  "description": "Part of peripheral nervous system that includes the somatic parts of the cranial and spinal nerves and their ganglia and the peripheral sensory receptors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000012#somatic-nervous-system",
+  "name": "somatic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000012",
+  "synonym": [
+    "PNS - somatic",
+    "somatic nervous system, somatic division",
+    "somatic part of peripheral nervous system",
+    "somatic peripheral nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticSensorySystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the somatic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "description": "The sensory system for the sense of touch and pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003942#somatosensory-system",
+  "name": "somatic sensory system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
+  "synonym": [
+    "somatic sensory system",
+    "somatosensory system",
+    "system for detection of somatic senses"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -11,7 +11,6 @@
   "name": "somatic sensory system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
   "synonym": [
-    "somatic sensory system",
     "somatosensory system",
     "system for detection of somatic senses"
   ]

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
   "synonym": [
     "pars sympathica divisionis autonomici systematis nervosi",
-    "sympathetic nervous system",
     "sympathetic part of autonomic division of nervous system"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013) ('is_a' and 'relationship')]",
+  "description": "The sympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system (the other being the parasympathetic nervous system). The sympathetic preganglionic neurons have their cell bodies in the thoracic and lumbar regions of the spinal cord and connect to the paravertebral chain of sympathetic ganglia. Innervate heart and blood vessels, sweat glands, viscera and the adrenal medulla. Most sympathetic neurons, but not all, use noradrenaline as a post-ganglionic neurotransmitter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000013#sympathetic-nervous-system-1",
+  "name": "sympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
+  "synonym": [
+    "pars sympathica divisionis autonomici systematis nervosi",
+    "sympathetic nervous system",
+    "sympathetic part of autonomic division of nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricleOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358) ('is_a' and 'relationship')]",
+  "description": "A layer in the central nervous system that lines system of communicating cavities in the brain and spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005358#ventricle-of-nervous-system",
+  "name": "ventricle of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005358",
+  "synonym": [
+    "ventricular layer"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemChoroidalFissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricle of nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192) ('is_a' and 'relationship')]",
+  "description": "The narrow cleft along the medial wall of the lateral ventricle along the margins of which the choroid plexus is attached; it lies between the upper surface of the thalamus and lateral edge of the fornix in the central part of the ventricle and between the terminal stria and fimbria hippocampi in the inferior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002192#ventricular-system-choroidal-fissure",
+  "name": "ventricular system choroidal fissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002192",
+  "synonym": [
+    "choroidal fissure of lateral ventricle",
+    "lateral ventricle choroid fissure",
+    "ventricular system choroid fissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemOfBrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Ventricular system of brain' is an anatomical system. It is part of the brain and ventricular system of central nervous system.",
+  "definition": "Is an anatomical system. Is part of the brain and the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005282) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731568",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005282#ventricular-system-of-brain",
   "name": "ventricular system of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005282",
-  "synonym": null
+  "synonym": [
+    "brain ventricular system"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281) ('is_a' and 'relationship')]",
+  "description": "A set of structures containing cerebrospinal fluid in the brain. It is continuous with the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005281#ventricular-system-of-central-nervous-system",
+  "name": "ventricular system of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005281",
+  "synonym": [
+    "CNS ventricular system",
+    "ventricular system",
+    "ventricular system of neuraxis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/visualProcessingPartOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006794) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006794#visual-processing-part-of-nervous-system",
+  "name": "visual processing part of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006794",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfVentricularSystemOfBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036661) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of ventricular system of brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036661",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/autonomicNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410) ('is_a' and 'relationship')]",
+  "description": "The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002410#autonomic-nervous-system",
+  "name": "autonomic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002410",
+  "synonym": [
+    "autonomic division of peripheral nervous system",
+    "autonomic part of peripheral nervous system",
+    "divisio autonomica systematis nervosi peripherici",
+    "pars autonomica systematis nervosi peripherici",
+    "peripheral autonomic nervous system",
+    "visceral nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "description": "The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001017#central-nervous-system-1",
+  "name": "central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001017",
+  "synonym": [
+    "CNS",
+    "systema nervosum centrale"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralNervousSystemCellPartCluster",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215) ('is_a' and 'relationship')]",
+  "description": "A multi cell part structure that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011215#central-nervous-system-cell-part-cluster",
+  "name": "central nervous system cell part cluster",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011215",
+  "synonym": [
+    "cell part cluster of neuraxis",
+    "neuraxis layer"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralNervousSystemGrayMatterLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "description": "A layer of of the central nervous system that is part of gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016548#central-nervous-system-gray-matter-layer",
+  "name": "central nervous system gray matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016548",
+  "synonym": [
+    "CNS gray matter layer",
+    "CNS grey matter layer",
+    "gray matter layer of neuraxis",
+    "grey matter layer of neuraxis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralNervousSystemWhiteMatterLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "description": "A layer of of the central nervous system that is composed of white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016549#central-nervous-system-white-matter-layer",
+  "name": "central nervous system white matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016549",
+  "synonym": [
+    "CNS white matter layer",
+    "white matter layer of neuraxis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -5,7 +5,7 @@
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
   "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
-  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous system regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
   "interlexIdentifier": null,
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",

--- a/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
-  "synonym": [
-    "circuit part of central nervous system",
-    "circuit part of central nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
+  "name": "circuit part of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
+  "synonym": [
+    "circuit part of central nervous system",
+    "circuit part of central nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/entericNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/entericNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/entericNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "description": "The enteric nervous system is composed of two ganglionated neural plexuses in the gut wall which form one of the three major divisions of the autonomic nervous system. The enteric nervous system innervates the gastrointestinal tract, the pancreas, and the gall bladder. It contains sensory neurons, interneurons, and motor neurons. Thus the circuitry can autonomously sense the tension and the chemical environment in the gut and regulate blood vessel tone, motility, secretions, and fluid transport. The system is itself governed by the central nervous system and receives both parasympathetic and sympathetic innervation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002005#enteric-nervous-system-1",
+  "name": "enteric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002005",
+  "synonym": [
+    "enteric PNS",
+    "PNS - enteric"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/extrapyramidalTractSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the motor system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803) ('is_a' and 'relationship')]",
+  "description": "A neural network located in the brain that is part of the motor system involved in the coordination of movement that is distinct from the pyramidal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035803#extrapyramidal-tract-system",
+  "name": "extrapyramidal tract system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035803",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglionOfCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339) ('is_a' and 'relationship')]",
+  "description": "A ganglion that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003339#ganglion-of-central-nervous-system",
+  "name": "ganglion of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003339",
+  "synonym": [
+    "central nervous system ganglion",
+    "ganglion of neuraxis",
+    "neuraxis ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglionOfPeripheralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "ganglion of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003338",
+  "synonym": [
+    "peripheral nervous system ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglionPartOfPeripheralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
+  "name": "ganglion part of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
+  "synonym": [
+    "ganglion part of peripheral nervous system",
+    "ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
   "name": "ganglion part of peripheral nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
-  "synonym": [
-    "ganglion part of peripheral nervous system",
-    "ganglion part of peripheral nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/glymphaticSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glymphaticSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glymphaticSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145) ('is_a' and 'relationship')]",
+  "description": "Macroscopic waste clearance system that utilizes a unique system of perivascular tunnels, formed by astroglial cells, to promote efficient elimination of soluble proteins and metabolites from the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036145#glymphatic-system",
+  "name": "glymphatic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036145",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/limbicSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/limbicSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/limbicSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the forebrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "description": "A set of midline structures surrounding the brainstem of the mammalian brain, originally described anatomically, e.g., hippocampal formation, amygdala, hypothalamus, cingulate cortex. Although the original designation was anatomical, the limbic system has come to be associated with the system in the brain subserving emotional functions. As such, it is very poorly defined and doesn't correspond closely to the anatomical meaning any longer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000349#limbic-system",
+  "name": "limbic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000349",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumenOfCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561) ('is_a' and 'relationship')]",
+  "description": "The cavity that is enclosed by the central nervous system. In vertebrates this is the cavity that includes as parts ventricular cavities and the central canal of the spinal cord that develops from the lumen of the neura tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002561#neuraxis-cavity",
+  "name": "lumen of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002561",
+  "synonym": [
+    "cavity of neuraxis",
+    "cavity of ventricular system of neuraxis",
+    "neuraxis cavity",
+    "neuraxis lumen"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
   "name": "motor system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
-  "synonym": [
-    "motor system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/motorSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "description": "The part of the central nervous system that is involved with movement. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
+  "name": "motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
+  "synonym": [
+    "motor system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "description": "The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organism, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001016#nervous-system-1",
+  "name": "nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001016",
+  "synonym": [
+    "neurological system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nervousSystemCellPartLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303) ('is_a' and 'relationship')]",
+  "description": "Single layer of a laminar structure, identified by different density, arrangement or size of cells and processes arranged in flattened layers or lamina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022303#nervous-system-cell-part-layer",
+  "name": "nervous system cell part layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022303",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nervousSystemCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "description": "Axon tract that crosses the midline of the central nervous system. In the context of Drosophila refers to a broad band of axons connecting equivalent neuropils each side of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001020#nervous-system-commissure",
+  "name": "nervous system commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001020",
+  "synonym": [
+    "commissure of neuraxis",
+    "neuraxis commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nervousSystemLemniscus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001) ('is_a' and 'relationship')]",
+  "description": "A bundle or band of sensory nerve fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003001#lemniscus",
+  "name": "nervous system lemniscus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003001",
+  "synonym": [
+    "lemniscus",
+    "neuraxis lemniscus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/neuralSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879) ('is_a' and 'relationship')]",
+  "description": "A set of neural structures that subserve a specific function, e.g., visual system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
+  "name": "neural system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
+  "synonym": [
+    "neural system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
   "name": "neural system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
-  "synonym": [
-    "neural system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parasympatheticNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "description": "The parasympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system. Parasympathetic nerves emerge cranially as pre ganglionic fibers from oculomotor, facial, glossopharyngeal and vagus and from the sacral region of the spinal cord. Most neurons are cholinergic and responses are mediated by muscarinic receptors. The parasympathetic system innervates, for example: salivary glands, thoracic and abdominal viscera, bladder and genitalia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000011#parasympathetic-nervous-system-1",
+  "name": "parasympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000011",
+  "synonym": [
+    "parasympathetic part of autonomic division of nervous system",
+    "pars parasympathica divisionis autonomici systematis nervosi",
+    "PNS - parasympathetic"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parenchymaOfCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "description": "The functional tissue of the central nervous system consisting of neurons and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005158#parenchyma-of-central-nervous-system",
+  "name": "parenchyma of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005158",
+  "synonym": [
+    "central nervous system parenchyma",
+    "CNS parenchyma",
+    "parenchyma of central nervous system",
+    "parenchyma of CNS"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -13,7 +13,6 @@
   "synonym": [
     "central nervous system parenchyma",
     "CNS parenchyma",
-    "parenchyma of central nervous system",
     "parenchyma of CNS"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/peripheralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010) ('is_a' and 'relationship')]",
+  "description": "A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000010#peripheral-nervous-system-1",
+  "name": "peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000010",
+  "synonym": [
+    "pars peripherica",
+    "systema nervosum periphericum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/proprioceptiveSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "description": "The sensory system for the sense of proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
+  "name": "proprioceptive system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
+  "synonym": [
+    "proprioceptive system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
   "name": "proprioceptive system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
-  "synonym": [
-    "proprioceptive system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/segmentalSubdivisionOfNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732) ('is_a' and 'relationship')]",
+  "description": "Any segmental subdivision of a nervous system. Includes metameric developmental segments, such as vertebrates neuromeres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004732#segmental-subdivision-of-nervous-system",
+  "name": "segmental subdivision of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004732",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensorimotorSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025534)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025534#sensorimotor-system",
+  "name": "sensorimotor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025534",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/somaticMotorSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945) ('is_a' and 'relationship')]",
+  "description": "The neural tissue involved in the transmission of motor signals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003945#somatic-motor-system",
+  "name": "somatic motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003945",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/somaticNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012) ('is_a' and 'relationship')]",
+  "description": "Part of peripheral nervous system that includes the somatic parts of the cranial and spinal nerves and their ganglia and the peripheral sensory receptors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000012#somatic-nervous-system",
+  "name": "somatic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000012",
+  "synonym": [
+    "PNS - somatic",
+    "somatic nervous system, somatic division",
+    "somatic part of peripheral nervous system",
+    "somatic peripheral nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/somaticSensorySystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the somatic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "description": "The sensory system for the sense of touch and pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003942#somatosensory-system",
+  "name": "somatic sensory system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
+  "synonym": [
+    "somatic sensory system",
+    "somatosensory system",
+    "system for detection of somatic senses"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -11,7 +11,6 @@
   "name": "somatic sensory system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
   "synonym": [
-    "somatic sensory system",
     "somatosensory system",
     "system for detection of somatic senses"
   ]

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sympatheticNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013) ('is_a' and 'relationship')]",
+  "description": "The sympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system (the other being the parasympathetic nervous system). The sympathetic preganglionic neurons have their cell bodies in the thoracic and lumbar regions of the spinal cord and connect to the paravertebral chain of sympathetic ganglia. Innervate heart and blood vessels, sweat glands, viscera and the adrenal medulla. Most sympathetic neurons, but not all, use noradrenaline as a post-ganglionic neurotransmitter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000013#sympathetic-nervous-system-1",
+  "name": "sympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
+  "synonym": [
+    "pars sympathica divisionis autonomici systematis nervosi",
+    "sympathetic nervous system",
+    "sympathetic part of autonomic division of nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
   "synonym": [
     "pars sympathica divisionis autonomici systematis nervosi",
-    "sympathetic nervous system",
     "sympathetic part of autonomic division of nervous system"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventricleOfNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358) ('is_a' and 'relationship')]",
+  "description": "A layer in the central nervous system that lines system of communicating cavities in the brain and spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005358#ventricle-of-nervous-system",
+  "name": "ventricle of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005358",
+  "synonym": [
+    "ventricular layer"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventricularSystemChoroidalFissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricle of nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192) ('is_a' and 'relationship')]",
+  "description": "The narrow cleft along the medial wall of the lateral ventricle along the margins of which the choroid plexus is attached; it lies between the upper surface of the thalamus and lateral edge of the fornix in the central part of the ventricle and between the terminal stria and fimbria hippocampi in the inferior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002192#ventricular-system-choroidal-fissure",
+  "name": "ventricular system choroidal fissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002192",
+  "synonym": [
+    "choroidal fissure of lateral ventricle",
+    "lateral ventricle choroid fissure",
+    "ventricular system choroid fissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventricularSystemOfBrain",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Ventricular system of brain' is an anatomical system. It is part of the brain and ventricular system of central nervous system.",
+  "definition": "Is an anatomical system. Is part of the brain and the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005282) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731568",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005282#ventricular-system-of-brain",
   "name": "ventricular system of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005282",
-  "synonym": null
+  "synonym": [
+    "brain ventricular system"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventricularSystemOfCentralNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281) ('is_a' and 'relationship')]",
+  "description": "A set of structures containing cerebrospinal fluid in the brain. It is continuous with the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005281#ventricular-system-of-central-nervous-system",
+  "name": "ventricular system of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005281",
+  "synonym": [
+    "CNS ventricular system",
+    "ventricular system",
+    "ventricular system of neuraxis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/visualProcessingPartOfNervousSystem",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006794) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006794#visual-processing-part-of-nervous-system",
+  "name": "visual processing part of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006794",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfVentricularSystemOfBrain",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036661) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of ventricular system of brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036661",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/autonomicNervousSystem.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/autonomicNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410) ('is_a' and 'relationship')]",
+  "description": "The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002410)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002410#autonomic-nervous-system",
+  "name": "autonomic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002410",
+  "synonym": [
+    "autonomic division of peripheral nervous system",
+    "autonomic part of peripheral nervous system",
+    "divisio autonomica systematis nervosi peripherici",
+    "pars autonomica systematis nervosi peripherici",
+    "peripheral autonomic nervous system",
+    "visceral nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "description": "The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001017)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001017#central-nervous-system-1",
+  "name": "central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001017",
+  "synonym": [
+    "CNS",
+    "systema nervosum centrale"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemCellPartCluster.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemCellPartCluster",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215) ('is_a' and 'relationship')]",
+  "description": "A multi cell part structure that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011215)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011215#central-nervous-system-cell-part-cluster",
+  "name": "central nervous system cell part cluster",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011215",
+  "synonym": [
+    "cell part cluster of neuraxis",
+    "neuraxis layer"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemGrayMatterLayer.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemGrayMatterLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "description": "A layer of of the central nervous system that is part of gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016548)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016548#central-nervous-system-gray-matter-layer",
+  "name": "central nervous system gray matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016548",
+  "synonym": [
+    "CNS gray matter layer",
+    "CNS grey matter layer",
+    "gray matter layer of neuraxis",
+    "grey matter layer of neuraxis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralNervousSystemWhiteMatterLayer.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralNervousSystemWhiteMatterLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "description": "A layer of of the central nervous system that is composed of white matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016549)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016549#central-nervous-system-white-matter-layer",
+  "name": "central nervous system white matter layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016549",
+  "synonym": [
+    "CNS white matter layer",
+    "white matter layer of neuraxis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
-  "synonym": [
-    "circuit part of central nervous system",
-    "circuit part of central nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -5,7 +5,7 @@
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
   "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
-  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous system regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
   "interlexIdentifier": null,
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
   "name": "circuit part of central nervous system",

--- a/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/circuitPartOfCentralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circuitPartOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914) ('is_a' and 'relationship')]",
+  "description": "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024914)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024914#circuit-part-of-central-nervous-system-1",
+  "name": "circuit part of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024914",
+  "synonym": [
+    "circuit part of central nervous system",
+    "circuit part of central nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/entericNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/entericNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/entericNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "description": "The enteric nervous system is composed of two ganglionated neural plexuses in the gut wall which form one of the three major divisions of the autonomic nervous system. The enteric nervous system innervates the gastrointestinal tract, the pancreas, and the gall bladder. It contains sensory neurons, interneurons, and motor neurons. Thus the circuitry can autonomously sense the tension and the chemical environment in the gut and regulate blood vessel tone, motility, secretions, and fluid transport. The system is itself governed by the central nervous system and receives both parasympathetic and sympathetic innervation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002005)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002005#enteric-nervous-system-1",
+  "name": "enteric nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002005",
+  "synonym": [
+    "enteric PNS",
+    "PNS - enteric"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/extrapyramidalTractSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/extrapyramidalTractSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the motor system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803) ('is_a' and 'relationship')]",
+  "description": "A neural network located in the brain that is part of the motor system involved in the coordination of movement that is distinct from the pyramidal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035803#extrapyramidal-tract-system",
+  "name": "extrapyramidal tract system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035803",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339) ('is_a' and 'relationship')]",
+  "description": "A ganglion that is part of a central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003339#ganglion-of-central-nervous-system",
+  "name": "ganglion of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003339",
+  "synonym": [
+    "central nervous system ganglion",
+    "ganglion of neuraxis",
+    "neuraxis ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionOfPeripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "ganglion of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003338",
+  "synonym": [
+    "peripheral nervous system ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionPartOfPeripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940) ('is_a' and 'relationship')]",
+  "description": "A spatially aggregated collection of nerve cell bodies in the PNS, consisting of one or more subpopulations that share cell type, chemical phenotype, and connections. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
+  "name": "ganglion part of peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
+  "synonym": [
+    "ganglion part of peripheral nervous system",
+    "ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionPartOfPeripheralNervousSystem.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024940#ganglion-part-of-peripheral-nervous-system-1",
   "name": "ganglion part of peripheral nervous system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024940",
-  "synonym": [
-    "ganglion part of peripheral nervous system",
-    "ganglion part of peripheral nervous system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/glymphaticSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glymphaticSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glymphaticSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145) ('is_a' and 'relationship')]",
+  "description": "Macroscopic waste clearance system that utilizes a unique system of perivascular tunnels, formed by astroglial cells, to promote efficient elimination of soluble proteins and metabolites from the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036145)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036145#glymphatic-system",
+  "name": "glymphatic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036145",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/limbicSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/limbicSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limbicSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the forebrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "description": "A set of midline structures surrounding the brainstem of the mammalian brain, originally described anatomically, e.g., hippocampal formation, amygdala, hypothalamus, cingulate cortex. Although the original designation was anatomical, the limbic system has come to be associated with the system in the brain subserving emotional functions. As such, it is very poorly defined and doesn't correspond closely to the anatomical meaning any longer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000349)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000349#limbic-system",
+  "name": "limbic system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000349",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumenOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumenOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561) ('is_a' and 'relationship')]",
+  "description": "The cavity that is enclosed by the central nervous system. In vertebrates this is the cavity that includes as parts ventricular cavities and the central canal of the spinal cord that develops from the lumen of the neura tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002561)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002561#neuraxis-cavity",
+  "name": "lumen of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002561",
+  "synonym": [
+    "cavity of neuraxis",
+    "cavity of ventricular system of neuraxis",
+    "neuraxis cavity",
+    "neuraxis lumen"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/motorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "description": "The part of the central nervous system that is involved with movement. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025525)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
+  "name": "motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
+  "synonym": [
+    "motor system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/motorSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/motorSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025525#motor-system",
   "name": "motor system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025525",
-  "synonym": [
-    "motor system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/nervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity and anatomical system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "description": "The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organism, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001016)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001016#nervous-system-1",
+  "name": "nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001016",
+  "synonym": [
+    "neurological system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nervousSystemCellPartLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemCellPartLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303) ('is_a' and 'relationship')]",
+  "description": "Single layer of a laminar structure, identified by different density, arrangement or size of cells and processes arranged in flattened layers or lamina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022303)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022303#nervous-system-cell-part-layer",
+  "name": "nervous system cell part layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022303",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nervousSystemCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "description": "Axon tract that crosses the midline of the central nervous system. In the context of Drosophila refers to a broad band of axons connecting equivalent neuropils each side of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001020)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001020#nervous-system-commissure",
+  "name": "nervous system commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001020",
+  "synonym": [
+    "commissure of neuraxis",
+    "neuraxis commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nervousSystemLemniscus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervousSystemLemniscus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001) ('is_a' and 'relationship')]",
+  "description": "A bundle or band of sensory nerve fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003001)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003001#lemniscus",
+  "name": "nervous system lemniscus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003001",
+  "synonym": [
+    "lemniscus",
+    "neuraxis lemniscus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
   "name": "neural system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
-  "synonym": [
-    "neural system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/neuralSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/neuralSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879) ('is_a' and 'relationship')]",
+  "description": "A set of neural structures that subserve a specific function, e.g., visual system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023879)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023879#neural-system-1",
+  "name": "neural system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023879",
+  "synonym": [
+    "neural system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parasympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the autonomic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "description": "The parasympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system. Parasympathetic nerves emerge cranially as pre ganglionic fibers from oculomotor, facial, glossopharyngeal and vagus and from the sacral region of the spinal cord. Most neurons are cholinergic and responses are mediated by muscarinic receptors. The parasympathetic system innervates, for example: salivary glands, thoracic and abdominal viscera, bladder and genitalia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000011)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000011#parasympathetic-nervous-system-1",
+  "name": "parasympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000011",
+  "synonym": [
+    "parasympathetic part of autonomic division of nervous system",
+    "pars parasympathica divisionis autonomici systematis nervosi",
+    "PNS - parasympathetic"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -13,7 +13,6 @@
   "synonym": [
     "central nervous system parenchyma",
     "CNS parenchyma",
-    "parenchyma of central nervous system",
     "parenchyma of CNS"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parenchymaOfCentralNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parenchymaOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "description": "The functional tissue of the central nervous system consisting of neurons and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005158)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005158#parenchyma-of-central-nervous-system",
+  "name": "parenchyma of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005158",
+  "synonym": [
+    "central nervous system parenchyma",
+    "CNS parenchyma",
+    "parenchyma of central nervous system",
+    "parenchyma of CNS"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/peripheralNervousSystem.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/peripheralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010) ('is_a' and 'relationship')]",
+  "description": "A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000010#peripheral-nervous-system-1",
+  "name": "peripheral nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000010",
+  "synonym": [
+    "pars peripherica",
+    "systema nervosum periphericum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/proprioceptiveSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "description": "The sensory system for the sense of proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025533)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
+  "name": "proprioceptive system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
+  "synonym": [
+    "proprioceptive system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/proprioceptiveSystem.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025533#proprioceptive-system",
   "name": "proprioceptive system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025533",
-  "synonym": [
-    "proprioceptive system"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/segmentalSubdivisionOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/segmentalSubdivisionOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732) ('is_a' and 'relationship')]",
+  "description": "Any segmental subdivision of a nervous system. Includes metameric developmental segments, such as vertebrates neuromeres. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004732)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004732#segmental-subdivision-of-nervous-system",
+  "name": "segmental subdivision of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004732",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensorimotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensorimotorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025534)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025534#sensorimotor-system",
+  "name": "sensorimotor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025534",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/somaticMotorSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticMotorSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945) ('is_a' and 'relationship')]",
+  "description": "The neural tissue involved in the transmission of motor signals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003945)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003945#somatic-motor-system",
+  "name": "somatic motor system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003945",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/somaticNervousSystem.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the peripheral nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012) ('is_a' and 'relationship')]",
+  "description": "Part of peripheral nervous system that includes the somatic parts of the cranial and spinal nerves and their ganglia and the peripheral sensory receptors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000012)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000012#somatic-nervous-system",
+  "name": "somatic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000012",
+  "synonym": [
+    "PNS - somatic",
+    "somatic nervous system, somatic division",
+    "somatic part of peripheral nervous system",
+    "somatic peripheral nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/somaticSensorySystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the somatic nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "description": "The sensory system for the sense of touch and pain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003942#somatosensory-system",
+  "name": "somatic sensory system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
+  "synonym": [
+    "somatic sensory system",
+    "somatosensory system",
+    "system for detection of somatic senses"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/somaticSensorySystem.jsonld
@@ -11,7 +11,6 @@
   "name": "somatic sensory system",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003942",
   "synonym": [
-    "somatic sensory system",
     "somatosensory system",
     "system for detection of somatic senses"
   ]

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
   "synonym": [
     "pars sympathica divisionis autonomici systematis nervosi",
-    "sympathetic nervous system",
     "sympathetic part of autonomic division of nervous system"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013) ('is_a' and 'relationship')]",
+  "description": "The sympathetic nervous system is one of the two divisions of the vertebrate autonomic nervous system (the other being the parasympathetic nervous system). The sympathetic preganglionic neurons have their cell bodies in the thoracic and lumbar regions of the spinal cord and connect to the paravertebral chain of sympathetic ganglia. Innervate heart and blood vessels, sweat glands, viscera and the adrenal medulla. Most sympathetic neurons, but not all, use noradrenaline as a post-ganglionic neurotransmitter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000013#sympathetic-nervous-system-1",
+  "name": "sympathetic nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000013",
+  "synonym": [
+    "pars sympathica divisionis autonomici systematis nervosi",
+    "sympathetic nervous system",
+    "sympathetic part of autonomic division of nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventricleOfNervousSystem.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricleOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358) ('is_a' and 'relationship')]",
+  "description": "A layer in the central nervous system that lines system of communicating cavities in the brain and spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005358)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005358#ventricle-of-nervous-system",
+  "name": "ventricle of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005358",
+  "synonym": [
+    "ventricular layer"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemChoroidalFissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemChoroidalFissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ventricle of nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192) ('is_a' and 'relationship')]",
+  "description": "The narrow cleft along the medial wall of the lateral ventricle along the margins of which the choroid plexus is attached; it lies between the upper surface of the thalamus and lateral edge of the fornix in the central part of the ventricle and between the terminal stria and fimbria hippocampi in the inferior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002192)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002192#ventricular-system-choroidal-fissure",
+  "name": "ventricular system choroidal fissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002192",
+  "synonym": [
+    "choroidal fissure of lateral ventricle",
+    "lateral ventricle choroid fissure",
+    "ventricular system choroid fissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemOfBrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Ventricular system of brain' is an anatomical system. It is part of the brain and ventricular system of central nervous system.",
+  "definition": "Is an anatomical system. Is part of the brain and the ventricular system of central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005282) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731568",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005282#ventricular-system-of-brain",
   "name": "ventricular system of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005282",
-  "synonym": null
+  "synonym": [
+    "brain ventricular system"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventricularSystemOfCentralNervousSystem.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventricularSystemOfCentralNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281) ('is_a' and 'relationship')]",
+  "description": "A set of structures containing cerebrospinal fluid in the brain. It is continuous with the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005281)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005281#ventricular-system-of-central-nervous-system",
+  "name": "ventricular system of central nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005281",
+  "synonym": [
+    "CNS ventricular system",
+    "ventricular system",
+    "ventricular system of neuraxis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/visualProcessingPartOfNervousSystem.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/visualProcessingPartOfNervousSystem",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006794) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006794#visual-processing-part-of-nervous-system",
+  "name": "visual processing part of nervous system",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006794",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfVentricularSystemOfBrain.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfVentricularSystemOfBrain",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036661) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of ventricular system of brain",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036661",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'system' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.