### PR TITLE
Eye related UBERON terms

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/centralRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004) ('is_a' and 'relationship')]",
+  "description": "Region of retina around the fovea that extends approximately for 6 mm. Central retina is considerably thick due to increased density of photoreceptors, particularly cones and their associated bipolar and ganglion cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "central retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_8000004",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/clivusOfFoveaCentralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the fovea centralis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002823) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002823#clivus-of-fovea-centralis-1",
+  "name": "clivus of fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002823",
+  "synonym": [
+    "clivus of macula lutea",
+    "fovea centralis clivus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/embryonicIntraretinalSpace",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253) ('is_a' and 'relationship')]",
+  "description": "The space separating the outer pigment epithelium and the inner neural retina of the optic cup and of the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006253#embryonic-intraretinal-space",
+  "name": "embryonic intraretinal space",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006253",
+  "synonym": [
+    "intraretinal space",
+    "intraretinal space of optic cup",
+    "intraretinal space of retina",
+    "retina intraretinal space"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/foveaCentralis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/foveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/foveaCentralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "description": "A depression in the inner retinal surface within the macula lutea, the photoreceptor layer of which is entirely cones and which is specialized for maximum visual acuity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001786#fovea",
+  "name": "fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001786",
+  "synonym": [
+    "centre of macula",
+    "fovea centralis in macula"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/foveolaOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the fovea centralis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "description": "A region of the fovea centralis that lies in the center of the fovea and contains only cone cells, and a cone-shaped zone of Müller cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018107#foveola-of-retina",
+  "name": "foveola of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018107",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionicLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina that contains somata of retinal ganglion cells, bounded by the stratum opticum and the inner plexiform layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001792#ganglionic-layer-of-retina",
+  "name": "ganglionic layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001792",
+  "synonym": [
+    "ganglionic cell layer of retina",
+    "GCL layer",
+    "retina ganglion cell layer",
+    "retina ganglion layer",
+    "retinal ganglion cell layer",
+    "retinal ganglion layer",
+    "RGC layer",
+    "stratum ganglionicum (retina)"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerLimitingLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "description": "The row of fused Muller cell processes and astrocytes that separates the retinal nerve fiber layer from the vitreous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001794#inner-limiting-layer-of-retina",
+  "name": "inner limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001794",
+  "synonym": [
+    "inner limiting membrane",
+    "inner limiting membrane of retina",
+    "internal limiting lamina of retina",
+    "internal limiting membrane of retina",
+    "retina inner limiting membrane",
+    "retina internal limiting lamina",
+    "stratum limitans internum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerNuclearLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina containing closely packed cell bodies, the majority of which are bipolar cells (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001791#inner-nuclear-layer-of-retina",
+  "name": "inner nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001791",
+  "synonym": [
+    "inner nuclear layer",
+    "intermediate cell layer",
+    "neural retina inner nuclear layer",
+    "retina inner nuclear layer",
+    "retinal inner nuclear layer",
+    "stratum nucleare internum",
+    "stratum nucleare internum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerPlexiformLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of the retina that is made up of a dense reticulum of fibrils formed by interlaced dendrites of retinal ganglion cells and cells of the inner nuclear layer (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001795#inner-plexiform-layer-of-retina",
+  "name": "inner plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001795",
+  "synonym": [
+    "retina inner plexiform layer",
+    "retinal inner plexiform layer",
+    "stratum plexiforme internum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/layerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/layerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/layerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781) ('is_a' and 'relationship')]",
+  "description": "Any of the layers that make up the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001781#layer-of-retina",
+  "name": "layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001781",
+  "synonym": [
+    "retina layer",
+    "retina neuronal layer",
+    "retinal layer",
+    "retinal neuronal layer"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limitingMembraneOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007619) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007619#limiting-membrane-of-retina",
+  "name": "limiting membrane of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007619",
+  "synonym": [
+    "retina lamina"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerLimitingLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "description": "The row of jucntional complexes between the plasma membranes of rod segments and the Muller glia cells; this barrier separates the layer of inner and outer segments of the rods and cones from the outer nuclear layer and forms a blood-retina barrier. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001788#outer-limiting-layer-of-retina",
+  "name": "outer limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001788",
+  "synonym": [
+    "external limiting lamina of retina",
+    "external limiting membrane",
+    "external limiting membrane of retina",
+    "outer limiting membrane",
+    "outer limiting membrane of retina",
+    "retina external limiting lamina",
+    "retina outer limiting membrane",
+    "stratum limitans externum (retina)",
+    "stratum limitans externum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerNuclearLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell bodies reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001789#outer-nuclear-layer-of-retina",
+  "name": "outer nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001789",
+  "synonym": [
+    "neural retina outer nuclear layer",
+    "retina outer nuclear layer",
+    "retinal outer nuclear layer",
+    "stratum nucleare externum (retina)",
+    "stratum nucleare externum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerPlexiformLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the bipolar cells synapse with the photoreceptor cells. Between the inner and outer nuclear layers, the outer plexiform layer (OPL) contains connections between the photoreceptors and bipolar and horizontal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001790#outer-plexiform-layer-of-retina",
+  "name": "outer plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001790",
+  "synonym": [
+    "outer plexiform layer",
+    "retina outer plexiform layer",
+    "retinal outer plexiform layer",
+    "stratum plexiforme externum",
+    "stratum plexiforme externum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parafovealPartOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "description": "The intermediate belt surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018104#parafoveal-part-of-retina",
+  "name": "parafoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018104",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perifovealPartOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "description": "The outermost region surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018105#perifoveal-part-of-retina",
+  "name": "perifoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018105",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/peripheralRegionOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682) ('is_a' and 'relationship')]",
+  "description": "Region of retina that extends from central retina to ora serrata. Peripheral retina is dominated by rods and also has less ganglion cells and is not as thick as central retina. It is responsible for peripheral and night vision. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013682#peripheral-region-of-retina",
+  "name": "peripheral region of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013682",
+  "synonym": [
+    "peripheral retina"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pigmentedLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "description": "A monolayer of pigmented epithelium covering the neural retina; develops from the outer of the two layers of the optic cup. the pigmented cell layer just outside the neurosensory retina that nourishes retinal visual cells, and is firmly attached to the underlying choroid and overlying retinal visual cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001782#pigmented-layer-of-retina",
+  "name": "pigmented layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001782",
+  "synonym": [
+    "outer pigmented layer of retina",
+    "pigment epithelium of retina",
+    "pigmented retina epithelium",
+    "pigmented retinal epithelium",
+    "retinal pigment epithelium",
+    "retinal pigmented epithelium",
+    "stratum pigmentosum (retina)",
+    "stratum pigmentosum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/retina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/retina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a photoreceptor array. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "description": "The retina is the innermost layer or coating at the back of the eyeball, which is sensitive to light and in which the optic nerve terminates. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000966#retina-1",
+  "name": "retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000966",
+  "synonym": [
+    "inner layer of eyeball",
+    "retina of camera-type eye",
+    "tunica interna of eyeball"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinalNeuralLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "description": "The part of the retina that contains neurons and photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003902#retinal-neural-layer",
+  "name": "retinal neural layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003902",
+  "synonym": [
+    "neural layer of retina",
+    "neural retina",
+    "neuroretina",
+    "stratum nervosum (retina)",
+    "stratum nervosum retinae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinalTapetumLucidum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "description": "A tapetum lucidum that is part of the retina, within the cytoplasm of the retinal epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010245#retinal-tapetum-lucidum",
+  "name": "retinal tapetum lucidum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010245",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substratumOfLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008921) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008921#substratum-of-layer-of-retina",
+  "name": "substratum of layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008921",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004) ('is_a' and 'relationship')]",
+  "description": "Region of retina around the fovea that extends approximately for 6 mm. Central retina is considerably thick due to increased density of photoreceptors, particularly cones and their associated bipolar and ganglion cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "central retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_8000004",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/clivusOfFoveaCentralis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the fovea centralis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002823) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002823#clivus-of-fovea-centralis-1",
+  "name": "clivus of fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002823",
+  "synonym": [
+    "clivus of macula lutea",
+    "fovea centralis clivus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/embryonicIntraretinalSpace",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253) ('is_a' and 'relationship')]",
+  "description": "The space separating the outer pigment epithelium and the inner neural retina of the optic cup and of the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006253#embryonic-intraretinal-space",
+  "name": "embryonic intraretinal space",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006253",
+  "synonym": [
+    "intraretinal space",
+    "intraretinal space of optic cup",
+    "intraretinal space of retina",
+    "retina intraretinal space"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/foveaCentralis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/foveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/foveaCentralis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "description": "A depression in the inner retinal surface within the macula lutea, the photoreceptor layer of which is entirely cones and which is specialized for maximum visual acuity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001786#fovea",
+  "name": "fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001786",
+  "synonym": [
+    "centre of macula",
+    "fovea centralis in macula"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/foveolaOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the fovea centralis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "description": "A region of the fovea centralis that lies in the center of the fovea and contains only cone cells, and a cone-shaped zone of Müller cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018107#foveola-of-retina",
+  "name": "foveola of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018107",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglionicLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina that contains somata of retinal ganglion cells, bounded by the stratum opticum and the inner plexiform layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001792#ganglionic-layer-of-retina",
+  "name": "ganglionic layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001792",
+  "synonym": [
+    "ganglionic cell layer of retina",
+    "GCL layer",
+    "retina ganglion cell layer",
+    "retina ganglion layer",
+    "retinal ganglion cell layer",
+    "retinal ganglion layer",
+    "RGC layer",
+    "stratum ganglionicum (retina)"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/innerLimitingLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "description": "The row of fused Muller cell processes and astrocytes that separates the retinal nerve fiber layer from the vitreous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001794#inner-limiting-layer-of-retina",
+  "name": "inner limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001794",
+  "synonym": [
+    "inner limiting membrane",
+    "inner limiting membrane of retina",
+    "internal limiting lamina of retina",
+    "internal limiting membrane of retina",
+    "retina inner limiting membrane",
+    "retina internal limiting lamina",
+    "stratum limitans internum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/innerNuclearLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina containing closely packed cell bodies, the majority of which are bipolar cells (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001791#inner-nuclear-layer-of-retina",
+  "name": "inner nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001791",
+  "synonym": [
+    "inner nuclear layer",
+    "intermediate cell layer",
+    "neural retina inner nuclear layer",
+    "retina inner nuclear layer",
+    "retinal inner nuclear layer",
+    "stratum nucleare internum",
+    "stratum nucleare internum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/innerPlexiformLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of the retina that is made up of a dense reticulum of fibrils formed by interlaced dendrites of retinal ganglion cells and cells of the inner nuclear layer (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001795#inner-plexiform-layer-of-retina",
+  "name": "inner plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001795",
+  "synonym": [
+    "retina inner plexiform layer",
+    "retinal inner plexiform layer",
+    "stratum plexiforme internum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/layerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/layerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/layerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781) ('is_a' and 'relationship')]",
+  "description": "Any of the layers that make up the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001781#layer-of-retina",
+  "name": "layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001781",
+  "synonym": [
+    "retina layer",
+    "retina neuronal layer",
+    "retinal layer",
+    "retinal neuronal layer"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/limitingMembraneOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007619) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007619#limiting-membrane-of-retina",
+  "name": "limiting membrane of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007619",
+  "synonym": [
+    "retina lamina"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/outerLimitingLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "description": "The row of jucntional complexes between the plasma membranes of rod segments and the Muller glia cells; this barrier separates the layer of inner and outer segments of the rods and cones from the outer nuclear layer and forms a blood-retina barrier. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001788#outer-limiting-layer-of-retina",
+  "name": "outer limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001788",
+  "synonym": [
+    "external limiting lamina of retina",
+    "external limiting membrane",
+    "external limiting membrane of retina",
+    "outer limiting membrane",
+    "outer limiting membrane of retina",
+    "retina external limiting lamina",
+    "retina outer limiting membrane",
+    "stratum limitans externum (retina)",
+    "stratum limitans externum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/outerNuclearLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell bodies reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001789#outer-nuclear-layer-of-retina",
+  "name": "outer nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001789",
+  "synonym": [
+    "neural retina outer nuclear layer",
+    "retina outer nuclear layer",
+    "retinal outer nuclear layer",
+    "stratum nucleare externum (retina)",
+    "stratum nucleare externum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/outerPlexiformLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the bipolar cells synapse with the photoreceptor cells. Between the inner and outer nuclear layers, the outer plexiform layer (OPL) contains connections between the photoreceptors and bipolar and horizontal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001790#outer-plexiform-layer-of-retina",
+  "name": "outer plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001790",
+  "synonym": [
+    "outer plexiform layer",
+    "retina outer plexiform layer",
+    "retinal outer plexiform layer",
+    "stratum plexiforme externum",
+    "stratum plexiforme externum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parafovealPartOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "description": "The intermediate belt surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018104#parafoveal-part-of-retina",
+  "name": "parafoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018104",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/perifovealPartOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "description": "The outermost region surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018105#perifoveal-part-of-retina",
+  "name": "perifoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018105",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/peripheralRegionOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682) ('is_a' and 'relationship')]",
+  "description": "Region of retina that extends from central retina to ora serrata. Peripheral retina is dominated by rods and also has less ganglion cells and is not as thick as central retina. It is responsible for peripheral and night vision. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013682#peripheral-region-of-retina",
+  "name": "peripheral region of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013682",
+  "synonym": [
+    "peripheral retina"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pigmentedLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "description": "A monolayer of pigmented epithelium covering the neural retina; develops from the outer of the two layers of the optic cup. the pigmented cell layer just outside the neurosensory retina that nourishes retinal visual cells, and is firmly attached to the underlying choroid and overlying retinal visual cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001782#pigmented-layer-of-retina",
+  "name": "pigmented layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001782",
+  "synonym": [
+    "outer pigmented layer of retina",
+    "pigment epithelium of retina",
+    "pigmented retina epithelium",
+    "pigmented retinal epithelium",
+    "retinal pigment epithelium",
+    "retinal pigmented epithelium",
+    "stratum pigmentosum (retina)",
+    "stratum pigmentosum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/retina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/retina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/retina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a photoreceptor array. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "description": "The retina is the innermost layer or coating at the back of the eyeball, which is sensitive to light and in which the optic nerve terminates. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000966#retina-1",
+  "name": "retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000966",
+  "synonym": [
+    "inner layer of eyeball",
+    "retina of camera-type eye",
+    "tunica interna of eyeball"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/retinalNeuralLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "description": "The part of the retina that contains neurons and photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003902#retinal-neural-layer",
+  "name": "retinal neural layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003902",
+  "synonym": [
+    "neural layer of retina",
+    "neural retina",
+    "neuroretina",
+    "stratum nervosum (retina)",
+    "stratum nervosum retinae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/retinalTapetumLucidum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "description": "A tapetum lucidum that is part of the retina, within the cytoplasm of the retinal epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010245#retinal-tapetum-lucidum",
+  "name": "retinal tapetum lucidum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010245",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/substratumOfLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008921) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008921#substratum-of-layer-of-retina",
+  "name": "substratum of layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008921",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004) ('is_a' and 'relationship')]",
+  "description": "Region of retina around the fovea that extends approximately for 6 mm. Central retina is considerably thick due to increased density of photoreceptors, particularly cones and their associated bipolar and ganglion cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_8000004)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "central retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_8000004",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/clivusOfFoveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/clivusOfFoveaCentralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the fovea centralis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002823) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002823#clivus-of-fovea-centralis-1",
+  "name": "clivus of fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002823",
+  "synonym": [
+    "clivus of macula lutea",
+    "fovea centralis clivus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/embryonicIntraretinalSpace.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/embryonicIntraretinalSpace",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253) ('is_a' and 'relationship')]",
+  "description": "The space separating the outer pigment epithelium and the inner neural retina of the optic cup and of the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006253)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006253#embryonic-intraretinal-space",
+  "name": "embryonic intraretinal space",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006253",
+  "synonym": [
+    "intraretinal space",
+    "intraretinal space of optic cup",
+    "intraretinal space of retina",
+    "retina intraretinal space"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/foveaCentralis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/foveaCentralis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/foveaCentralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "description": "A depression in the inner retinal surface within the macula lutea, the photoreceptor layer of which is entirely cones and which is specialized for maximum visual acuity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001786)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001786#fovea",
+  "name": "fovea centralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001786",
+  "synonym": [
+    "centre of macula",
+    "fovea centralis in macula"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/foveolaOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/foveolaOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the fovea centralis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "description": "A region of the fovea centralis that lies in the center of the fovea and contains only cone cells, and a cone-shaped zone of Müller cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018107)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018107#foveola-of-retina",
+  "name": "foveola of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018107",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionicLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionicLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina that contains somata of retinal ganglion cells, bounded by the stratum opticum and the inner plexiform layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001792)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001792#ganglionic-layer-of-retina",
+  "name": "ganglionic layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001792",
+  "synonym": [
+    "ganglionic cell layer of retina",
+    "GCL layer",
+    "retina ganglion cell layer",
+    "retina ganglion layer",
+    "retinal ganglion cell layer",
+    "retinal ganglion layer",
+    "RGC layer",
+    "stratum ganglionicum (retina)"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/innerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerLimitingLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "description": "The row of fused Muller cell processes and astrocytes that separates the retinal nerve fiber layer from the vitreous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001794)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001794#inner-limiting-layer-of-retina",
+  "name": "inner limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001794",
+  "synonym": [
+    "inner limiting membrane",
+    "inner limiting membrane of retina",
+    "internal limiting lamina of retina",
+    "internal limiting membrane of retina",
+    "retina inner limiting membrane",
+    "retina internal limiting lamina",
+    "stratum limitans internum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/innerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerNuclearLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of retina containing closely packed cell bodies, the majority of which are bipolar cells (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001791)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001791#inner-nuclear-layer-of-retina",
+  "name": "inner nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001791",
+  "synonym": [
+    "inner nuclear layer",
+    "intermediate cell layer",
+    "neural retina inner nuclear layer",
+    "retina inner nuclear layer",
+    "retinal inner nuclear layer",
+    "stratum nucleare internum",
+    "stratum nucleare internum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/innerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/innerPlexiformLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural layer of the retina that is made up of a dense reticulum of fibrils formed by interlaced dendrites of retinal ganglion cells and cells of the inner nuclear layer (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001795#inner-plexiform-layer-of-retina",
+  "name": "inner plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001795",
+  "synonym": [
+    "retina inner plexiform layer",
+    "retinal inner plexiform layer",
+    "stratum plexiforme internum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/layerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/layerOfRetina.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/layerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781) ('is_a' and 'relationship')]",
+  "description": "Any of the layers that make up the retina. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001781)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001781#layer-of-retina",
+  "name": "layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001781",
+  "synonym": [
+    "retina layer",
+    "retina neuronal layer",
+    "retinal layer",
+    "retinal neuronal layer"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/limitingMembraneOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limitingMembraneOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007619) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007619#limiting-membrane-of-retina",
+  "name": "limiting membrane of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007619",
+  "synonym": [
+    "retina lamina"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/outerLimitingLayerOfRetina.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerLimitingLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limiting membrane of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "description": "The row of jucntional complexes between the plasma membranes of rod segments and the Muller glia cells; this barrier separates the layer of inner and outer segments of the rods and cones from the outer nuclear layer and forms a blood-retina barrier. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001788)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001788#outer-limiting-layer-of-retina",
+  "name": "outer limiting layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001788",
+  "synonym": [
+    "external limiting lamina of retina",
+    "external limiting membrane",
+    "external limiting membrane of retina",
+    "outer limiting membrane",
+    "outer limiting membrane of retina",
+    "retina external limiting lamina",
+    "retina outer limiting membrane",
+    "stratum limitans externum (retina)",
+    "stratum limitans externum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/outerNuclearLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerNuclearLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the photoreceptor cell bodies reside. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001789)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001789#outer-nuclear-layer-of-retina",
+  "name": "outer nuclear layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001789",
+  "synonym": [
+    "neural retina outer nuclear layer",
+    "retina outer nuclear layer",
+    "retinal outer nuclear layer",
+    "stratum nucleare externum (retina)",
+    "stratum nucleare externum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/outerPlexiformLayerOfRetina.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/outerPlexiformLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790) ('is_a' and 'relationship')]",
+  "description": "The layer within the retina where the bipolar cells synapse with the photoreceptor cells. Between the inner and outer nuclear layers, the outer plexiform layer (OPL) contains connections between the photoreceptors and bipolar and horizontal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001790)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001790#outer-plexiform-layer-of-retina",
+  "name": "outer plexiform layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001790",
+  "synonym": [
+    "outer plexiform layer",
+    "retina outer plexiform layer",
+    "retinal outer plexiform layer",
+    "stratum plexiforme externum",
+    "stratum plexiforme externum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parafovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parafovealPartOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "description": "The intermediate belt surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018104)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018104#parafoveal-part-of-retina",
+  "name": "parafoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018104",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/perifovealPartOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perifovealPartOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the macula lutea. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "description": "The outermost region surrounding the fovea centralis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018105#perifoveal-part-of-retina",
+  "name": "perifoveal part of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018105",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/peripheralRegionOfRetina.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/peripheralRegionOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682) ('is_a' and 'relationship')]",
+  "description": "Region of retina that extends from central retina to ora serrata. Peripheral retina is dominated by rods and also has less ganglion cells and is not as thick as central retina. It is responsible for peripheral and night vision. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013682)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013682#peripheral-region-of-retina",
+  "name": "peripheral region of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013682",
+  "synonym": [
+    "peripheral retina"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pigmentedLayerOfRetina.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pigmentedLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "description": "A monolayer of pigmented epithelium covering the neural retina; develops from the outer of the two layers of the optic cup. the pigmented cell layer just outside the neurosensory retina that nourishes retinal visual cells, and is firmly attached to the underlying choroid and overlying retinal visual cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001782)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001782#pigmented-layer-of-retina",
+  "name": "pigmented layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001782",
+  "synonym": [
+    "outer pigmented layer of retina",
+    "pigment epithelium of retina",
+    "pigmented retina epithelium",
+    "pigmented retinal epithelium",
+    "retinal pigment epithelium",
+    "retinal pigmented epithelium",
+    "stratum pigmentosum (retina)",
+    "stratum pigmentosum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/retina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/retina.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a photoreceptor array. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "description": "The retina is the innermost layer or coating at the back of the eyeball, which is sensitive to light and in which the optic nerve terminates. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000966)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000966#retina-1",
+  "name": "retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000966",
+  "synonym": [
+    "inner layer of eyeball",
+    "retina of camera-type eye",
+    "tunica interna of eyeball"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/retinalNeuralLayer.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinalNeuralLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "description": "The part of the retina that contains neurons and photoreceptor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003902)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003902#retinal-neural-layer",
+  "name": "retinal neural layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003902",
+  "synonym": [
+    "neural layer of retina",
+    "neural retina",
+    "neuroretina",
+    "stratum nervosum (retina)",
+    "stratum nervosum retinae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/retinalTapetumLucidum.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/retinalTapetumLucidum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the retina. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "description": "A tapetum lucidum that is part of the retina, within the cytoplasm of the retinal epithelium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010245)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010245#retinal-tapetum-lucidum",
+  "name": "retinal tapetum lucidum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010245",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/substratumOfLayerOfRetina.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substratumOfLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008921) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008921#substratum-of-layer-of-retina",
+  "name": "substratum of layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008921",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'retina' or 'fovea' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.