### PR TITLE
UBERON terms with 'organ' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/chemosensoryOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000005) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000005#chemosensory-organ",
+  "name": "chemosensory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000005",
+  "synonym": [
+    "chemosensory sensory organ"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -4,15 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circumventricularOrgan",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Circumventricular organ' is a regional part of brain.",
-  "description": "Brain region located around or in relation to the ventricular system that is highly vascularized and distinguished by the lack of a blood brain barrier.",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
+  "description": "Any of any of the secretory or sensory organs located in the brain region around or in relation to the ventricular system that are characterized by extensive vasculature and a lack of a normal blood brain barrier (BBB) and allow for the linkage between the central nervous system and peripheral blood flow. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102196",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005408#circumventricular-organ-1",
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "CVO",
     "circumventricular organ",
-    "circumventricular organ of neuraxis"
+    "circumventricular organ of neuraxis",
+    "CVO"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -11,7 +11,6 @@
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "circumventricular organ",
     "circumventricular organ of neuraxis",
     "CVO"
   ]

--- a/instances/latest/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gustatoryOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a chemosensory organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "description": "Any sense organ that functions in (some) detection of chemical stimulus involved in sensory perception of taste (GO:0050912). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003212#gustatory-organ",
+  "name": "gustatory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003212",
+  "synonym": [
+    "gustatory organ system organ",
+    "gustatory system organ",
+    "organ of gustatory organ system",
+    "organ of gustatory system",
+    "organ of taste system",
+    "taste organ",
+    "taste system organ"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/infundibularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/infundibularOrgan.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/infundibularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011358) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011358#infundibular-organ",
+  "name": "infundibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011358",
+  "synonym": [
+    "infundibular organ of Boeke",
+    "ventral infundibular organ"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/otolithOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/otolithOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/otolithOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vestibular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "description": "The crystalline particles composed of calcium carbonate and a protein which adhere to the gelatinous membrane of the maculae of the utricle and saccule (otolithic membrane) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002518#otolith-organ",
+  "name": "otolith organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002518",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parapinealOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parapinealOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parapinealOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015241#parapineal-organ",
+  "name": "parapineal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015241",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/paraventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a diencephalic nucleus. Is part of the caudal tuberculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000475) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000475#paraventricular-organ",
+  "name": "paraventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000475",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parietalOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parietalOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "description": "A part of the epithalamus present in some animal species. The eye may be photoreceptive and is usually associated with the pineal gland, regulating circadian rhythmicity and hormone production for thermoregulation. The parietal eye is a part of the epithalamus, which can be divided into two major parts; the epiphysis (the pineal organ, or pineal gland if mostly endocrine) and the parietal organ (often called the parietal eye, or third eye if it is photoreceptive). It arises as an anterior evagination of the pineal organ or as a separate outgrowth of the roof of the diencephalon. In some species, it protrudes through the skull. The parietal eye uses a different biochemical method of detecting light than rod cells or cone cells in a normal vertebrate eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004869#parietal-organ",
+  "name": "parietal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004869",
+  "synonym": [
+    "parietal eye"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secretoryCircumventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circumventricular organ and neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "description": "A circumventricular organ that is capable of secreting substances into the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010134#secretory-circumventricular-organ",
+  "name": "secretory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010134",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryCircumventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circumventricular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "description": "A circumventricular organ that is capable of monitoring the levels of substances to the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010135#sensory-circumventricular-organ",
+  "name": "sensory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010135",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/septalOrganOfMasera",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the olfactory epithelium. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "description": "A small island of olfactory neuroepithelium lying bilaterally at the ventral base of the nasal septum near the entrance of the nasopharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015246#septal-organ-of-masera",
+  "name": "septal organ of Masera",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015246",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
@@ -4,17 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subcommissuralOrgan",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Subcommissural organ' is a secretory circumventricular organ. It is part of the midbrain tectum and Reissner's fiber.",
-  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin[WP,partially vetted].",
+  "definition": "Is a secretory circumventricular organ. Is part of the midbrain tectum and the Reissner's fiber. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139) ('is_a' and 'relationship')]",
+  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111159",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002139#subcommissural-organ-1",
   "name": "subcommissural organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002139",
-  "synonym": [
-    "cerebral aqueduct subcommissural organ",
-    "corpus subcommissurale",
-    "dorsal subcommissural organ",
-    "organum subcommissurale",
-    "SCO"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subfornicalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory circumventricular organ. Is part of the septal nuclear complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219) ('is_a' and 'relationship')]",
+  "description": "Group of neurons situated on the ventral surface of the fornix at the level of the foramen of Monro in the third ventricle (adapted from Wikipedia via NIF). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002219#subfornical-organ",
+  "name": "subfornical organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002219",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibularOrgan.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibularOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585) ('is_a' and 'relationship')]",
+  "description": "An organ that is part of a vestibular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006585#vestibular-organ-1",
+  "name": "vestibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006585",
+  "synonym": [
+    "balance organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/chemosensoryOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000005) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000005#chemosensory-organ",
+  "name": "chemosensory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000005",
+  "synonym": [
+    "chemosensory sensory organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -11,7 +11,6 @@
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "circumventricular organ",
     "circumventricular organ of neuraxis",
     "CVO"
   ]

--- a/instances/v3.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -4,15 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/circumventricularOrgan",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Circumventricular organ' is a regional part of brain.",
-  "description": "Brain region located around or in relation to the ventricular system that is highly vascularized and distinguished by the lack of a blood brain barrier.",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
+  "description": "Any of any of the secretory or sensory organs located in the brain region around or in relation to the ventricular system that are characterized by extensive vasculature and a lack of a normal blood brain barrier (BBB) and allow for the linkage between the central nervous system and peripheral blood flow. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102196",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005408#circumventricular-organ-1",
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "CVO",
     "circumventricular organ",
-    "circumventricular organ of neuraxis"
+    "circumventricular organ of neuraxis",
+    "CVO"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/gustatoryOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a chemosensory organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "description": "Any sense organ that functions in (some) detection of chemical stimulus involved in sensory perception of taste (GO:0050912). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003212#gustatory-organ",
+  "name": "gustatory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003212",
+  "synonym": [
+    "gustatory organ system organ",
+    "gustatory system organ",
+    "organ of gustatory organ system",
+    "organ of gustatory system",
+    "organ of taste system",
+    "taste organ",
+    "taste system organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/infundibularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/infundibularOrgan.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/infundibularOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011358) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011358#infundibular-organ",
+  "name": "infundibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011358",
+  "synonym": [
+    "infundibular organ of Boeke",
+    "ventral infundibular organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/otolithOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/otolithOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/otolithOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a vestibular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "description": "The crystalline particles composed of calcium carbonate and a protein which adhere to the gelatinous membrane of the maculae of the utricle and saccule (otolithic membrane) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002518#otolith-organ",
+  "name": "otolith organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002518",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parapinealOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parapinealOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parapinealOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015241#parapineal-organ",
+  "name": "parapineal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015241",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/paraventricularOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a diencephalic nucleus. Is part of the caudal tuberculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000475) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000475#paraventricular-organ",
+  "name": "paraventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000475",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parietalOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parietalOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parietalOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "description": "A part of the epithalamus present in some animal species. The eye may be photoreceptive and is usually associated with the pineal gland, regulating circadian rhythmicity and hormone production for thermoregulation. The parietal eye is a part of the epithalamus, which can be divided into two major parts; the epiphysis (the pineal organ, or pineal gland if mostly endocrine) and the parietal organ (often called the parietal eye, or third eye if it is photoreceptive). It arises as an anterior evagination of the pineal organ or as a separate outgrowth of the roof of the diencephalon. In some species, it protrudes through the skull. The parietal eye uses a different biochemical method of detecting light than rod cells or cone cells in a normal vertebrate eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004869#parietal-organ",
+  "name": "parietal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004869",
+  "synonym": [
+    "parietal eye"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secretoryCircumventricularOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a circumventricular organ and neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "description": "A circumventricular organ that is capable of secreting substances into the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010134#secretory-circumventricular-organ",
+  "name": "secretory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010134",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryCircumventricularOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a circumventricular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "description": "A circumventricular organ that is capable of monitoring the levels of substances to the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010135#sensory-circumventricular-organ",
+  "name": "sensory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010135",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/septalOrganOfMasera",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the olfactory epithelium. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "description": "A small island of olfactory neuroepithelium lying bilaterally at the ventral base of the nasal septum near the entrance of the nasopharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015246#septal-organ-of-masera",
+  "name": "septal organ of Masera",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015246",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
@@ -4,17 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subcommissuralOrgan",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Subcommissural organ' is a secretory circumventricular organ. It is part of the midbrain tectum and Reissner's fiber.",
-  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin[WP,partially vetted].",
+  "definition": "Is a secretory circumventricular organ. Is part of the midbrain tectum and the Reissner's fiber. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139) ('is_a' and 'relationship')]",
+  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111159",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002139#subcommissural-organ-1",
   "name": "subcommissural organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002139",
-  "synonym": [
-    "cerebral aqueduct subcommissural organ",
-    "corpus subcommissurale",
-    "dorsal subcommissural organ",
-    "organum subcommissurale",
-    "SCO"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subfornicalOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory circumventricular organ. Is part of the septal nuclear complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219) ('is_a' and 'relationship')]",
+  "description": "Group of neurons situated on the ventral surface of the fornix at the level of the foramen of Monro in the third ventricle (adapted from Wikipedia via NIF). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002219#subfornical-organ",
+  "name": "subfornical organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002219",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibularOrgan.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibularOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibularOrgan",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585) ('is_a' and 'relationship')]",
+  "description": "An organ that is part of a vestibular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006585#vestibular-organ-1",
+  "name": "vestibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006585",
+  "synonym": [
+    "balance organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/chemosensoryOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/chemosensoryOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000005) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000005#chemosensory-organ",
+  "name": "chemosensory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000005",
+  "synonym": [
+    "chemosensory sensory organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -4,15 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/circumventricularOrgan",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Circumventricular organ' is a regional part of brain.",
-  "description": "Brain region located around or in relation to the ventricular system that is highly vascularized and distinguished by the lack of a blood brain barrier.",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
+  "description": "Any of any of the secretory or sensory organs located in the brain region around or in relation to the ventricular system that are characterized by extensive vasculature and a lack of a normal blood brain barrier (BBB) and allow for the linkage between the central nervous system and peripheral blood flow. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005408)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102196",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005408#circumventricular-organ-1",
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "CVO",
     "circumventricular organ",
-    "circumventricular organ of neuraxis"
+    "circumventricular organ of neuraxis",
+    "CVO"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/circumventricularOrgan.jsonld
@@ -11,7 +11,6 @@
   "name": "circumventricular organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005408",
   "synonym": [
-    "circumventricular organ",
     "circumventricular organ of neuraxis",
     "CVO"
   ]

--- a/instances/v4.0/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/gustatoryOrgan.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gustatoryOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a chemosensory organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "description": "Any sense organ that functions in (some) detection of chemical stimulus involved in sensory perception of taste (GO:0050912). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003212)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003212#gustatory-organ",
+  "name": "gustatory organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003212",
+  "synonym": [
+    "gustatory organ system organ",
+    "gustatory system organ",
+    "organ of gustatory organ system",
+    "organ of gustatory system",
+    "organ of taste system",
+    "taste organ",
+    "taste system organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/infundibularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/infundibularOrgan.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/infundibularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of nervous system. Is part of the central nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011358) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011358#infundibular-organ",
+  "name": "infundibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011358",
+  "synonym": [
+    "infundibular organ of Boeke",
+    "ventral infundibular organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/otolithOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/otolithOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/otolithOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vestibular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "description": "The crystalline particles composed of calcium carbonate and a protein which adhere to the gelatinous membrane of the maculae of the utricle and saccule (otolithic membrane) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002518)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002518#otolith-organ",
+  "name": "otolith organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002518",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parapinealOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parapinealOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parapinealOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015241)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015241#parapineal-organ",
+  "name": "parapineal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015241",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/paraventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/paraventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a diencephalic nucleus. Is part of the caudal tuberculum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000475) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000475#paraventricular-organ",
+  "name": "paraventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000475",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parietalOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parietalOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the pineal complex. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "description": "A part of the epithalamus present in some animal species. The eye may be photoreceptive and is usually associated with the pineal gland, regulating circadian rhythmicity and hormone production for thermoregulation. The parietal eye is a part of the epithalamus, which can be divided into two major parts; the epiphysis (the pineal organ, or pineal gland if mostly endocrine) and the parietal organ (often called the parietal eye, or third eye if it is photoreceptive). It arises as an anterior evagination of the pineal organ or as a separate outgrowth of the roof of the diencephalon. In some species, it protrudes through the skull. The parietal eye uses a different biochemical method of detecting light than rod cells or cone cells in a normal vertebrate eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004869)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004869#parietal-organ",
+  "name": "parietal organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004869",
+  "synonym": [
+    "parietal eye"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secretoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secretoryCircumventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circumventricular organ and neuroendocrine gland. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "description": "A circumventricular organ that is capable of secreting substances into the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010134#secretory-circumventricular-organ",
+  "name": "secretory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010134",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryCircumventricularOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryCircumventricularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circumventricular organ. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "description": "A circumventricular organ that is capable of monitoring the levels of substances to the cerebrospinal fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010135)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010135#sensory-circumventricular-organ",
+  "name": "sensory circumventricular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010135",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/septalOrganOfMasera.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/septalOrganOfMasera",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the olfactory epithelium. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "description": "A small island of olfactory neuroepithelium lying bilaterally at the ventral base of the nasal septum near the entrance of the nasopharynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015246)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015246#septal-organ-of-masera",
+  "name": "septal organ of Masera",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015246",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subcommissuralOrgan.jsonld
@@ -4,17 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subcommissuralOrgan",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Subcommissural organ' is a secretory circumventricular organ. It is part of the midbrain tectum and Reissner's fiber.",
-  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin[WP,partially vetted].",
+  "definition": "Is a secretory circumventricular organ. Is part of the midbrain tectum and the Reissner's fiber. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139) ('is_a' and 'relationship')]",
+  "description": "The subcommissural organ is a circumventricular organ consisting of ependymal cells which secrete SCO-spondin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002139)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111159",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002139#subcommissural-organ-1",
   "name": "subcommissural organ",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002139",
-  "synonym": [
-    "cerebral aqueduct subcommissural organ",
-    "corpus subcommissurale",
-    "dorsal subcommissural organ",
-    "organum subcommissurale",
-    "SCO"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subfornicalOrgan.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subfornicalOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory circumventricular organ. Is part of the septal nuclear complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219) ('is_a' and 'relationship')]",
+  "description": "Group of neurons situated on the ventral surface of the fornix at the level of the foramen of Monro in the third ventricle (adapted from Wikipedia via NIF). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002219)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002219#subfornical-organ",
+  "name": "subfornical organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002219",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibularOrgan.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibularOrgan.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularOrgan",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585) ('is_a' and 'relationship')]",
+  "description": "An organ that is part of a vestibular system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006585#vestibular-organ-1",
+  "name": "vestibular organ",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006585",
+  "synonym": [
+    "balance organ"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'organ' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.