### PR TITLE
UBERON terms with 'nerve' in their name (part 2 of 2)

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/RuffiniNerveEnding",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "description": "An encapsulated nerve receptor present in subpapillary dermis and deep dermis of hairy and glabrous skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012457#ruffini-nerve-ending",
+  "name": "Ruffini nerve ending",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012457",
+  "synonym": [
+    "corpusculum sensorium fusiforme",
+    "Ruffini's corpuscle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013671)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013671#nerve-ending-of-of-corpus-cavernosum-maxillaris",
+  "name": "nerve ending of of corpus cavernosum maxillaris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013671",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveFasciculus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveFasciculus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFasciculus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "description": "A slender neuron projection bundle; A bundle of anatomical fibers, as of muscle or nerve (American Heritage Dictionary 4th ed). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001019#fasciculus",
+  "name": "nerve fasciculus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001019",
+  "synonym": [
+    "fasciculus",
+    "nerve bundle",
+    "nerve fasciculus",
+    "neural fasciculus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveFiber.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nerve fasciculus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134) ('is_a' and 'relationship')]",
+  "description": "A threadlike extension of a nerve cell and consists of an axon and myelin sheath (if it is myelinated) in the nervous system. There are nerve fibers in the central nervous system and peripheral nervous system. A nerve fiber may be myelinated and/or unmyelinated. In the central nervous system (CNS), myelin by oligodendroglia cells is formed. Schwann cells form myelin in the peripheral nervous system (PNS). Schwann cells also make a thin covering in an axon without myelin (in the PNS). A peripheral nerve fiber contains an axon, myelin sheath, schwann cells and its endoneurium. There are no endoneurium and schwann cells in the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006134#nerve-fiber",
+  "name": "nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006134",
+  "synonym": [
+    "nerve fibre",
+    "neurofibra",
+    "neurofibrum"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFiberLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina formed by expansion of the fibers of the optic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001793#nerve-fiber-layer-of-retina",
+  "name": "nerve fiber layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001793",
+  "synonym": [
+    "layer of nerve fibers of retina",
+    "layer of nerve fibres of retina",
+    "optic fiber layer",
+    "retina nerve fiber layer",
+    "stratum neurofibrarum (retina)",
+    "stratum neurofibrarum retinae",
+    "stratum opticum of retina"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveInnervatingPinna",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648) ('is_a' and 'relationship')]",
+  "description": "Any nerve that innervates the pinna. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035648#nerve-innervating-pinna",
+  "name": "nerve innervating pinna",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035648",
+  "synonym": [
+    "auricular nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfAbdominalSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "description": "A nerve that is part of an abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003825#nerve-of-abdominal-segment",
+  "name": "nerve of abdominal segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003825",
+  "synonym": [
+    "abdominal segment nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfCervicalVertebra",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "description": "The cervical nerves are the spinal nerves from the cervical vertebrae. Although there are seven cervical vertebrae (C1-C7), there are eight cervical nerves (C1-C8). All nerves except C8 emerge above their corresponding vertebrae, while the C8 nerve emerges below the C7 vertebra. (In the other portions of the spine, the nerve emerges below the vertebra with the same name. Dorsal (posterior) distribution includes the greater occipital (C2) and third occipital (C3). Ventral (anterior) distribution includes the cervical plexus (C1-C4) and brachial plexus (C5-C8). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000962#nerve-of-cervical-vertebra",
+  "name": "nerve of cervical vertebra",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000962",
+  "synonym": [
+    "cervical nerve",
+    "cervical nerve tree",
+    "cervical spinal nerve",
+    "nervus cervicalis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfClitoris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "description": "Any nerve that innervates the clitoris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035650#nerve-of-clitoris",
+  "name": "nerve of clitoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035650",
+  "synonym": [
+    "clitoral nerve",
+    "clitoris nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfHeadRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "description": "A nerve that is part of a head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011779#nerve-of-head-region",
+  "name": "nerve of head region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011779",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfPenis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfPenis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfPenis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "description": "Any nerve that innervates the penis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035649#nerve-of-penis",
+  "name": "nerve of penis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035649",
+  "synonym": [
+    "penile nerve",
+    "penis nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfThoracicSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "description": "A nerve that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003824#nerve-of-thoracic-segment",
+  "name": "nerve of thoracic segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003824",
+  "synonym": [
+    "nerve of thorax",
+    "thoracic segment nerve",
+    "thorax nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfTrunkRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "description": "A nerve that is part of the trunk region of the body (not to be confused with a nerve trunk). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003439#nerve-of-trunk-region",
+  "name": "nerve of trunk region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003439",
+  "synonym": [
+    "nerve of torso",
+    "nerve of trunk",
+    "torso nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfTympanicCavity",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "description": "A nerve that is part of a tympanic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004116#nerve-of-tympanic-cavity",
+  "name": "nerve of tympanic cavity",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004116",
+  "synonym": [
+    "anatomical cavity of middle ear nerve",
+    "cavity of middle ear nerve",
+    "middle ear anatomical cavity nerve",
+    "middle ear cavity nerve",
+    "nerve of anatomical cavity of middle ear",
+    "nerve of cavity of middle ear",
+    "nerve of middle ear anatomical cavity",
+    "nerve of middle ear cavity",
+    "tympanic cavity nerve",
+    "tympanic cavity nerves"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tissue. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "description": "Anatomical junction where subdivisions of two or more neural trees interconnect with one another to form a network through which nerve fibers of the constituent nerve trees become regrouped; together with other nerve plexuses, nerves and ganglia, it constitutes the peripheral nervous system. Examples: cervical nerve plexus, brachial nerve plexus, sacral nerve plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001810#nerve-plexus",
+  "name": "nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001810",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveRoot.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "description": "A continuation of the neuron projection bundle component of a nerve inside, crossing or immediately outside the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002211#nerve-root",
+  "name": "nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002211",
+  "synonym": [
+    "initial segment of nerve",
+    "radix nervi"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToQuadratusFemoris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984) ('is_a' and 'relationship')]",
+  "description": "The nerve to quadratus femoris is a nerve that provides innervation to the quadratus femoris and gemellus inferior muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034984#nerve-to-quadratus-femoris",
+  "name": "nerve to quadratus femoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034984",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToStylohyoidFromFacialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316) ('is_a' and 'relationship')]",
+  "description": "The stylohyoid branch of facial nerve frequently arises in conjunction with the digastric branch; it is long and slender, and enters the Stylohyoideus about its middle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011316#nerve-to-stylohyoid-from-facial-nerve",
+  "name": "nerve to stylohyoid from facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011316",
+  "synonym": [
+    "facial nerve stylohyoid branch",
+    "nerve to stylohyoid",
+    "ramus stylohyoideus",
+    "ramus stylohyoideus nervus facialis",
+    "stylodigastric nerve",
+    "stylohyoid branch of facial nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317) ('is_a' and 'relationship')]",
+  "description": "The stylopharyngeal branch of glossopharyngeal nerve is distributed to the Stylopharyngeus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011317#nerve-to-stylopharyngeus-from-glossopharyngeal-nerve",
+  "name": "nerve to stylopharyngeus from glossopharyngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011317",
+  "synonym": [
+    "branch of glossopharyngeal nerve to stylopharyngeus",
+    "nerve to stylopharyngeus",
+    "ramus musculi stylopharyngei nervus glossopharyngei",
+    "stylopharyngeal branch of glossopharyngeal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. Is part of the nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002464) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002464#nerve-trunk",
+  "name": "nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002464",
+  "synonym": [
+    "peripheral nerve trunk",
+    "trunk of nerve",
+    "trunk of peripheral nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusOfPhrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "description": "Neuron cell bodies located in the more medial portions of the anterior horn at cervical levels C3-C7 that innervate the diaphragm via the phrenic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016850#nucleus-of-phrenic-nerve",
+  "name": "nucleus of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016850",
+  "synonym": [
+    "phrenic neural nucleus",
+    "phrenic nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusOfPudendalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. Is part of the ventral horn of spinal cord and the sacral spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the ventral part of the anterior horn of the sacral region of the spinal cord that is the origin of the pudendal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022278#nucleus-of-pudendal-nerve",
+  "name": "nucleus of pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022278",
+  "synonym": [
+    "nucleus of Onuf",
+    "Onuf's nucleus",
+    "pudendal neural nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/obturatorNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/obturatorNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/obturatorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465) ('is_a' and 'relationship')]",
+  "description": "The obturator nerve arises from the ventral divisions of the second, third, and fourth lumbar nerves; the branch from the third is the largest, while that from the second is often very small. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005465#obturator-nerve",
+  "name": "obturator nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005465",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/octavalNerveMotorNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "description": "Hindbrain nucleus which consists of cell bodies whose axons exit the hindbrain via cranial nerve VIII and innervate hair cells of the lateral line and inner ear. The neurons of these nuclei are unusual in that they extend both contra- and ipsilateral dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002174#octaval-nerve-motor-nucleus",
+  "name": "octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002174",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/octavalNerveSensoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000401#octaval-nerve-sensory-nucleus",
+  "name": "octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000401",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/oculomotorNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/oculomotorNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oculomotorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "description": "Cranial nerve which connects the midbrain to the extra-ocular and intra-ocular muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001643#oculomotor-nerve-1",
+  "name": "oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001643",
+  "synonym": [
+    "nervus oculomotorius",
+    "nervus oculomotorius [III]",
+    "oculomotor III",
+    "oculomotor III nerve",
+    "oculomotor nerve [III]",
+    "oculomotor nerve tree",
+    "third cranial nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oculomotorNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Oculomotor nerve root' is a root of cranial nerve. It is part of the midbrain tegmentum.",
-  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain.",
+  "definition": "Is a root of cranial nerve. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668) ('is_a' and 'relationship')]",
+  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107898",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002668#oculomotor-nerve-fibers",
   "name": "oculomotor nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002668",
   "synonym": [
-    "3nf",
     "central part of oculomotor nerve",
-    "fibrae nervi oculomotorii",
     "oculomotor nerve fibers",
-    "oculomotor nerve tract",
     "root of oculomotor nerve"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulbOuterNerveLayer",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory bulb outer nerve layer' is an olfactory bulb layer.",
-  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
+  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107942",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005978#olfactory-bulb-main-olfactory-nerve-layer",
   "name": "olfactory bulb outer nerve layer",
@@ -15,3 +15,4 @@
     "olfactory bulb olfactory nerve layer"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "description": "Nerve that carries information from the olfactory epithelium to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001579#olfactory-nerve-1",
+  "name": "olfactory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001579",
+  "synonym": [
+    "first cranial nerve",
+    "nervus olfactorius [i]",
+    "olfactory I",
+    "olfactory i nerve",
+    "olfactory nerve [I]"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ophthalmicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348) ('is_a' and 'relationship')]",
+  "description": "The sensory nerve subdivision of the trigeminal nerve that transmits sensory information from the orbit and its contents, the nasal cavity and the skin of the nose and forehead. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000348#ophthalmic-nerve",
+  "name": "ophthalmic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000348",
+  "synonym": [
+    "cranial nerve V, branch V1",
+    "first branch of fifth cranial nerve",
+    "first division of fifth cranial nerve",
+    "first division of trigeminal nerve",
+    "nervus ophthalmicus (V1)",
+    "nervus ophthalmicus (Va)",
+    "nervus ophthalmicus [v1]",
+    "nervus ophthalmicus [va]",
+    "ophthalmic division [V1]",
+    "ophthalmic division [Va]",
+    "ophthalmic division of fifth cranial nerve",
+    "ophthalmic division of trigeminal nerve (V1)",
+    "ophthalmic division of trigeminal nerve (Va)",
+    "ophthalmic nerve [V1]",
+    "ophthalmic nerve [Va]",
+    "opthalmic nerve",
+    "ramus opthalmicus profundus (ramus V1)",
+    "rostral branch of trigeminal nerve",
+    "trigeminal V nerve ophthalmic division"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palmarBranchOfMedianNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the median nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430) ('is_a' and 'relationship')]",
+  "description": "The palmar branch of the median nerve is a branch of the median nerve which arises at the lower part of the forearm and innervates skin of proximal central palm and thenar eminence. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016430#palmar-branch-of-median-nerve",
+  "name": "palmar branch of median nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016430",
+  "synonym": [
+    "median nerve palmar branch",
+    "palmar branch of anterior interosseous nerve",
+    "palmar cutaneous branch of median nerve",
+    "ramus palmaris (nervus medianus)",
+    "ramus palmaris nervus interossei antebrachii anterior"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an eyelid nerve and nerve of head region. Is part of the infra-orbital nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates an eyelid and is a branch of the infra-orbital branch of the maxillary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022297#palpebral-branch-of-infra-orbital-nerve",
+  "name": "palpebral branch of infra-orbital nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022297",
+  "synonym": [
+    "palpebral branch of maxillary nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293) ('is_a' and 'relationship')]",
+  "description": "A nerve that is part of a parasympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004293#parasympathetic-nerve",
+  "name": "parasympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004293",
+  "synonym": [
+    "nerve of parasympathetic nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pedalDigitNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pes nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "description": "A nerve that is part of a toe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003435#pedal-digit-nerve",
+  "name": "pedal digit nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003435",
+  "synonym": [
+    "digit of foot nerve",
+    "digit of terminal segment of free lower limb nerve",
+    "digitus pedis nerve",
+    "foot digit nerve",
+    "hind limb digit nerve",
+    "nerve of digit of foot",
+    "nerve of digit of terminal segment of free lower limb",
+    "nerve of digitus pedis",
+    "nerve of foot digit",
+    "nerve of terminal segment of free lower limb digit",
+    "nerve of toe",
+    "terminal segment of free lower limb digit nerve",
+    "toe nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvicSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and parasympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "description": "A splanchnic nerves that arises from sacral spinal nerves S2, S3, S4 to provide parasympathetic innervation to the hindgut. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018675#pelvic-splanchnic-nerve",
+  "name": "pelvic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018675",
+  "synonym": [
+    "pelvic splanchnic parasympathetic nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pelvisNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pelvisNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvisNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of abdominal segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "description": "A nerve that is part of a pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003444#pelvis-nerve",
+  "name": "pelvis nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003444",
+  "synonym": [
+    "nerve of pelvis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/perinealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/perinealNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perinealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the pudendal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391) ('is_a' and 'relationship')]",
+  "description": "A nerve arising from the pudendal nerve that supplies the perineum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011391#perineal-nerve",
+  "name": "perineal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011391",
+  "synonym": [
+    "perineal branch of pudendal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pesNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pesNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pesNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a hindlimb nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "description": "A nerve that is part of a foot. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003445#pes-nerve",
+  "name": "pes nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003445",
+  "synonym": [
+    "foot nerve",
+    "nerve of foot"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealBranchOfVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929) ('is_a' and 'relationship')]",
+  "description": "Motor nerve of the pharynx, arises from the upper part of the ganglion nodosum, and consists principally of filaments from the cranial portion of the accessory nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000929#pharyngeal-branch-of-vagus-nerve",
+  "name": "pharyngeal branch of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000929",
+  "synonym": [
+    "pharyngeal branch",
+    "pharyngeal branch of inferior vagal ganglion",
+    "pharyngeal branch of vagus",
+    "ramus pharyngealis nervi vagalis",
+    "ramus pharyngeus",
+    "ramus pharyngeus",
+    "tenth cranial nerve pharyngeal branch",
+    "vagal pharyngeal branch",
+    "vagus nerve pharyngeal branch"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "description": "The pharyngeal plexus is a network of nerve fibers innervating most of the palate, larynx, and pharynx. It is located on the surface of the middle pharyngeal constrictor muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011325#pharyngeal-nerve-plexus",
+  "name": "pharyngeal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011325",
+  "synonym": [
+    "pharyngeal nerve plexus",
+    "pharyngeal plexus of vagus nerve",
+    "plexus pharyngeus nervi vagi",
+    "vagus nerve pharyngeal plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/phrenicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/phrenicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/phrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic cavity nerve. Is part of the nerve of cervical vertebra. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884) ('is_a' and 'relationship')]",
+  "description": "A nerve that arises from the caudal cervical nerves and is primarily the motor nerve of the diaphragm but also sends sensory fibers to the pericardium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001884#phrenic-nerve",
+  "name": "phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001884",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/plantarNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/plantarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/plantarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates the sole of the foot. Planar nerves arise from the posterior branch of the tibial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035109#plantar-nerve",
+  "name": "plantar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035109",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorAuricularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve innervating pinna. Is part of the cervical nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647) ('is_a' and 'relationship')]",
+  "description": "A branch of the facial nerve that innervates the posterior auricular and intrinsic muscles of the auricle and, through its occipital branch, innervates the occipital belly of the occipitofrontal muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035647#posterior-auricular-nerve",
+  "name": "posterior auricular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035647",
+  "synonym": [
+    "auricularis posterior branch of facial nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "description": "Cranial nerve which enters the brain between cranial nerves VIII and IX; contains afferents and sensory efferents to the posterior lateral line ganglion and middle ganglion. Fibers from the posterior lateral line ganglion innervate the occipital dorsal lateral line and trunk lateral lines. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000175#posterior-lateral-line-nerve",
+  "name": "posterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000175",
+  "synonym": [
+    "caudal lateral line nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineNervePLLN",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "description": "Sensory nerve of the posterior lateral line component. It develops from de postotic posterior placode. PLLN innervates the trunk lines of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010115#posterior-lateral-line-nerve-plln",
+  "name": "posterior lateral line nerve (PLLN)",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010115",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorSuperiorAlveolarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a superior alveolar nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "description": "The posterior superior alveolar branches (posterior superior dental branches) arise from the trunk of the maxillary nerve just before it enters the infraorbital groove; they are generally two in number, but sometimes arise by a single trunk. They descend on the tuberosity of the maxilla and give off several twigs to the gums and neighboring parts of the mucous membrane of the cheek. They then enter the posterior alveolar canals on the infratemporal surface of the maxilla, and, passing from behind forward in the substance of the bone, communicate with the middle superior alveolar nerve, and give off branches to the lining membrane of the maxillary sinus and gingival and dental branches to each molar tooth from a superior dental plexus; these branches enter the apical foramina at the roots of the teeth. The posterior superior alveolar nerve innervates the second and third maxillary molars, and two of the three roots of the maxillary first molar (all but the mesiobuccal root). When giving a Posterior Superior Alveolar nerve block, it will anesthetize the mesialbuccal root of the maxillary first molar approximately 72% of the time. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018401#posterior-superior-alveolar-nerve",
+  "name": "posterior superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018401",
+  "synonym": [
+    "posterior superior dental nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryDorsalNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "description": "A nerve cord in the dorsal mid-line that is the most prominent nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005054#primary-dorsal-nerve-cord",
+  "name": "primary dorsal nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005054",
+  "synonym": [
+    "dorsal nerve cord",
+    "true dorsal nerve cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/primaryNerveCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primaryNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "description": "A cluster of neurons that is the most prominent longitudinally extending condensed part of a nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005053#primary-nerve-cord",
+  "name": "primary nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005053",
+  "synonym": [
+    "nerve cord",
+    "true nerve cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
@@ -4,11 +4,25 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Principal sensory nucleus of trigeminal nerve' is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. It is part of the pontine tegmentum.",
-  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [WP,unvetted].",
+  "definition": "Is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597) ('is_a' and 'relationship')]",
+  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109355",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002597#principal-sensory-nucleus-of-trigeminal-nerve-1",
   "name": "principal sensory nucleus of trigeminal nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002597",
-  "synonym": null
+  "synonym": [
+    "chief sensory nucleus",
+    "main sensory nucleus",
+    "main sensory nucleus of cranial nerve v",
+    "principal sensory nucleus",
+    "principal sensory nucleus of trigeminal nerve",
+    "principal sensory trigeminal nucleus",
+    "principal trigeminal nucleus",
+    "superior trigeminal nucleus",
+    "superior trigeminal sensory nucleus",
+    "trigeminal nerve superior sensory nucleus",
+    "trigeminal V chief sensory nucleus",
+    "trigeminal V principal sensory nucleus"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pterygopalatineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725) ('is_a' and 'relationship')]",
+  "description": "The pharyngeal nerve (pterygopalatine nerve) is a small branch arising from the posterior part of the pterygopalatine ganglion. It passes through the pharyngeal canal with the pharyngeal branch of the maxillary artery, and is distributed to the mucous membrane of the nasal part of the pharynx, behind the auditory tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034725#pterygopalatine-nerve",
+  "name": "pterygopalatine nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034725",
+  "synonym": [
+    "ganglionic branch of maxillary nerve to pterygopalatine ganglion",
+    "pterygopalatine nerve",
+    "radix sensoria ganglii pterygopalatini",
+    "sensory root of pterygopalatine ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pudendalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pudendalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pudendalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390) ('is_a' and 'relationship')]",
+  "description": "The pudendal nerve is a somatic nerve in the pelvic region that innervates the external genitalia of both sexes, as well as sphincters for the bladder and the rectum. It originates in Onuf's nucleus in the sacral region of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011390#pudendal-nerve",
+  "name": "pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011390",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pulmonaryNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009) ('is_a' and 'relationship')]",
+  "description": "The pulmonary plexus is an autonomic plexus formed from pulmonary branches of vagus nerve and the sympathetic trunk that supplies the Bronchial tree. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002009#pulmonary-nerve-plexus",
+  "name": "pulmonary nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002009",
+  "synonym": [
+    "plexus pulmonalis",
+    "pulmonary plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/radialNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/radialNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492) ('is_a' and 'relationship')]",
+  "description": "A nerve that supplies the upper limb, including the triceps brachii muscle of the arm, as well as all 12 muscles in the posterior osteofascial compartment of the forearm, as well as the associated joints and overlying skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001492#radial-nerve",
+  "name": "radial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001492",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusAuricularisOfTheVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "description": "An afferent branch of the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010740#ramus-auricularis-of-the-vagus-nerve",
+  "name": "ramus auricularis of the vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010740",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726) ('is_a' and 'relationship')]",
+  "description": "Branchiomotor branch of the glossopharyngeus nerve innervating the m. subarcuales rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010726#ramus-muscularis-of-glossopharyngeus-nerve",
+  "name": "ramus muscularis of glossopharyngeus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010726",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMuscularisOfVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ramus recurrens. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751) ('is_a' and 'relationship')]",
+  "description": "Motor nervous branch of the vagus innervating m. subarcualis rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010751#ramus-muscularis-of-vagus-nerve",
+  "name": "ramus muscularis of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010751",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/recurrentLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716) ('is_a' and 'relationship')]",
+  "description": "A branch of the vagus nerve that supplies motor function and sensation to the larynx (voice box). It travels within the endoneurium. It is the nerve of the 6th Branchial Arch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003716#recurrent-laryngeal-nerve",
+  "name": "recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003716",
+  "synonym": [
+    "nervus laryngeus recurrens",
+    "recurrent laryngeal nerve from vagus nerve",
+    "vagus X nerve recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/renalNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/renalNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/renalNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "description": "The renal plexus is formed by filaments from the celiac plexus, the aorticorenal ganglion, and the aortic plexus. It is joined also by the least splanchnic nerve. The nerves from these sources, fifteen or twenty in number, have a few ganglia developed upon them. They accompany the branches of the renal artery into the kidney; some filaments are distributed to the spermatic plexus and, on the right side, to the inferior vena cava. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018676#renal-nerve-plexus",
+  "name": "renal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018676",
+  "synonym": [
+    "plexus renalis",
+    "renal plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightRecurrentLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a recurrent laryngeal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011767)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011767#right-recurrent-laryngeal-nerve",
+  "name": "right recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011767",
+  "synonym": [
+    "right recurrent laryngeal branch",
+    "right recurrent laryngeal nerve",
+    "vagus X nerve right recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightVagusXNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035021)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035021#right-vagus-x-nerve-trunk",
+  "name": "right vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035021",
+  "synonym": [
+    "right vagus neural trunk",
+    "trunk of right vagus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfAbducensNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Root of abducens nerve' is a root of cranial nerve. It is part of the medulla oblongata.",
-  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum",
+  "definition": "Is a root of cranial nerve. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100173",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002786#abducens-nerve-fibers",
   "name": "root of abducens nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002786",
   "synonym": [
     "abducens nerve fibers",
-    "abducens nerve root",
     "abducens nerve tract",
-    "abducens nerve/root",
     "central part of abducens nerve",
-    "fibrae nervi abducentis",
     "root of abducens nerve"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCervicalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009632)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009632#nerve-root-part-of-cervical-spinal-cord",
+  "name": "root of cervical nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009632",
+  "synonym": [
+    "cervical neural root",
+    "cervical spinal root",
+    "nerve root part of cervical spinal cord",
+    "root of cervical spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCoccygealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "description": "A spinal nerve root that is part of a coccygeal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009634#root-of-coccygeal-nerve",
+  "name": "root of coccygeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009634",
+  "synonym": [
+    "coccygeal neural root",
+    "coccygeal spinal nerve root",
+    "root of coccygeal spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCranialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "description": "The initial segment of a cranial nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006843#root-of-cranial-nerve",
+  "name": "root of cranial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006843",
+  "synonym": [
+    "cranial nerve root",
+    "cranial neural root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfLumbarSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "description": "A spinal nerve root that is part of a lumbar nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009631#nerve-root-part-of-lumbar-spinal-cord",
+  "name": "root of lumbar spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009631",
+  "synonym": [
+    "lumbar spinal nerve root",
+    "lumbar spinal neural root",
+    "nerve root part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfOlfactoryNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The initial segment of an olfactory nerve, leaving the central nervous system.",
-  "description": "'Root of olfactory nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
+  "description": "The initial segment of an olfactory nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727253",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019311#olfactory-nerve-root",
   "name": "root of olfactory nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019311",
-  "synonym": null
+  "synonym": [
+    "olfactory nerve root"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfOpticNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A nerve root that extends_fibers_into a nerve connecting eye with brain.",
-  "description": "'Root of optic nerve' is a root of cranial nerve.",
+  "definition": "Is a root of cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
+  "description": "A nerve root that extends fibers into a nerve connecting eye with brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728874",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009906#optic-nerve-root",
   "name": "root of optic nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009906",
-  "synonym": null
+  "synonym": [
+    "optic nerve root",
+    "optic tract root",
+    "root of optic tract"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfSacralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "description": "A spinal nerve root that is part of a sacral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009633#nerve-root-part-of-sacral-spinal-cord",
+  "name": "root of sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009633",
+  "synonym": [
+    "nerve root part of sacral spinal cord",
+    "root of sacral spinal nerve",
+    "sacral neural root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfThoracicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "description": "A spinal nerve root that is part of a thoracic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009630#nerve-root-part-of-thoracic-spinal-cord",
+  "name": "root of thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009630",
+  "synonym": [
+    "nerve root part of thoracic spinal cord",
+    "thoracic nerve root",
+    "thoracic neural root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
@@ -4,20 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfTrochlearNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Root of trochlear nerve' is a root of cranial nerve. It is part of the brainstem.",
-  "description": "",
+  "definition": "Is a root of cranial nerve. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002618) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112003",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002618#trochlear-nerve-fibers",
   "name": "root of trochlear nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002618",
   "synonym": [
-    "4nf",
     "central part of trochlear nerve",
-    "fibrae nervi trochlearis",
     "trochlear nerve fibers",
-    "trochlear nerve or its root",
     "trochlear nerve root",
-    "trochlear nerve tract",
-    "trochlear nerve/root"
+    "trochlear nerve tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfVagusNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A root of cranial nerve that is part of a vagus nerve.",
-  "description": "'Root of vagus nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
+  "description": "A root of cranial nerve that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731734",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011213#vagus-nerve-root",
   "name": "root of vagus nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011213",
-  "synonym": null
+  "synonym": [
+    "rootlet of vagus nerve",
+    "vagal root",
+    "vagus nerve root",
+    "vagus root"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralOctavalNerveMotorNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an octaval nerve motor nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002175#rostral-octaval-nerve-motor-nucleus",
+  "name": "rostral octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002175",
+  "synonym": [
+    "ROLE",
+    "rostral cranial nerve VIII motor nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralOctavalNerveSensoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an octaval nerve sensory nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000274)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000274#rostral-octaval-nerve-sensory-nucleus",
+  "name": "rostral octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000274",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralRootOfAbducensNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of abducens nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009909)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009909#rostral-root-of-abducens-nerve",
+  "name": "rostral root of abducens nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009909",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "description": "The five sacral nerves emerge from the sacrum. Although the vertebral components of the sacrum are fused into a single bone, the sacral vertebrae are still used to number the sacral nerves. Posteriorly, they emerge from the posterior sacral foramina, and form the posterior branches of sacral nerves. Anteriorly, they emerge from the anterior sacral foramina, and contribute to the sacral plexus (S1-S4) and coccygeal plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009625#sacral-nerve",
+  "name": "sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009625",
+  "synonym": [
+    "nervus sacralis",
+    "sacral spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbosacral nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "description": "A nerve plexus which provides motor and sensory nerves for the posterior thigh, most of the lower leg, the entire foot, and part of the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034986#sacral-nerve-plexus",
+  "name": "sacral nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034986",
+  "synonym": [
+    "plexus sacralis",
+    "sacral plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "description": "A splanchnic nerve that connects the inferior hypogastric plexus to the sympathetic trunk in the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018684#sacral-splanchnic-nerve",
+  "name": "sacral splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018684",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034902)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034902#sacral-sympathetic-nerve-trunk",
+  "name": "sacral sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034902",
+  "synonym": [
+    "sacral part of sympathetic trunk",
+    "sacral sympathetic chain",
+    "sacral sympathetic trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/saphenousNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/saphenousNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/saphenousNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the femoral nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475) ('is_a' and 'relationship')]",
+  "description": "The largest cutaneous branch of the femoral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002475#saphenous-nerve",
+  "name": "saphenous nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002475",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sciaticNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sciaticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sciaticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322) ('is_a' and 'relationship')]",
+  "description": "A large nerve that supplies nearly the whole of the skin of the leg, the muscles of the back of the thigh, and those of the leg and foot. It begins in the lower back and runs through the buttock and down the lower limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001322#sciatic-nerve-1",
+  "name": "sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001322",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/segmentalSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005197)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005197#segmental-spinal-nerve",
+  "name": "segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005197",
+  "synonym": [
+    "cervical segmental spinal nerves C1-7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "description": "A nerve that transmits from sensory receptors on the surface of the body to the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001027#sensory-nerve",
+  "name": "sensory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001027",
+  "synonym": [
+    "nervus sensorius"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryRootOfFacialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a facial nerve root. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699) ('is_a' and 'relationship')]",
+  "description": "The nervus intermedius, or intermediate nerve, is the part of the facial nerve (cranial nerve VII) located between the motor component of the facial nerve and the vestibulocochlear nerve (cranial nerve VIII). It contains the sensory and parasympathetic fibers of the facial nerve. Upon reaching the facial canal, it joins with the motor root of the facial nerve at the geniculate ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001699#sensory-root-of-facial-nerve",
+  "name": "sensory root of facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001699",
+  "synonym": [
+    "sensory component of the VIIth (facial) nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryRootOfTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009907)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009907#sensory-root-of-trigeminal-nerve",
+  "name": "sensory root of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009907",
+  "synonym": [
+    "radix sensoria (nervus trigeminus [v])",
+    "radix sensoria nervus trigemini"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/shortCiliaryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an iris nerve, parasympathetic nerve and nerve of head region. Is part of the main ciliary ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302) ('is_a' and 'relationship')]",
+  "description": "A branch of the ciliary ganglion that innervates the ciliary muscles, the iris, and the tunics of the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022302#short-ciliary-nerve",
+  "name": "short ciliary nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022302",
+  "synonym": [
+    "lower branch of ciliary ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/shoulderNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/shoulderNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/shoulderNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "description": "A nerve that is part of a shoulder. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003436#shoulder-nerve",
+  "name": "shoulder nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003436",
+  "synonym": [
+    "nerve of shoulder"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "description": "The any of the paired peripheral nerves formed by the union of the dorsal and ventral spinal roots from each spinal cord segment. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001780#spinal-nerve",
+  "name": "spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001780",
+  "synonym": [
+    "backbone nerve",
+    "nerve of backbone",
+    "nerve of spinal column",
+    "nerve of spine",
+    "nerve of vertebral column",
+    "spinal column nerve",
+    "spinal nerve tree",
+    "spine nerve",
+    "vertebral column nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "description": "An intermingling of fiber fascicles from adjacent spinal nerves to form a network. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001813#spinal-nerve-plexus",
+  "name": "spinal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001813",
+  "synonym": [
+    "plexus nervorum spinalium",
+    "plexus of spinal nerves",
+    "somatic nerve plexus",
+    "spinal nerve plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "description": "The paired bundles of nerve fibers entering and leaving the spinal cord at each segment. The dorsal and ventral nerve roots join to form the mixed segmental spinal nerves. The dorsal roots are generally afferent, formed by the central projections of the spinal (dorsal root) ganglia sensory cells, and the ventral roots efferent, comprising the axons of spinal motor and autonomic preganglionic neurons. There are, however, some exceptions to this afferent/efferent rule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009623#spinal-nerve-root",
+  "name": "spinal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009623",
+  "synonym": [
+    "root of spinal nerve",
+    "spinal neural root",
+    "spinal root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476) ('is_a' and 'relationship')]",
+  "description": "Trunk part of spinal nerve, where dorsal and ventral roots meet to form the spinal nerve, before branching off to dorsal and ventral rami. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005476#spinal-nerve-trunk",
+  "name": "spinal nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005476",
+  "synonym": [
+    "spinal nerve (trunk)",
+    "spinal neural trunk",
+    "trunk of spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNucleusOfTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal sensory nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "description": "Nucleus extending from the upper spinal cord through the pontine tegmentum that receives sensory inputs from the trigeminal nerve. It is continuous caudally with the dorsal gray matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001717#spinal-nucleus-of-trigeminal-nerve",
+  "name": "spinal nucleus of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001717",
+  "synonym": [
+    "spinal nucleus of cranial nerve v",
+    "spinal trigeminal nucleus",
+    "trigeminal nerve spinal tract nucleus",
+    "trigeminal spinal nucleus",
+    "trigeminal v spinal sensory nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/splanchnicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/splanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/splanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "description": "The major nerves supplying sympathetic innervation to the abdomen, including the greater, lesser, and lowest (or smallest) splanchnic nerves that are formed by preganglionic fibers from the spinal cord which pass through the paravertebral ganglia and then to the celiac ganglia and plexuses and the lumbar splanchnic nerves carry fibers which pass through the lumbar paravertebral ganglia to the mesenteric and hypogastric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003715#splanchnic-nerve",
+  "name": "splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003715",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/submucousNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an enteric plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "description": "The gangliated plexus of unmyelinated nerve fibers that ramify the stomach and intestinal submucosa. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005304#submucous-nerve-plexus",
+  "name": "submucous nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005304",
+  "synonym": [
+    "submucosal nerve plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superficialFibularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve and fibular nerve. Is part of the common fibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526) ('is_a' and 'relationship')]",
+  "description": "A branch of the common fibular nerve that innervates the fibularis longus and brevis muscles, and via branches innervates parts of the dorsal part of the pes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035526#superficial-fibular-nerve",
+  "name": "superficial fibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035526",
+  "synonym": [
+    "superficial peroneal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorAlveolarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018398) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018398#superior-alveolar-nerve",
+  "name": "superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018398",
+  "synonym": [
+    "superior dental nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorBranchOfOculomotorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the oculomotor nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162) ('is_a' and 'relationship')]",
+  "description": "The superior branch of the oculomotor nerve or the superior division, the smaller, passes medialward over the optic nerve. It supplies the Superior rectus and Levator palpebrae superioris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015162#superior-branch-of-oculomotor-nerve",
+  "name": "superior branch of oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015162",
+  "synonym": [
+    "oculomotor nerve superior division",
+    "ramus superior (nervus oculomotorius [III])",
+    "ramus superior nervi oculomotorii",
+    "ramus superior nervus oculomotorii",
+    "superior ramus of oculomotor nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorHypogastricNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "description": "The superior hypogastric plexus (in older texts, hypogastric plexus or presacral nerve) is a plexus of nerves situated on the vertebral bodies below the bifurcation of the aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002013#superior-hypogastric-nerve-plexus",
+  "name": "superior hypogastric nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002013",
+  "synonym": [
+    "nervus presacralis",
+    "plexus hypogastricus superior",
+    "presacral nerve",
+    "superior hypogastric plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326) ('is_a' and 'relationship')]",
+  "description": "The superior laryngeal nerve is a branch of the vagus nerve. It arises from the middle of the ganglion nodosum and in its course receives a branch from the superior cervical ganglion of the sympathetic. It descends, by the side of the pharynx, behind the internal carotid artery, and divides into two branches: external laryngeal nerve internal laryngeal nerve A superior laryngeal nerve palsy changes the pitch of the voice and causes an inability to make explosive sounds. If no recovery is evident three months after the palsy initially presents, the damage is most likely to be permanent. A bilateral palsy presents as a tiring and hoarse voice. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011326#superior-laryngeal-nerve",
+  "name": "superior laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011326",
+  "synonym": [
+    "nervus laryngealis superior",
+    "nervus laryngeus superior",
+    "superior laryngeal branch of inferior vagal ganglion",
+    "superior laryngeal branch of vagus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/suralNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/suralNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/suralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488) ('is_a' and 'relationship')]",
+  "description": "The sural nerve (short saphenous nerve), formed by the junction of the medial sural cutaneous with the peroneal anastomotic branch of the lateral sural cutaneous nerve, passes downward near the lateral margin of the tendo calcaneus, lying close to the small saphenous vein, to the interval between the lateral malleolus and the calcaneus. It runs forward below the lateral malleolus, and is continued as the lateral dorsal cutaneous nerve along the lateral side of the foot and little toe (via a dorsal digital nerve), communicating on the dorsum of the foot with the intermediate dorsal cutaneous nerve, a branch of the superficial peroneal. In the leg, its branches communicate with those of the posterior femoral cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015488#sural-nerve",
+  "name": "sural nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015488",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034729) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034729#sympathetic-nerve",
+  "name": "sympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034729",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373) ('is_a' and 'relationship')]",
+  "description": "A nerve plexus that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012373#sympathetic-nerve-plexus",
+  "name": "sympathetic nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012373",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004295#sympathetic-nerve-trunk",
+  "name": "sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004295",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system",
+    "nerve trunk of sympathetic part of autonomic division of nervous system",
+    "sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/terminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/terminalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/terminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "description": "The terminal nerve, located anterior to cranial nerve I, is comprised of a group of cells with somata adjacent to the olfactory bulb and processes that extend anteriorly to the olfactory epithelium and posteriorly to the telencephalon. In teleost fish an additional group of axons extends along the optic tract and delivers putative neuromodulators to the retina. It is thought to develop from cranial neural crest. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002924#terminal-nerve-1",
+  "name": "terminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002924",
+  "synonym": [
+    "cranial nerve 0",
+    "cranial nerve zero",
+    "nervus terminalis",
+    "terminalis nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/terminalNerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "description": "A nerve root that extends fibers into a terminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014641#terminal-nerve-root-1",
+  "name": "terminal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014641",
+  "synonym": [
+    "cranial nerve 0 root",
+    "root of terminal nerve",
+    "terminal nerve root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicCavityNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "description": "A nerve that is located in a thoracic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003443#thoracic-cavity-nerve",
+  "name": "thoracic cavity nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003443",
+  "synonym": [
+    "cavity of chest nerve",
+    "cavity of thorax nerve",
+    "chest cavity nerve",
+    "nerve of cavity of chest",
+    "nerve of cavity of thorax",
+    "nerve of chest cavity",
+    "nerve of pectoral cavity",
+    "nerve of thoracic cavity",
+    "pectoral cavity nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "description": "The twelve spinal nerves on each side of the thorax. They include eleven INTERCOSTAL NERVES and one subcostal nerve. Both sensory and motor, they supply the muscles and skin of the thoracic and abdominal walls. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003726#thoracic-nerve",
+  "name": "thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003726",
+  "synonym": [
+    "nervus thoracis",
+    "thoracic spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and nerve of thoracic segment. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679) ('is_a' and 'relationship')]",
+  "description": "Thoracic splanchnic nerves are splanchnic nerves that arise from the sympathetic trunk in the thorax and travel inferiorly to provide sympathetic innervation to the abdomen. The nerves contain preganglionic sympathetic and general visceral afferent fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018679#thoracic-splanchnic-nerve",
+  "name": "thoracic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018679",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "description": "A sympathetic nerve trunk that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004863#thoracic-sympathetic-nerve-trunk",
+  "name": "thoracic sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004863",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system of thorax",
+    "nerve trunk of sympathetic part of autonomic division of nervous system of thorax",
+    "sympathetic nerve trunk of thorax",
+    "sympathetic nervous system nerve trunk of thorax",
+    "thoracic part of sympathetic trunk",
+    "thoracic sympathetic chain",
+    "thorax nerve trunk of sympathetic nervous system",
+    "thorax nerve trunk of sympathetic part of autonomic division of nervous system",
+    "thorax sympathetic nerve trunk",
+    "thorax sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tibialNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tibialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tibialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323) ('is_a' and 'relationship')]",
+  "description": "The tibial nerve is a branch of the sciatic nerve. The tibial nerve passes through the popliteal fossa to pass below the arch of soleus. In the popliteal fossa the nerve gives off branches to gastrocnemius, popliteus, soleus and plantaris muscles, an articular branch to the knee joint, and a cutaneous branch that will become the sural nerve. The sural nerve is joined by fibres from the common peroneal nerve and runs down the calf to supply the lateral side of the foot. Below the soleus muscle the nerve lies close to the tibia and supplies the tibialis posterior, the flexor digitorum longus and the flexor hallucis longus. The nerve passes into the foot running posterior to the medial malleolus. Here it is bound down by the flexor retinaculum in company with the posterior tibial artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001323#tibial-nerve",
+  "name": "tibial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001323",
+  "synonym": [
+    "medial popliteal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trigeminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trigeminalNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "description": "Cranial nerve that has three branches - the ophthalmic (supplying the skin of the nose and upper jaw), the maxillary and the mandibular (supplying the lower jaw). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001645#trigeminal-nerve-1",
+  "name": "trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001645",
+  "synonym": [
+    "fifth cranial nerve",
+    "nervus trigeminus",
+    "nervus trigeminus [v]",
+    "trigeminal nerve [V]",
+    "trigeminal nerve tree",
+    "trigeminal V",
+    "trigeminal v nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerveFibers",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A nerve fiber that is part of a trigeminal nerve.",
-  "description": "'Trigeminal nerve fibers' is a nerve fiber. It is part of the trigeminal nerve.",
+  "definition": "Is a nerve fiber. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041) ('is_a' and 'relationship')]",
+  "description": "A nerve fiber that is part of a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111965",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003041#trigeminal-nerve-fibers-1",
   "name": "trigeminal nerve fibers",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003041",
   "synonym": [
     "central part of trigeminal nerve",
-    "fibrae nervi trigemini",
     "trigeminal nerve fibers",
     "trigeminal nerve tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
@@ -4,11 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Trigeminal nerve root' is a root of cranial nerve. It is part of the metencephalon.",
-  "description": "A nerve root that extends_fibers_into a trigeminal nerve.",
+  "definition": "Is a root of cranial nerve. Is part of the metencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673) ('is_a' and 'relationship')]",
+  "description": "A nerve root that extends fibers into a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111966",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004673#trigeminal-nerve-root-1",
   "name": "trigeminal nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004673",
-  "synonym": null
+  "synonym": [
+    "radix descendens nervi trigemini",
+    "root of trigeminal nerve",
+    "root of trigeminal V nerve",
+    "trigeminal nerve root",
+    "trigeminal neural root"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/trochlearNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trochlearNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trochlearNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "description": "A cranial nerve that runs to the eye muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001644#trochlear-nerve-1",
+  "name": "trochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001644",
+  "synonym": [
+    "cranial nerve IV",
+    "fourth cranial nerve",
+    "nervus trochlearis [IV]",
+    "superior oblique nerve",
+    "trochlear IV nerve",
+    "trochlear nerve [IV]",
+    "trochlear nerve tree"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfIntercostalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the intercostal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002327) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002327#trunk-of-intercostal-nerve",
+  "name": "trunk of intercostal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002327",
+  "synonym": [
+    "intercostal nerve trunk",
+    "intercostal neural trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfPhrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the phrenic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001889) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001889#trunk-of-phrenic-nerve",
+  "name": "trunk of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001889",
+  "synonym": [
+    "phrenic nerve trunk",
+    "phrenic neural trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfSciaticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002004) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002004#trunk-of-sciatic-nerve",
+  "name": "trunk of sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002004",
+  "synonym": [
+    "sciatic nerve trunk",
+    "sciatic neural trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfSegmentalSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the segmental spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035022) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035022#trunk-of-segmental-spinal-nerve",
+  "name": "trunk of segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035022",
+  "synonym": [
+    "segmental spinal nerve trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tympanicNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tympanicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tympanicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216) ('is_a' and 'relationship')]",
+  "description": "The tympanic nerve (nerve of Jacobson) is a branch of the glossopharyngeal nerve found near the ear. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036216#tympanic-nerve",
+  "name": "tympanic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036216",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ulnarNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ulnarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ulnarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494) ('is_a' and 'relationship')]",
+  "description": "A nerve which runs near the ulna bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001494#ulnar-nerve",
+  "name": "ulnar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001494",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/unmyelinatedNerveFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve fiber. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006136)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006136#unmyelinated-nerve-fiber",
+  "name": "unmyelinated nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006136",
+  "synonym": [
+    "non-myelinated nerve fiber"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/upperArmNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/upperArmNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperArmNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "description": "A nerve that is part of a forelimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004217#upper-arm-nerve",
+  "name": "upper arm nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004217",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperEyelidNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an eyelid nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "description": "A nerve that innervates an upper eyelid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022299#upper-eyelid-nerve",
+  "name": "upper eyelid nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022299",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/upperLegNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/upperLegNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperLegNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "description": "A nerve that is part of a hindlimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004214#upper-leg-nerve",
+  "name": "upper leg nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004214",
+  "synonym": [
+    "hind limb stylopod nerve",
+    "hindlimb stylopod nerve",
+    "lower extremity stylopod nerve",
+    "thigh RELATED"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
@@ -4,18 +4,21 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalNerveFiberBundle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Vagal nerve fiber bundle' is a neuron projection bundle and central nervous system cell part cluster. It is part of the medulla oblongata.",
-  "description": "",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006116) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112236",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006116#vagal-nerve-fiber-bundle-1",
   "name": "vagal nerve fiber bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006116",
   "synonym": [
     "central part of vagus nerve",
-    "fibrae nervi vagi",
+    "central part of vagus nerve",
+    "tenth cranial nerve fibers",
     "tenth cranial nerve fibers",
     "vagal nerve fiber bundle",
+    "vagal nerve fibers",
     "vagal nerve fibers",
     "vagal nerve tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/vagusNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagusNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "description": "Cranial nerve that branches into the lateral (to body sense organs) and the intestino-accessorial (to the skin, muscles of shoulder, hyoid, larynx, gut, lungs, and heart). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001759#vagus-nerve-1",
+  "name": "vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001759",
+  "synonym": [
+    "nervus vagus [x]",
+    "tenth cranial nerve",
+    "vagus",
+    "vagus nerve [X]",
+    "vagus nerve tree",
+    "vagus X nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusNerveNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "description": "A cranial nerve nucleus that is associated with a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011775#vagus-nerve-nucleus",
+  "name": "vagus nerve nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011775",
+  "synonym": [
+    "nucleus of vagal nerve",
+    "nucleus of vagal X nerve",
+    "nucleus of vagus nerve",
+    "nucleus of Xth nerve",
+    "tenth cranial nerve nucleus",
+    "vagal nucleus",
+    "vagal X nucleus",
+    "vagus nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusXNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003535#vagus-x-nerve-trunk",
+  "name": "vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003535",
+  "synonym": [
+    "trunk of vagal nerve",
+    "trunk of vagus nerve",
+    "vagal nerve trunk",
+    "vagal X nerve trunk",
+    "vagus nerve trunk",
+    "vagus neural trunk"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralAnteriorLateralLineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. Is part of the anterior lateral line nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers originating from the ventral anterior lateral line ganglion. These rami innervate the mandibular and opercular neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001481#ventral-anterior-lateral-line-nerve",
+  "name": "ventral anterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001481",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralMotorNucleusTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a motor nucleus of trigeminal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000703)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000703#ventral-motor-nucleus-trigeminal-nerve",
+  "name": "ventral motor nucleus trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000703",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralNerveCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralNerveCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "description": "The pair of closely united ventral longitudinal nerves with their segmental ganglia that is characteristic of many elongate invertebrates (as earthworms). A large process bundle that runs along the vental mid-line extending from the ventral region of the nerve ring. The ventral cord is one of the distinguishing traits of the central nervous system of all arthropods (such as insects, crustaceans and arachnids) as well as many other invertebrates, such as the annelid worms. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000934#ventral-nerve-cord",
+  "name": "ventral nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000934",
+  "synonym": [
+    "ventral cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral root of spinal cord and root of cervical nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "description": "A ventral root of spinal cord that overlaps a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014634#ventral-nerve-root-of-cervical-spinal-cord-1",
+  "name": "ventral nerve root of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014634",
+  "synonym": [
+    "ventral nerve root of cervical spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of lumbar spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024382)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024382#ventral-nerve-root-of-lumbar-spinal-cord-1",
+  "name": "ventral nerve root of lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024382",
+  "synonym": [
+    "ventral nerve root of lumbar spinal cord",
+    "ventral nerve root of lumbar spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfSacralSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of sacral nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023623)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023623#ventral-nerve-root-of-sacral-spinal-cord-1",
+  "name": "ventral nerve root of sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023623",
+  "synonym": [
+    "ventral nerve root of sacral spinal cord",
+    "ventral nerve root of sacral spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of thoracic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014617)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014617#ventral-nerve-root-of-thoracic-spinal-cord-1",
+  "name": "ventral nerve root of thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014617",
+  "synonym": [
+    "ventral nerve root of thoracic spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralRamusOfSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the spinal nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838) ('is_a' and 'relationship')]",
+  "description": "Branch of spinal nerve that innervates the hypaxial muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006838#ventral-ramus-of-spinal-nerve",
+  "name": "ventral ramus of spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006838",
+  "synonym": [
+    "anterior primary ramus of spinal nerve",
+    "anterior ramus of spinal nerve",
+    "ventral ramus of spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibularNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibularNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vestibulocochlear nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723) ('is_a' and 'relationship')]",
+  "description": "The vestibular nerve is one of the two branches of the Vestibulocochlear nerve (the cochlear nerve being the other). It goes to the semicircular canals via the vestibular ganglion. It receives positional information. Axons of the vestibular nerve synapse in the vestibular nucleus on the lateral floor and wall of the fourth ventricle in the pons and medulla. It arises from bipolar cells in the vestibular ganglion, ganglion of Scarpa, which is situated in the upper part of the outer end of the internal auditory meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003723#vestibular-nerve",
+  "name": "vestibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003723",
+  "synonym": [
+    "vestibular root of acoustic nerve",
+    "vestibular root of eighth cranial nerve",
+    "vestibulocochlear VIII nerve vestibular component"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "description": "Cranial nerve that transmits sound and equilibrium (balance) information from the inner ear to the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001648#vestibulocochlear-nerve-1",
+  "name": "vestibulocochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001648",
+  "synonym": [
+    "acoustic nerve",
+    "acoustic nerve (Crosby)",
+    "acoustic VIII nerve",
+    "CN-VIII",
+    "cochlear-vestibular nerve",
+    "cochleovestibular nerve",
+    "cranial nerve VIII",
+    "eighth cranial nerve",
+    "nervus vestibulocochlearis [viii]",
+    "stato-acoustic nerve",
+    "vestibulocochlear nerve [VIII]",
+    "vestibulocochlear nerve tree",
+    "vestibulocochlear VIII nerve",
+    "VIII nerve",
+    "VIIIth cranial nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Vestibulocochlear nerve root' is a root of cranial nerve. It is part of the pontine tegmentum.",
-  "description": "Either of the two roots that come of the vestibulocochlear nerve",
+  "definition": "Is a root of cranial nerve. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731) ('is_a' and 'relationship')]",
+  "description": "Either of the two roots that come of the vestibulocochlear nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112460",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002731#vestibulocochlear-nerve-fiber-bundle",
   "name": "vestibulocochlear nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002731",
   "synonym": [
-    "8cn",
     "central part of vestibulocochlear nerve",
     "fibrae nervi statoacustici",
     "root of vestibulocochlear nerve",
     "statoacoustic nerve fibers",
-    "vestibular root of vestibulocochlear nerve",
     "vestibulocochlear nerve fibers",
     "vestibulocochlear nerve roots",
     "vestibulocochlear nerve tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/vidianNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vidianNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vidianNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412) ('is_a' and 'relationship')]",
+  "description": "A nerve that is formed by the junction of the great petrosal nerve and the deep petrosal nerve and continues on to innervate the palate, nose and lacrimal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018412#vidian-nerve",
+  "name": "vidian nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018412",
+  "synonym": [
+    "nerve of pterygoid canal",
+    "pterygoid canal nerve",
+    "vidian nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vomeronasalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "description": "Nerve carrying fibers from the vomeronasal organ epithelium to the accessory olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009121#vomeronasal-nerve",
+  "name": "vomeronasal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009121",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wristNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wristNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wristNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a manus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "description": "A nerve that is part of a wrist. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003434#wrist-nerve",
+  "name": "wrist nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003434",
+  "synonym": [
+    "carpal region nerve",
+    "nerve of carpal region",
+    "nerve of wrist"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/zygomaticotemporalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264) ('is_a' and 'relationship')]",
+  "description": "The zygomaticotemporal nerve or zygomaticotemporal branch (temporal branch) is derived from the maxillary branch of the trigeminal nerve (Cranial nerve V). It runs along the lateral wall of the orbit in a groove in the zygomatic bone, receives a branch of communication from the lacrimal, and passes through zygomaticotemporal foramen in the zygomatic bone to enter the temporal fossa. It ascends between the bone, and substance of the Temporalis muscle, pierces the temporal fascia about 2.5 cm. above the zygomatic arch, and is distributed to the skin of the side of the forehead, and communicates with the facial nerve and with the auriculotemporal branch of the mandibular nerve. As it pierces the temporal fascia, it gives off a slender twig, which runs between the two layers of the fascia to the lateral angle of the orbit. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036264#zygomaticotemporal-nerve",
+  "name": "zygomaticotemporal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036264",
+  "synonym": [
+    "ramus zygomaticotemporalis (Nervus zygomaticus)",
+    "ramus zygomaticotemporalis nervus zygomatici",
+    "zygomaticotemporal branch of zygomatic nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/RuffiniNerveEnding",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "description": "An encapsulated nerve receptor present in subpapillary dermis and deep dermis of hairy and glabrous skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012457#ruffini-nerve-ending",
+  "name": "Ruffini nerve ending",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012457",
+  "synonym": [
+    "corpusculum sensorium fusiforme",
+    "Ruffini's corpuscle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013671)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013671#nerve-ending-of-of-corpus-cavernosum-maxillaris",
+  "name": "nerve ending of of corpus cavernosum maxillaris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013671",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveFasciculus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveFasciculus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveFasciculus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "description": "A slender neuron projection bundle; A bundle of anatomical fibers, as of muscle or nerve (American Heritage Dictionary 4th ed). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001019#fasciculus",
+  "name": "nerve fasciculus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001019",
+  "synonym": [
+    "fasciculus",
+    "nerve bundle",
+    "nerve fasciculus",
+    "neural fasciculus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveFiber.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nerve fasciculus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134) ('is_a' and 'relationship')]",
+  "description": "A threadlike extension of a nerve cell and consists of an axon and myelin sheath (if it is myelinated) in the nervous system. There are nerve fibers in the central nervous system and peripheral nervous system. A nerve fiber may be myelinated and/or unmyelinated. In the central nervous system (CNS), myelin by oligodendroglia cells is formed. Schwann cells form myelin in the peripheral nervous system (PNS). Schwann cells also make a thin covering in an axon without myelin (in the PNS). A peripheral nerve fiber contains an axon, myelin sheath, schwann cells and its endoneurium. There are no endoneurium and schwann cells in the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006134#nerve-fiber",
+  "name": "nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006134",
+  "synonym": [
+    "nerve fibre",
+    "neurofibra",
+    "neurofibrum"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveFiberLayerOfRetina",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina formed by expansion of the fibers of the optic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001793#nerve-fiber-layer-of-retina",
+  "name": "nerve fiber layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001793",
+  "synonym": [
+    "layer of nerve fibers of retina",
+    "layer of nerve fibres of retina",
+    "optic fiber layer",
+    "retina nerve fiber layer",
+    "stratum neurofibrarum (retina)",
+    "stratum neurofibrarum retinae",
+    "stratum opticum of retina"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveInnervatingPinna",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648) ('is_a' and 'relationship')]",
+  "description": "Any nerve that innervates the pinna. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035648#nerve-innervating-pinna",
+  "name": "nerve innervating pinna",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035648",
+  "synonym": [
+    "auricular nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfAbdominalSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "description": "A nerve that is part of an abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003825#nerve-of-abdominal-segment",
+  "name": "nerve of abdominal segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003825",
+  "synonym": [
+    "abdominal segment nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfCervicalVertebra",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "description": "The cervical nerves are the spinal nerves from the cervical vertebrae. Although there are seven cervical vertebrae (C1-C7), there are eight cervical nerves (C1-C8). All nerves except C8 emerge above their corresponding vertebrae, while the C8 nerve emerges below the C7 vertebra. (In the other portions of the spine, the nerve emerges below the vertebra with the same name. Dorsal (posterior) distribution includes the greater occipital (C2) and third occipital (C3). Ventral (anterior) distribution includes the cervical plexus (C1-C4) and brachial plexus (C5-C8). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000962#nerve-of-cervical-vertebra",
+  "name": "nerve of cervical vertebra",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000962",
+  "synonym": [
+    "cervical nerve",
+    "cervical nerve tree",
+    "cervical spinal nerve",
+    "nervus cervicalis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfClitoris",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "description": "Any nerve that innervates the clitoris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035650#nerve-of-clitoris",
+  "name": "nerve of clitoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035650",
+  "synonym": [
+    "clitoral nerve",
+    "clitoris nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfHeadRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "description": "A nerve that is part of a head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011779#nerve-of-head-region",
+  "name": "nerve of head region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011779",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfPenis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfPenis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfPenis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "description": "Any nerve that innervates the penis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035649#nerve-of-penis",
+  "name": "nerve of penis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035649",
+  "synonym": [
+    "penile nerve",
+    "penis nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfThoracicSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "description": "A nerve that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003824#nerve-of-thoracic-segment",
+  "name": "nerve of thoracic segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003824",
+  "synonym": [
+    "nerve of thorax",
+    "thoracic segment nerve",
+    "thorax nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfTrunkRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "description": "A nerve that is part of the trunk region of the body (not to be confused with a nerve trunk). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003439#nerve-of-trunk-region",
+  "name": "nerve of trunk region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003439",
+  "synonym": [
+    "nerve of torso",
+    "nerve of trunk",
+    "torso nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveOfTympanicCavity",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "description": "A nerve that is part of a tympanic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004116#nerve-of-tympanic-cavity",
+  "name": "nerve of tympanic cavity",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004116",
+  "synonym": [
+    "anatomical cavity of middle ear nerve",
+    "cavity of middle ear nerve",
+    "middle ear anatomical cavity nerve",
+    "middle ear cavity nerve",
+    "nerve of anatomical cavity of middle ear",
+    "nerve of cavity of middle ear",
+    "nerve of middle ear anatomical cavity",
+    "nerve of middle ear cavity",
+    "tympanic cavity nerve",
+    "tympanic cavity nerves"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural tissue. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "description": "Anatomical junction where subdivisions of two or more neural trees interconnect with one another to form a network through which nerve fibers of the constituent nerve trees become regrouped; together with other nerve plexuses, nerves and ganglia, it constitutes the peripheral nervous system. Examples: cervical nerve plexus, brachial nerve plexus, sacral nerve plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001810#nerve-plexus",
+  "name": "nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001810",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveRoot.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveRoot",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "description": "A continuation of the neuron projection bundle component of a nerve inside, crossing or immediately outside the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002211#nerve-root",
+  "name": "nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002211",
+  "synonym": [
+    "initial segment of nerve",
+    "radix nervi"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveToQuadratusFemoris",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984) ('is_a' and 'relationship')]",
+  "description": "The nerve to quadratus femoris is a nerve that provides innervation to the quadratus femoris and gemellus inferior muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034984#nerve-to-quadratus-femoris",
+  "name": "nerve to quadratus femoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034984",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveToStylohyoidFromFacialNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316) ('is_a' and 'relationship')]",
+  "description": "The stylohyoid branch of facial nerve frequently arises in conjunction with the digastric branch; it is long and slender, and enters the Stylohyoideus about its middle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011316#nerve-to-stylohyoid-from-facial-nerve",
+  "name": "nerve to stylohyoid from facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011316",
+  "synonym": [
+    "facial nerve stylohyoid branch",
+    "nerve to stylohyoid",
+    "ramus stylohyoideus",
+    "ramus stylohyoideus nervus facialis",
+    "stylodigastric nerve",
+    "stylohyoid branch of facial nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317) ('is_a' and 'relationship')]",
+  "description": "The stylopharyngeal branch of glossopharyngeal nerve is distributed to the Stylopharyngeus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011317#nerve-to-stylopharyngeus-from-glossopharyngeal-nerve",
+  "name": "nerve to stylopharyngeus from glossopharyngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011317",
+  "synonym": [
+    "branch of glossopharyngeal nerve to stylopharyngeus",
+    "nerve to stylopharyngeus",
+    "ramus musculi stylopharyngei nervus glossopharyngei",
+    "stylopharyngeal branch of glossopharyngeal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. Is part of the nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002464) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002464#nerve-trunk",
+  "name": "nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002464",
+  "synonym": [
+    "peripheral nerve trunk",
+    "trunk of nerve",
+    "trunk of peripheral nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nucleusOfPhrenicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "description": "Neuron cell bodies located in the more medial portions of the anterior horn at cervical levels C3-C7 that innervate the diaphragm via the phrenic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016850#nucleus-of-phrenic-nerve",
+  "name": "nucleus of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016850",
+  "synonym": [
+    "phrenic neural nucleus",
+    "phrenic nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nucleusOfPudendalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. Is part of the ventral horn of spinal cord and the sacral spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the ventral part of the anterior horn of the sacral region of the spinal cord that is the origin of the pudendal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022278#nucleus-of-pudendal-nerve",
+  "name": "nucleus of pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022278",
+  "synonym": [
+    "nucleus of Onuf",
+    "Onuf's nucleus",
+    "pudendal neural nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/obturatorNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/obturatorNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/obturatorNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465) ('is_a' and 'relationship')]",
+  "description": "The obturator nerve arises from the ventral divisions of the second, third, and fourth lumbar nerves; the branch from the third is the largest, while that from the second is often very small. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005465#obturator-nerve",
+  "name": "obturator nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005465",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/octavalNerveMotorNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "description": "Hindbrain nucleus which consists of cell bodies whose axons exit the hindbrain via cranial nerve VIII and innervate hair cells of the lateral line and inner ear. The neurons of these nuclei are unusual in that they extend both contra- and ipsilateral dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002174#octaval-nerve-motor-nucleus",
+  "name": "octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002174",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/octavalNerveSensoryNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000401#octaval-nerve-sensory-nucleus",
+  "name": "octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000401",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/oculomotorNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/oculomotorNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/oculomotorNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "description": "Cranial nerve which connects the midbrain to the extra-ocular and intra-ocular muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001643#oculomotor-nerve-1",
+  "name": "oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001643",
+  "synonym": [
+    "nervus oculomotorius",
+    "nervus oculomotorius [III]",
+    "oculomotor III",
+    "oculomotor III nerve",
+    "oculomotor nerve [III]",
+    "oculomotor nerve tree",
+    "third cranial nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/oculomotorNerveRoot",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Oculomotor nerve root' is a root of cranial nerve. It is part of the midbrain tegmentum.",
-  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain.",
+  "definition": "Is a root of cranial nerve. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668) ('is_a' and 'relationship')]",
+  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107898",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002668#oculomotor-nerve-fibers",
   "name": "oculomotor nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002668",
   "synonym": [
-    "3nf",
     "central part of oculomotor nerve",
-    "fibrae nervi oculomotorii",
     "oculomotor nerve fibers",
-    "oculomotor nerve tract",
     "root of oculomotor nerve"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryBulbOuterNerveLayer",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Olfactory bulb outer nerve layer' is an olfactory bulb layer.",
-  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
+  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107942",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005978#olfactory-bulb-main-olfactory-nerve-layer",
   "name": "olfactory bulb outer nerve layer",
@@ -15,3 +15,4 @@
     "olfactory bulb olfactory nerve layer"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "description": "Nerve that carries information from the olfactory epithelium to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001579#olfactory-nerve-1",
+  "name": "olfactory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001579",
+  "synonym": [
+    "first cranial nerve",
+    "nervus olfactorius [i]",
+    "olfactory I",
+    "olfactory i nerve",
+    "olfactory nerve [I]"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ophthalmicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348) ('is_a' and 'relationship')]",
+  "description": "The sensory nerve subdivision of the trigeminal nerve that transmits sensory information from the orbit and its contents, the nasal cavity and the skin of the nose and forehead. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000348#ophthalmic-nerve",
+  "name": "ophthalmic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000348",
+  "synonym": [
+    "cranial nerve V, branch V1",
+    "first branch of fifth cranial nerve",
+    "first division of fifth cranial nerve",
+    "first division of trigeminal nerve",
+    "nervus ophthalmicus (V1)",
+    "nervus ophthalmicus (Va)",
+    "nervus ophthalmicus [v1]",
+    "nervus ophthalmicus [va]",
+    "ophthalmic division [V1]",
+    "ophthalmic division [Va]",
+    "ophthalmic division of fifth cranial nerve",
+    "ophthalmic division of trigeminal nerve (V1)",
+    "ophthalmic division of trigeminal nerve (Va)",
+    "ophthalmic nerve [V1]",
+    "ophthalmic nerve [Va]",
+    "opthalmic nerve",
+    "ramus opthalmicus profundus (ramus V1)",
+    "rostral branch of trigeminal nerve",
+    "trigeminal V nerve ophthalmic division"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/palmarBranchOfMedianNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the median nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430) ('is_a' and 'relationship')]",
+  "description": "The palmar branch of the median nerve is a branch of the median nerve which arises at the lower part of the forearm and innervates skin of proximal central palm and thenar eminence. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016430#palmar-branch-of-median-nerve",
+  "name": "palmar branch of median nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016430",
+  "synonym": [
+    "median nerve palmar branch",
+    "palmar branch of anterior interosseous nerve",
+    "palmar cutaneous branch of median nerve",
+    "ramus palmaris (nervus medianus)",
+    "ramus palmaris nervus interossei antebrachii anterior"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an eyelid nerve and nerve of head region. Is part of the infra-orbital nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates an eyelid and is a branch of the infra-orbital branch of the maxillary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022297#palpebral-branch-of-infra-orbital-nerve",
+  "name": "palpebral branch of infra-orbital nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022297",
+  "synonym": [
+    "palpebral branch of maxillary nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parasympatheticNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293) ('is_a' and 'relationship')]",
+  "description": "A nerve that is part of a parasympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004293#parasympathetic-nerve",
+  "name": "parasympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004293",
+  "synonym": [
+    "nerve of parasympathetic nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pedalDigitNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a pes nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "description": "A nerve that is part of a toe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003435#pedal-digit-nerve",
+  "name": "pedal digit nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003435",
+  "synonym": [
+    "digit of foot nerve",
+    "digit of terminal segment of free lower limb nerve",
+    "digitus pedis nerve",
+    "foot digit nerve",
+    "hind limb digit nerve",
+    "nerve of digit of foot",
+    "nerve of digit of terminal segment of free lower limb",
+    "nerve of digitus pedis",
+    "nerve of foot digit",
+    "nerve of terminal segment of free lower limb digit",
+    "nerve of toe",
+    "terminal segment of free lower limb digit nerve",
+    "toe nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pelvicSplanchnicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and parasympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "description": "A splanchnic nerves that arises from sacral spinal nerves S2, S3, S4 to provide parasympathetic innervation to the hindgut. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018675#pelvic-splanchnic-nerve",
+  "name": "pelvic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018675",
+  "synonym": [
+    "pelvic splanchnic parasympathetic nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pelvisNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pelvisNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pelvisNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of abdominal segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "description": "A nerve that is part of a pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003444#pelvis-nerve",
+  "name": "pelvis nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003444",
+  "synonym": [
+    "nerve of pelvis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/perinealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/perinealNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/perinealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the pudendal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391) ('is_a' and 'relationship')]",
+  "description": "A nerve arising from the pudendal nerve that supplies the perineum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011391#perineal-nerve",
+  "name": "perineal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011391",
+  "synonym": [
+    "perineal branch of pudendal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pesNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pesNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pesNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a hindlimb nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "description": "A nerve that is part of a foot. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003445#pes-nerve",
+  "name": "pes nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003445",
+  "synonym": [
+    "foot nerve",
+    "nerve of foot"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pharyngealBranchOfVagusNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929) ('is_a' and 'relationship')]",
+  "description": "Motor nerve of the pharynx, arises from the upper part of the ganglion nodosum, and consists principally of filaments from the cranial portion of the accessory nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000929#pharyngeal-branch-of-vagus-nerve",
+  "name": "pharyngeal branch of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000929",
+  "synonym": [
+    "pharyngeal branch",
+    "pharyngeal branch of inferior vagal ganglion",
+    "pharyngeal branch of vagus",
+    "ramus pharyngealis nervi vagalis",
+    "ramus pharyngeus",
+    "ramus pharyngeus",
+    "tenth cranial nerve pharyngeal branch",
+    "vagal pharyngeal branch",
+    "vagus nerve pharyngeal branch"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pharyngealNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "description": "The pharyngeal plexus is a network of nerve fibers innervating most of the palate, larynx, and pharynx. It is located on the surface of the middle pharyngeal constrictor muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011325#pharyngeal-nerve-plexus",
+  "name": "pharyngeal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011325",
+  "synonym": [
+    "pharyngeal nerve plexus",
+    "pharyngeal plexus of vagus nerve",
+    "plexus pharyngeus nervi vagi",
+    "vagus nerve pharyngeal plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/phrenicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/phrenicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/phrenicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic cavity nerve. Is part of the nerve of cervical vertebra. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884) ('is_a' and 'relationship')]",
+  "description": "A nerve that arises from the caudal cervical nerves and is primarily the motor nerve of the diaphragm but also sends sensory fibers to the pericardium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001884#phrenic-nerve",
+  "name": "phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001884",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/plantarNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/plantarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/plantarNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates the sole of the foot. Planar nerves arise from the posterior branch of the tibial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035109#plantar-nerve",
+  "name": "plantar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035109",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorAuricularNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve innervating pinna. Is part of the cervical nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647) ('is_a' and 'relationship')]",
+  "description": "A branch of the facial nerve that innervates the posterior auricular and intrinsic muscles of the auricle and, through its occipital branch, innervates the occipital belly of the occipitofrontal muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035647#posterior-auricular-nerve",
+  "name": "posterior auricular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035647",
+  "synonym": [
+    "auricularis posterior branch of facial nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorLateralLineNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "description": "Cranial nerve which enters the brain between cranial nerves VIII and IX; contains afferents and sensory efferents to the posterior lateral line ganglion and middle ganglion. Fibers from the posterior lateral line ganglion innervate the occipital dorsal lateral line and trunk lateral lines. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000175#posterior-lateral-line-nerve",
+  "name": "posterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000175",
+  "synonym": [
+    "caudal lateral line nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorLateralLineNervePLLN",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "description": "Sensory nerve of the posterior lateral line component. It develops from de postotic posterior placode. PLLN innervates the trunk lines of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010115#posterior-lateral-line-nerve-plln",
+  "name": "posterior lateral line nerve (PLLN)",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010115",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorSuperiorAlveolarNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a superior alveolar nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "description": "The posterior superior alveolar branches (posterior superior dental branches) arise from the trunk of the maxillary nerve just before it enters the infraorbital groove; they are generally two in number, but sometimes arise by a single trunk. They descend on the tuberosity of the maxilla and give off several twigs to the gums and neighboring parts of the mucous membrane of the cheek. They then enter the posterior alveolar canals on the infratemporal surface of the maxilla, and, passing from behind forward in the substance of the bone, communicate with the middle superior alveolar nerve, and give off branches to the lining membrane of the maxillary sinus and gingival and dental branches to each molar tooth from a superior dental plexus; these branches enter the apical foramina at the roots of the teeth. The posterior superior alveolar nerve innervates the second and third maxillary molars, and two of the three roots of the maxillary first molar (all but the mesiobuccal root). When giving a Posterior Superior Alveolar nerve block, it will anesthetize the mesialbuccal root of the maxillary first molar approximately 72% of the time. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018401#posterior-superior-alveolar-nerve",
+  "name": "posterior superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018401",
+  "synonym": [
+    "posterior superior dental nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primaryDorsalNerveCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "description": "A nerve cord in the dorsal mid-line that is the most prominent nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005054#primary-dorsal-nerve-cord",
+  "name": "primary dorsal nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005054",
+  "synonym": [
+    "dorsal nerve cord",
+    "true dorsal nerve cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primaryNerveCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primaryNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primaryNerveCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "description": "A cluster of neurons that is the most prominent longitudinally extending condensed part of a nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005053#primary-nerve-cord",
+  "name": "primary nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005053",
+  "synonym": [
+    "nerve cord",
+    "true nerve cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
@@ -4,11 +4,25 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Principal sensory nucleus of trigeminal nerve' is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. It is part of the pontine tegmentum.",
-  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [WP,unvetted].",
+  "definition": "Is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597) ('is_a' and 'relationship')]",
+  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109355",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002597#principal-sensory-nucleus-of-trigeminal-nerve-1",
   "name": "principal sensory nucleus of trigeminal nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002597",
-  "synonym": null
+  "synonym": [
+    "chief sensory nucleus",
+    "main sensory nucleus",
+    "main sensory nucleus of cranial nerve v",
+    "principal sensory nucleus",
+    "principal sensory nucleus of trigeminal nerve",
+    "principal sensory trigeminal nucleus",
+    "principal trigeminal nucleus",
+    "superior trigeminal nucleus",
+    "superior trigeminal sensory nucleus",
+    "trigeminal nerve superior sensory nucleus",
+    "trigeminal V chief sensory nucleus",
+    "trigeminal V principal sensory nucleus"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pterygopalatineNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725) ('is_a' and 'relationship')]",
+  "description": "The pharyngeal nerve (pterygopalatine nerve) is a small branch arising from the posterior part of the pterygopalatine ganglion. It passes through the pharyngeal canal with the pharyngeal branch of the maxillary artery, and is distributed to the mucous membrane of the nasal part of the pharynx, behind the auditory tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034725#pterygopalatine-nerve",
+  "name": "pterygopalatine nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034725",
+  "synonym": [
+    "ganglionic branch of maxillary nerve to pterygopalatine ganglion",
+    "pterygopalatine nerve",
+    "radix sensoria ganglii pterygopalatini",
+    "sensory root of pterygopalatine ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pudendalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pudendalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pudendalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390) ('is_a' and 'relationship')]",
+  "description": "The pudendal nerve is a somatic nerve in the pelvic region that innervates the external genitalia of both sexes, as well as sphincters for the bladder and the rectum. It originates in Onuf's nucleus in the sacral region of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011390#pudendal-nerve",
+  "name": "pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011390",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pulmonaryNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009) ('is_a' and 'relationship')]",
+  "description": "The pulmonary plexus is an autonomic plexus formed from pulmonary branches of vagus nerve and the sympathetic trunk that supplies the Bronchial tree. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002009#pulmonary-nerve-plexus",
+  "name": "pulmonary nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002009",
+  "synonym": [
+    "plexus pulmonalis",
+    "pulmonary plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/radialNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/radialNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/radialNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492) ('is_a' and 'relationship')]",
+  "description": "A nerve that supplies the upper limb, including the triceps brachii muscle of the arm, as well as all 12 muscles in the posterior osteofascial compartment of the forearm, as well as the associated joints and overlying skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001492#radial-nerve",
+  "name": "radial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001492",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusAuricularisOfTheVagusNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a vagus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "description": "An afferent branch of the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010740#ramus-auricularis-of-the-vagus-nerve",
+  "name": "ramus auricularis of the vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010740",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726) ('is_a' and 'relationship')]",
+  "description": "Branchiomotor branch of the glossopharyngeus nerve innervating the m. subarcuales rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010726#ramus-muscularis-of-glossopharyngeus-nerve",
+  "name": "ramus muscularis of glossopharyngeus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010726",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusMuscularisOfVagusNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ramus recurrens. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751) ('is_a' and 'relationship')]",
+  "description": "Motor nervous branch of the vagus innervating m. subarcualis rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010751#ramus-muscularis-of-vagus-nerve",
+  "name": "ramus muscularis of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010751",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/recurrentLaryngealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716) ('is_a' and 'relationship')]",
+  "description": "A branch of the vagus nerve that supplies motor function and sensation to the larynx (voice box). It travels within the endoneurium. It is the nerve of the 6th Branchial Arch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003716#recurrent-laryngeal-nerve",
+  "name": "recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003716",
+  "synonym": [
+    "nervus laryngeus recurrens",
+    "recurrent laryngeal nerve from vagus nerve",
+    "vagus X nerve recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/renalNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/renalNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/renalNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "description": "The renal plexus is formed by filaments from the celiac plexus, the aorticorenal ganglion, and the aortic plexus. It is joined also by the least splanchnic nerve. The nerves from these sources, fifteen or twenty in number, have a few ganglia developed upon them. They accompany the branches of the renal artery into the kidney; some filaments are distributed to the spermatic plexus and, on the right side, to the inferior vena cava. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018676#renal-nerve-plexus",
+  "name": "renal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018676",
+  "synonym": [
+    "plexus renalis",
+    "renal plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightRecurrentLaryngealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a recurrent laryngeal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011767)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011767#right-recurrent-laryngeal-nerve",
+  "name": "right recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011767",
+  "synonym": [
+    "right recurrent laryngeal branch",
+    "right recurrent laryngeal nerve",
+    "vagus X nerve right recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightVagusXNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a vagus X nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035021)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035021#right-vagus-x-nerve-trunk",
+  "name": "right vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035021",
+  "synonym": [
+    "right vagus neural trunk",
+    "trunk of right vagus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfAbducensNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Root of abducens nerve' is a root of cranial nerve. It is part of the medulla oblongata.",
-  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum",
+  "definition": "Is a root of cranial nerve. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100173",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002786#abducens-nerve-fibers",
   "name": "root of abducens nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002786",
   "synonym": [
     "abducens nerve fibers",
-    "abducens nerve root",
     "abducens nerve tract",
-    "abducens nerve/root",
     "central part of abducens nerve",
-    "fibrae nervi abducentis",
     "root of abducens nerve"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfCervicalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009632)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009632#nerve-root-part-of-cervical-spinal-cord",
+  "name": "root of cervical nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009632",
+  "synonym": [
+    "cervical neural root",
+    "cervical spinal root",
+    "nerve root part of cervical spinal cord",
+    "root of cervical spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfCoccygealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "description": "A spinal nerve root that is part of a coccygeal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009634#root-of-coccygeal-nerve",
+  "name": "root of coccygeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009634",
+  "synonym": [
+    "coccygeal neural root",
+    "coccygeal spinal nerve root",
+    "root of coccygeal spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfCranialNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve root and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "description": "The initial segment of a cranial nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006843#root-of-cranial-nerve",
+  "name": "root of cranial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006843",
+  "synonym": [
+    "cranial nerve root",
+    "cranial neural root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfLumbarSpinalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "description": "A spinal nerve root that is part of a lumbar nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009631#nerve-root-part-of-lumbar-spinal-cord",
+  "name": "root of lumbar spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009631",
+  "synonym": [
+    "lumbar spinal nerve root",
+    "lumbar spinal neural root",
+    "nerve root part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfOlfactoryNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "The initial segment of an olfactory nerve, leaving the central nervous system.",
-  "description": "'Root of olfactory nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
+  "description": "The initial segment of an olfactory nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727253",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019311#olfactory-nerve-root",
   "name": "root of olfactory nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019311",
-  "synonym": null
+  "synonym": [
+    "olfactory nerve root"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfOpticNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "A nerve root that extends_fibers_into a nerve connecting eye with brain.",
-  "description": "'Root of optic nerve' is a root of cranial nerve.",
+  "definition": "Is a root of cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
+  "description": "A nerve root that extends fibers into a nerve connecting eye with brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728874",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009906#optic-nerve-root",
   "name": "root of optic nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009906",
-  "synonym": null
+  "synonym": [
+    "optic nerve root",
+    "optic tract root",
+    "root of optic tract"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfSacralNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "description": "A spinal nerve root that is part of a sacral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009633#nerve-root-part-of-sacral-spinal-cord",
+  "name": "root of sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009633",
+  "synonym": [
+    "nerve root part of sacral spinal cord",
+    "root of sacral spinal nerve",
+    "sacral neural root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfThoracicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "description": "A spinal nerve root that is part of a thoracic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009630#nerve-root-part-of-thoracic-spinal-cord",
+  "name": "root of thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009630",
+  "synonym": [
+    "nerve root part of thoracic spinal cord",
+    "thoracic nerve root",
+    "thoracic neural root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
@@ -4,20 +4,17 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfTrochlearNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Root of trochlear nerve' is a root of cranial nerve. It is part of the brainstem.",
-  "description": "",
+  "definition": "Is a root of cranial nerve. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002618) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112003",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002618#trochlear-nerve-fibers",
   "name": "root of trochlear nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002618",
   "synonym": [
-    "4nf",
     "central part of trochlear nerve",
-    "fibrae nervi trochlearis",
     "trochlear nerve fibers",
-    "trochlear nerve or its root",
     "trochlear nerve root",
-    "trochlear nerve tract",
-    "trochlear nerve/root"
+    "trochlear nerve tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rootOfVagusNerve",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "A root of cranial nerve that is part of a vagus nerve.",
-  "description": "'Root of vagus nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
+  "description": "A root of cranial nerve that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731734",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011213#vagus-nerve-root",
   "name": "root of vagus nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011213",
-  "synonym": null
+  "synonym": [
+    "rootlet of vagus nerve",
+    "vagal root",
+    "vagus nerve root",
+    "vagus root"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rostralOctavalNerveMotorNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an octaval nerve motor nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002175#rostral-octaval-nerve-motor-nucleus",
+  "name": "rostral octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002175",
+  "synonym": [
+    "ROLE",
+    "rostral cranial nerve VIII motor nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rostralOctavalNerveSensoryNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an octaval nerve sensory nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000274)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000274#rostral-octaval-nerve-sensory-nucleus",
+  "name": "rostral octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000274",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rostralRootOfAbducensNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a root of abducens nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009909)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009909#rostral-root-of-abducens-nerve",
+  "name": "rostral root of abducens nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009909",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "description": "The five sacral nerves emerge from the sacrum. Although the vertebral components of the sacrum are fused into a single bone, the sacral vertebrae are still used to number the sacral nerves. Posteriorly, they emerge from the posterior sacral foramina, and form the posterior branches of sacral nerves. Anteriorly, they emerge from the anterior sacral foramina, and contribute to the sacral plexus (S1-S4) and coccygeal plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009625#sacral-nerve",
+  "name": "sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009625",
+  "synonym": [
+    "nervus sacralis",
+    "sacral spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbosacral nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "description": "A nerve plexus which provides motor and sensory nerves for the posterior thigh, most of the lower leg, the entire foot, and part of the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034986#sacral-nerve-plexus",
+  "name": "sacral nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034986",
+  "synonym": [
+    "plexus sacralis",
+    "sacral plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSplanchnicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a splanchnic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "description": "A splanchnic nerve that connects the inferior hypogastric plexus to the sympathetic trunk in the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018684#sacral-splanchnic-nerve",
+  "name": "sacral splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018684",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSympatheticNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034902)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034902#sacral-sympathetic-nerve-trunk",
+  "name": "sacral sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034902",
+  "synonym": [
+    "sacral part of sympathetic trunk",
+    "sacral sympathetic chain",
+    "sacral sympathetic trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/saphenousNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/saphenousNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/saphenousNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the femoral nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475) ('is_a' and 'relationship')]",
+  "description": "The largest cutaneous branch of the femoral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002475#saphenous-nerve",
+  "name": "saphenous nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002475",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sciaticNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sciaticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sciaticNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322) ('is_a' and 'relationship')]",
+  "description": "A large nerve that supplies nearly the whole of the skin of the leg, the muscles of the back of the thigh, and those of the leg and foot. It begins in the lower back and runs through the buttock and down the lower limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001322#sciatic-nerve-1",
+  "name": "sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001322",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/segmentalSpinalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005197)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005197#segmental-spinal-nerve",
+  "name": "segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005197",
+  "synonym": [
+    "cervical segmental spinal nerves C1-7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "description": "A nerve that transmits from sensory receptors on the surface of the body to the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001027#sensory-nerve",
+  "name": "sensory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001027",
+  "synonym": [
+    "nervus sensorius"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryRootOfFacialNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a facial nerve root. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699) ('is_a' and 'relationship')]",
+  "description": "The nervus intermedius, or intermediate nerve, is the part of the facial nerve (cranial nerve VII) located between the motor component of the facial nerve and the vestibulocochlear nerve (cranial nerve VIII). It contains the sensory and parasympathetic fibers of the facial nerve. Upon reaching the facial canal, it joins with the motor root of the facial nerve at the geniculate ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001699#sensory-root-of-facial-nerve",
+  "name": "sensory root of facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001699",
+  "synonym": [
+    "sensory component of the VIIth (facial) nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryRootOfTrigeminalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a trigeminal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009907)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009907#sensory-root-of-trigeminal-nerve",
+  "name": "sensory root of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009907",
+  "synonym": [
+    "radix sensoria (nervus trigeminus [v])",
+    "radix sensoria nervus trigemini"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/shortCiliaryNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an iris nerve, parasympathetic nerve and nerve of head region. Is part of the main ciliary ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302) ('is_a' and 'relationship')]",
+  "description": "A branch of the ciliary ganglion that innervates the ciliary muscles, the iris, and the tunics of the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022302#short-ciliary-nerve",
+  "name": "short ciliary nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022302",
+  "synonym": [
+    "lower branch of ciliary ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/shoulderNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/shoulderNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/shoulderNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "description": "A nerve that is part of a shoulder. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003436#shoulder-nerve",
+  "name": "shoulder nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003436",
+  "synonym": [
+    "nerve of shoulder"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "description": "The any of the paired peripheral nerves formed by the union of the dorsal and ventral spinal roots from each spinal cord segment. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001780#spinal-nerve",
+  "name": "spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001780",
+  "synonym": [
+    "backbone nerve",
+    "nerve of backbone",
+    "nerve of spinal column",
+    "nerve of spine",
+    "nerve of vertebral column",
+    "spinal column nerve",
+    "spinal nerve tree",
+    "spine nerve",
+    "vertebral column nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "description": "An intermingling of fiber fascicles from adjacent spinal nerves to form a network. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001813#spinal-nerve-plexus",
+  "name": "spinal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001813",
+  "synonym": [
+    "plexus nervorum spinalium",
+    "plexus of spinal nerves",
+    "somatic nerve plexus",
+    "spinal nerve plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalNerveRoot",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "description": "The paired bundles of nerve fibers entering and leaving the spinal cord at each segment. The dorsal and ventral nerve roots join to form the mixed segmental spinal nerves. The dorsal roots are generally afferent, formed by the central projections of the spinal (dorsal root) ganglia sensory cells, and the ventral roots efferent, comprising the axons of spinal motor and autonomic preganglionic neurons. There are, however, some exceptions to this afferent/efferent rule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009623#spinal-nerve-root",
+  "name": "spinal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009623",
+  "synonym": [
+    "root of spinal nerve",
+    "spinal neural root",
+    "spinal root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476) ('is_a' and 'relationship')]",
+  "description": "Trunk part of spinal nerve, where dorsal and ventral roots meet to form the spinal nerve, before branching off to dorsal and ventral rami. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005476#spinal-nerve-trunk",
+  "name": "spinal nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005476",
+  "synonym": [
+    "spinal nerve (trunk)",
+    "spinal neural trunk",
+    "trunk of spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalNucleusOfTrigeminalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a trigeminal sensory nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "description": "Nucleus extending from the upper spinal cord through the pontine tegmentum that receives sensory inputs from the trigeminal nerve. It is continuous caudally with the dorsal gray matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001717#spinal-nucleus-of-trigeminal-nerve",
+  "name": "spinal nucleus of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001717",
+  "synonym": [
+    "spinal nucleus of cranial nerve v",
+    "spinal trigeminal nucleus",
+    "trigeminal nerve spinal tract nucleus",
+    "trigeminal spinal nucleus",
+    "trigeminal v spinal sensory nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/splanchnicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/splanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/splanchnicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "description": "The major nerves supplying sympathetic innervation to the abdomen, including the greater, lesser, and lowest (or smallest) splanchnic nerves that are formed by preganglionic fibers from the spinal cord which pass through the paravertebral ganglia and then to the celiac ganglia and plexuses and the lumbar splanchnic nerves carry fibers which pass through the lumbar paravertebral ganglia to the mesenteric and hypogastric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003715#splanchnic-nerve",
+  "name": "splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003715",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/submucousNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an enteric plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "description": "The gangliated plexus of unmyelinated nerve fibers that ramify the stomach and intestinal submucosa. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005304#submucous-nerve-plexus",
+  "name": "submucous nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005304",
+  "synonym": [
+    "submucosal nerve plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superficialFibularNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve and fibular nerve. Is part of the common fibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526) ('is_a' and 'relationship')]",
+  "description": "A branch of the common fibular nerve that innervates the fibularis longus and brevis muscles, and via branches innervates parts of the dorsal part of the pes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035526#superficial-fibular-nerve",
+  "name": "superficial fibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035526",
+  "synonym": [
+    "superficial peroneal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorAlveolarNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018398) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018398#superior-alveolar-nerve",
+  "name": "superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018398",
+  "synonym": [
+    "superior dental nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorBranchOfOculomotorNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the oculomotor nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162) ('is_a' and 'relationship')]",
+  "description": "The superior branch of the oculomotor nerve or the superior division, the smaller, passes medialward over the optic nerve. It supplies the Superior rectus and Levator palpebrae superioris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015162#superior-branch-of-oculomotor-nerve",
+  "name": "superior branch of oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015162",
+  "synonym": [
+    "oculomotor nerve superior division",
+    "ramus superior (nervus oculomotorius [III])",
+    "ramus superior nervi oculomotorii",
+    "ramus superior nervus oculomotorii",
+    "superior ramus of oculomotor nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorHypogastricNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "description": "The superior hypogastric plexus (in older texts, hypogastric plexus or presacral nerve) is a plexus of nerves situated on the vertebral bodies below the bifurcation of the aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002013#superior-hypogastric-nerve-plexus",
+  "name": "superior hypogastric nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002013",
+  "synonym": [
+    "nervus presacralis",
+    "plexus hypogastricus superior",
+    "presacral nerve",
+    "superior hypogastric plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorLaryngealNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326) ('is_a' and 'relationship')]",
+  "description": "The superior laryngeal nerve is a branch of the vagus nerve. It arises from the middle of the ganglion nodosum and in its course receives a branch from the superior cervical ganglion of the sympathetic. It descends, by the side of the pharynx, behind the internal carotid artery, and divides into two branches: external laryngeal nerve internal laryngeal nerve A superior laryngeal nerve palsy changes the pitch of the voice and causes an inability to make explosive sounds. If no recovery is evident three months after the palsy initially presents, the damage is most likely to be permanent. A bilateral palsy presents as a tiring and hoarse voice. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011326#superior-laryngeal-nerve",
+  "name": "superior laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011326",
+  "synonym": [
+    "nervus laryngealis superior",
+    "nervus laryngeus superior",
+    "superior laryngeal branch of inferior vagal ganglion",
+    "superior laryngeal branch of vagus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/suralNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/suralNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/suralNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488) ('is_a' and 'relationship')]",
+  "description": "The sural nerve (short saphenous nerve), formed by the junction of the medial sural cutaneous with the peroneal anastomotic branch of the lateral sural cutaneous nerve, passes downward near the lateral margin of the tendo calcaneus, lying close to the small saphenous vein, to the interval between the lateral malleolus and the calcaneus. It runs forward below the lateral malleolus, and is continued as the lateral dorsal cutaneous nerve along the lateral side of the foot and little toe (via a dorsal digital nerve), communicating on the dorsum of the foot with the intermediate dorsal cutaneous nerve, a branch of the superficial peroneal. In the leg, its branches communicate with those of the posterior femoral cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015488#sural-nerve",
+  "name": "sural nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015488",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sympatheticNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034729) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034729#sympathetic-nerve",
+  "name": "sympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034729",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sympatheticNervePlexus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373) ('is_a' and 'relationship')]",
+  "description": "A nerve plexus that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012373#sympathetic-nerve-plexus",
+  "name": "sympathetic nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012373",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sympatheticNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004295#sympathetic-nerve-trunk",
+  "name": "sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004295",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system",
+    "nerve trunk of sympathetic part of autonomic division of nervous system",
+    "sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/terminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/terminalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/terminalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "description": "The terminal nerve, located anterior to cranial nerve I, is comprised of a group of cells with somata adjacent to the olfactory bulb and processes that extend anteriorly to the olfactory epithelium and posteriorly to the telencephalon. In teleost fish an additional group of axons extends along the optic tract and delivers putative neuromodulators to the retina. It is thought to develop from cranial neural crest. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002924#terminal-nerve-1",
+  "name": "terminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002924",
+  "synonym": [
+    "cranial nerve 0",
+    "cranial nerve zero",
+    "nervus terminalis",
+    "terminalis nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/terminalNerveRoot",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "description": "A nerve root that extends fibers into a terminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014641#terminal-nerve-root-1",
+  "name": "terminal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014641",
+  "synonym": [
+    "cranial nerve 0 root",
+    "root of terminal nerve",
+    "terminal nerve root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicCavityNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "description": "A nerve that is located in a thoracic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003443#thoracic-cavity-nerve",
+  "name": "thoracic cavity nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003443",
+  "synonym": [
+    "cavity of chest nerve",
+    "cavity of thorax nerve",
+    "chest cavity nerve",
+    "nerve of cavity of chest",
+    "nerve of cavity of thorax",
+    "nerve of chest cavity",
+    "nerve of pectoral cavity",
+    "nerve of thoracic cavity",
+    "pectoral cavity nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "description": "The twelve spinal nerves on each side of the thorax. They include eleven INTERCOSTAL NERVES and one subcostal nerve. Both sensory and motor, they supply the muscles and skin of the thoracic and abdominal walls. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003726#thoracic-nerve",
+  "name": "thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003726",
+  "synonym": [
+    "nervus thoracis",
+    "thoracic spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSplanchnicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and nerve of thoracic segment. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679) ('is_a' and 'relationship')]",
+  "description": "Thoracic splanchnic nerves are splanchnic nerves that arise from the sympathetic trunk in the thorax and travel inferiorly to provide sympathetic innervation to the abdomen. The nerves contain preganglionic sympathetic and general visceral afferent fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018679#thoracic-splanchnic-nerve",
+  "name": "thoracic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018679",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSympatheticNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "description": "A sympathetic nerve trunk that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004863#thoracic-sympathetic-nerve-trunk",
+  "name": "thoracic sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004863",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system of thorax",
+    "nerve trunk of sympathetic part of autonomic division of nervous system of thorax",
+    "sympathetic nerve trunk of thorax",
+    "sympathetic nervous system nerve trunk of thorax",
+    "thoracic part of sympathetic trunk",
+    "thoracic sympathetic chain",
+    "thorax nerve trunk of sympathetic nervous system",
+    "thorax nerve trunk of sympathetic part of autonomic division of nervous system",
+    "thorax sympathetic nerve trunk",
+    "thorax sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tibialNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tibialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tibialNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323) ('is_a' and 'relationship')]",
+  "description": "The tibial nerve is a branch of the sciatic nerve. The tibial nerve passes through the popliteal fossa to pass below the arch of soleus. In the popliteal fossa the nerve gives off branches to gastrocnemius, popliteus, soleus and plantaris muscles, an articular branch to the knee joint, and a cutaneous branch that will become the sural nerve. The sural nerve is joined by fibres from the common peroneal nerve and runs down the calf to supply the lateral side of the foot. Below the soleus muscle the nerve lies close to the tibia and supplies the tibialis posterior, the flexor digitorum longus and the flexor hallucis longus. The nerve passes into the foot running posterior to the medial malleolus. Here it is bound down by the flexor retinaculum in company with the posterior tibial artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001323#tibial-nerve",
+  "name": "tibial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001323",
+  "synonym": [
+    "medial popliteal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trigeminalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "description": "Cranial nerve that has three branches - the ophthalmic (supplying the skin of the nose and upper jaw), the maxillary and the mandibular (supplying the lower jaw). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001645#trigeminal-nerve-1",
+  "name": "trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001645",
+  "synonym": [
+    "fifth cranial nerve",
+    "nervus trigeminus",
+    "nervus trigeminus [v]",
+    "trigeminal nerve [V]",
+    "trigeminal nerve tree",
+    "trigeminal V",
+    "trigeminal v nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trigeminalNerveFibers",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "A nerve fiber that is part of a trigeminal nerve.",
-  "description": "'Trigeminal nerve fibers' is a nerve fiber. It is part of the trigeminal nerve.",
+  "definition": "Is a nerve fiber. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041) ('is_a' and 'relationship')]",
+  "description": "A nerve fiber that is part of a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111965",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003041#trigeminal-nerve-fibers-1",
   "name": "trigeminal nerve fibers",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003041",
   "synonym": [
     "central part of trigeminal nerve",
-    "fibrae nervi trigemini",
     "trigeminal nerve fibers",
     "trigeminal nerve tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
@@ -4,11 +4,18 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trigeminalNerveRoot",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Trigeminal nerve root' is a root of cranial nerve. It is part of the metencephalon.",
-  "description": "A nerve root that extends_fibers_into a trigeminal nerve.",
+  "definition": "Is a root of cranial nerve. Is part of the metencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673) ('is_a' and 'relationship')]",
+  "description": "A nerve root that extends fibers into a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111966",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004673#trigeminal-nerve-root-1",
   "name": "trigeminal nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004673",
-  "synonym": null
+  "synonym": [
+    "radix descendens nervi trigemini",
+    "root of trigeminal nerve",
+    "root of trigeminal V nerve",
+    "trigeminal nerve root",
+    "trigeminal neural root"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trochlearNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trochlearNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trochlearNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "description": "A cranial nerve that runs to the eye muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001644#trochlear-nerve-1",
+  "name": "trochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001644",
+  "synonym": [
+    "cranial nerve IV",
+    "fourth cranial nerve",
+    "nervus trochlearis [IV]",
+    "superior oblique nerve",
+    "trochlear IV nerve",
+    "trochlear nerve [IV]",
+    "trochlear nerve tree"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkOfIntercostalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the intercostal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002327) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002327#trunk-of-intercostal-nerve",
+  "name": "trunk of intercostal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002327",
+  "synonym": [
+    "intercostal nerve trunk",
+    "intercostal neural trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkOfPhrenicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the phrenic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001889) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001889#trunk-of-phrenic-nerve",
+  "name": "trunk of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001889",
+  "synonym": [
+    "phrenic nerve trunk",
+    "phrenic neural trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkOfSciaticNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002004) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002004#trunk-of-sciatic-nerve",
+  "name": "trunk of sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002004",
+  "synonym": [
+    "sciatic nerve trunk",
+    "sciatic neural trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkOfSegmentalSpinalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the segmental spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035022) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035022#trunk-of-segmental-spinal-nerve",
+  "name": "trunk of segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035022",
+  "synonym": [
+    "segmental spinal nerve trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tympanicNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tympanicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tympanicNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216) ('is_a' and 'relationship')]",
+  "description": "The tympanic nerve (nerve of Jacobson) is a branch of the glossopharyngeal nerve found near the ear. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036216#tympanic-nerve",
+  "name": "tympanic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036216",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ulnarNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ulnarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ulnarNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494) ('is_a' and 'relationship')]",
+  "description": "A nerve which runs near the ulna bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001494#ulnar-nerve",
+  "name": "ulnar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001494",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/unmyelinatedNerveFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve fiber. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006136)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006136#unmyelinated-nerve-fiber",
+  "name": "unmyelinated nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006136",
+  "synonym": [
+    "non-myelinated nerve fiber"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/upperArmNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/upperArmNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/upperArmNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an arm nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "description": "A nerve that is part of a forelimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004217#upper-arm-nerve",
+  "name": "upper arm nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004217",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/upperEyelidNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an eyelid nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "description": "A nerve that innervates an upper eyelid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022299#upper-eyelid-nerve",
+  "name": "upper eyelid nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022299",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/upperLegNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/upperLegNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/upperLegNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a leg nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "description": "A nerve that is part of a hindlimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004214#upper-leg-nerve",
+  "name": "upper leg nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004214",
+  "synonym": [
+    "hind limb stylopod nerve",
+    "hindlimb stylopod nerve",
+    "lower extremity stylopod nerve",
+    "thigh RELATED"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
@@ -4,18 +4,21 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalNerveFiberBundle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Vagal nerve fiber bundle' is a neuron projection bundle and central nervous system cell part cluster. It is part of the medulla oblongata.",
-  "description": "",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006116) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112236",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006116#vagal-nerve-fiber-bundle-1",
   "name": "vagal nerve fiber bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006116",
   "synonym": [
     "central part of vagus nerve",
-    "fibrae nervi vagi",
+    "central part of vagus nerve",
+    "tenth cranial nerve fibers",
     "tenth cranial nerve fibers",
     "vagal nerve fiber bundle",
+    "vagal nerve fibers",
     "vagal nerve fibers",
     "vagal nerve tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagusNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagusNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagusNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "description": "Cranial nerve that branches into the lateral (to body sense organs) and the intestino-accessorial (to the skin, muscles of shoulder, hyoid, larynx, gut, lungs, and heart). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001759#vagus-nerve-1",
+  "name": "vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001759",
+  "synonym": [
+    "nervus vagus [x]",
+    "tenth cranial nerve",
+    "vagus",
+    "vagus nerve [X]",
+    "vagus nerve tree",
+    "vagus X nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagusNerveNucleus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "description": "A cranial nerve nucleus that is associated with a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011775#vagus-nerve-nucleus",
+  "name": "vagus nerve nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011775",
+  "synonym": [
+    "nucleus of vagal nerve",
+    "nucleus of vagal X nerve",
+    "nucleus of vagus nerve",
+    "nucleus of Xth nerve",
+    "tenth cranial nerve nucleus",
+    "vagal nucleus",
+    "vagal X nucleus",
+    "vagus nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagusXNerveTrunk",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003535#vagus-x-nerve-trunk",
+  "name": "vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003535",
+  "synonym": [
+    "trunk of vagal nerve",
+    "trunk of vagus nerve",
+    "vagal nerve trunk",
+    "vagal X nerve trunk",
+    "vagus nerve trunk",
+    "vagus neural trunk"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralAnteriorLateralLineNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line nerve. Is part of the anterior lateral line nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers originating from the ventral anterior lateral line ganglion. These rami innervate the mandibular and opercular neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001481#ventral-anterior-lateral-line-nerve",
+  "name": "ventral anterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001481",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralMotorNucleusTrigeminalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a motor nucleus of trigeminal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000703)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000703#ventral-motor-nucleus-trigeminal-nerve",
+  "name": "ventral motor nucleus trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000703",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralNerveCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralNerveCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralNerveCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "description": "The pair of closely united ventral longitudinal nerves with their segmental ganglia that is characteristic of many elongate invertebrates (as earthworms). A large process bundle that runs along the vental mid-line extending from the ventral region of the nerve ring. The ventral cord is one of the distinguishing traits of the central nervous system of all arthropods (such as insects, crustaceans and arachnids) as well as many other invertebrates, such as the annelid worms. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000934#ventral-nerve-cord",
+  "name": "ventral nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000934",
+  "synonym": [
+    "ventral cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventral root of spinal cord and root of cervical nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "description": "A ventral root of spinal cord that overlaps a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014634#ventral-nerve-root-of-cervical-spinal-cord-1",
+  "name": "ventral nerve root of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014634",
+  "synonym": [
+    "ventral nerve root of cervical spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a root of lumbar spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024382)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024382#ventral-nerve-root-of-lumbar-spinal-cord-1",
+  "name": "ventral nerve root of lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024382",
+  "synonym": [
+    "ventral nerve root of lumbar spinal cord",
+    "ventral nerve root of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralNerveRootOfSacralSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a root of sacral nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023623)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023623#ventral-nerve-root-of-sacral-spinal-cord-1",
+  "name": "ventral nerve root of sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023623",
+  "synonym": [
+    "ventral nerve root of sacral spinal cord",
+    "ventral nerve root of sacral spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a root of thoracic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014617)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014617#ventral-nerve-root-of-thoracic-spinal-cord-1",
+  "name": "ventral nerve root of thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014617",
+  "synonym": [
+    "ventral nerve root of thoracic spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralRamusOfSpinalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the spinal nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838) ('is_a' and 'relationship')]",
+  "description": "Branch of spinal nerve that innervates the hypaxial muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006838#ventral-ramus-of-spinal-nerve",
+  "name": "ventral ramus of spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006838",
+  "synonym": [
+    "anterior primary ramus of spinal nerve",
+    "anterior ramus of spinal nerve",
+    "ventral ramus of spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibularNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibularNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibularNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vestibulocochlear nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723) ('is_a' and 'relationship')]",
+  "description": "The vestibular nerve is one of the two branches of the Vestibulocochlear nerve (the cochlear nerve being the other). It goes to the semicircular canals via the vestibular ganglion. It receives positional information. Axons of the vestibular nerve synapse in the vestibular nucleus on the lateral floor and wall of the fourth ventricle in the pons and medulla. It arises from bipolar cells in the vestibular ganglion, ganglion of Scarpa, which is situated in the upper part of the outer end of the internal auditory meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003723#vestibular-nerve",
+  "name": "vestibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003723",
+  "synonym": [
+    "vestibular root of acoustic nerve",
+    "vestibular root of eighth cranial nerve",
+    "vestibulocochlear VIII nerve vestibular component"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibulocochlearNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "description": "Cranial nerve that transmits sound and equilibrium (balance) information from the inner ear to the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001648#vestibulocochlear-nerve-1",
+  "name": "vestibulocochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001648",
+  "synonym": [
+    "acoustic nerve",
+    "acoustic nerve (Crosby)",
+    "acoustic VIII nerve",
+    "CN-VIII",
+    "cochlear-vestibular nerve",
+    "cochleovestibular nerve",
+    "cranial nerve VIII",
+    "eighth cranial nerve",
+    "nervus vestibulocochlearis [viii]",
+    "stato-acoustic nerve",
+    "vestibulocochlear nerve [VIII]",
+    "vestibulocochlear nerve tree",
+    "vestibulocochlear VIII nerve",
+    "VIII nerve",
+    "VIIIth cranial nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibulocochlearNerveRoot",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Vestibulocochlear nerve root' is a root of cranial nerve. It is part of the pontine tegmentum.",
-  "description": "Either of the two roots that come of the vestibulocochlear nerve",
+  "definition": "Is a root of cranial nerve. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731) ('is_a' and 'relationship')]",
+  "description": "Either of the two roots that come of the vestibulocochlear nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112460",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002731#vestibulocochlear-nerve-fiber-bundle",
   "name": "vestibulocochlear nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002731",
   "synonym": [
-    "8cn",
     "central part of vestibulocochlear nerve",
     "fibrae nervi statoacustici",
     "root of vestibulocochlear nerve",
     "statoacoustic nerve fibers",
-    "vestibular root of vestibulocochlear nerve",
     "vestibulocochlear nerve fibers",
     "vestibulocochlear nerve roots",
     "vestibulocochlear nerve tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vidianNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vidianNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vidianNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412) ('is_a' and 'relationship')]",
+  "description": "A nerve that is formed by the junction of the great petrosal nerve and the deep petrosal nerve and continues on to innervate the palate, nose and lacrimal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018412#vidian-nerve",
+  "name": "vidian nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018412",
+  "synonym": [
+    "nerve of pterygoid canal",
+    "pterygoid canal nerve",
+    "vidian nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vomeronasalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "description": "Nerve carrying fibers from the vomeronasal organ epithelium to the accessory olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009121#vomeronasal-nerve",
+  "name": "vomeronasal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009121",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wristNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wristNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wristNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a manus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "description": "A nerve that is part of a wrist. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003434#wrist-nerve",
+  "name": "wrist nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003434",
+  "synonym": [
+    "carpal region nerve",
+    "nerve of carpal region",
+    "nerve of wrist"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/zygomaticotemporalNerve",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264) ('is_a' and 'relationship')]",
+  "description": "The zygomaticotemporal nerve or zygomaticotemporal branch (temporal branch) is derived from the maxillary branch of the trigeminal nerve (Cranial nerve V). It runs along the lateral wall of the orbit in a groove in the zygomatic bone, receives a branch of communication from the lacrimal, and passes through zygomaticotemporal foramen in the zygomatic bone to enter the temporal fossa. It ascends between the bone, and substance of the Temporalis muscle, pierces the temporal fascia about 2.5 cm. above the zygomatic arch, and is distributed to the skin of the side of the forehead, and communicates with the facial nerve and with the auriculotemporal branch of the mandibular nerve. As it pierces the temporal fascia, it gives off a slender twig, which runs between the two layers of the fascia to the lateral angle of the orbit. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036264#zygomaticotemporal-nerve",
+  "name": "zygomaticotemporal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036264",
+  "synonym": [
+    "ramus zygomaticotemporalis (Nervus zygomaticus)",
+    "ramus zygomaticotemporalis nervus zygomatici",
+    "zygomaticotemporal branch of zygomatic nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/RuffiniNerveEnding.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/RuffiniNerveEnding",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mechanoreceptor. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "description": "An encapsulated nerve receptor present in subpapillary dermis and deep dermis of hairy and glabrous skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012457)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012457#ruffini-nerve-ending",
+  "name": "Ruffini nerve ending",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012457",
+  "synonym": [
+    "corpusculum sensorium fusiforme",
+    "Ruffini's corpuscle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveEndingOfOfCorpusCavernosumMaxillaris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve ending. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013671)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013671#nerve-ending-of-of-corpus-cavernosum-maxillaris",
+  "name": "nerve ending of of corpus cavernosum maxillaris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013671",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveFasciculus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveFasciculus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFasciculus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "description": "A slender neuron projection bundle; A bundle of anatomical fibers, as of muscle or nerve (American Heritage Dictionary 4th ed). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001019)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001019#fasciculus",
+  "name": "nerve fasciculus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001019",
+  "synonym": [
+    "fasciculus",
+    "nerve bundle",
+    "nerve fasciculus",
+    "neural fasciculus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveFiber.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nerve fasciculus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134) ('is_a' and 'relationship')]",
+  "description": "A threadlike extension of a nerve cell and consists of an axon and myelin sheath (if it is myelinated) in the nervous system. There are nerve fibers in the central nervous system and peripheral nervous system. A nerve fiber may be myelinated and/or unmyelinated. In the central nervous system (CNS), myelin by oligodendroglia cells is formed. Schwann cells form myelin in the peripheral nervous system (PNS). Schwann cells also make a thin covering in an axon without myelin (in the PNS). A peripheral nerve fiber contains an axon, myelin sheath, schwann cells and its endoneurium. There are no endoneurium and schwann cells in the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006134#nerve-fiber",
+  "name": "nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006134",
+  "synonym": [
+    "nerve fibre",
+    "neurofibra",
+    "neurofibrum"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveFiberLayerOfRetina.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveFiberLayerOfRetina",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a layer of retina. Is part of the retinal neural layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793) ('is_a' and 'relationship')]",
+  "description": "Layer of the retina formed by expansion of the fibers of the optic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001793)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001793#nerve-fiber-layer-of-retina",
+  "name": "nerve fiber layer of retina",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001793",
+  "synonym": [
+    "layer of nerve fibers of retina",
+    "layer of nerve fibres of retina",
+    "optic fiber layer",
+    "retina nerve fiber layer",
+    "stratum neurofibrarum (retina)",
+    "stratum neurofibrarum retinae",
+    "stratum opticum of retina"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveInnervatingPinna.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveInnervatingPinna",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648) ('is_a' and 'relationship')]",
+  "description": "Any nerve that innervates the pinna. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035648#nerve-innervating-pinna",
+  "name": "nerve innervating pinna",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035648",
+  "synonym": [
+    "auricular nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfAbdominalSegment.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfAbdominalSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "description": "A nerve that is part of an abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003825#nerve-of-abdominal-segment",
+  "name": "nerve of abdominal segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003825",
+  "synonym": [
+    "abdominal segment nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfCervicalVertebra.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfCervicalVertebra",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "description": "The cervical nerves are the spinal nerves from the cervical vertebrae. Although there are seven cervical vertebrae (C1-C7), there are eight cervical nerves (C1-C8). All nerves except C8 emerge above their corresponding vertebrae, while the C8 nerve emerges below the C7 vertebra. (In the other portions of the spine, the nerve emerges below the vertebra with the same name. Dorsal (posterior) distribution includes the greater occipital (C2) and third occipital (C3). Ventral (anterior) distribution includes the cervical plexus (C1-C4) and brachial plexus (C5-C8). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000962#nerve-of-cervical-vertebra",
+  "name": "nerve of cervical vertebra",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000962",
+  "synonym": [
+    "cervical nerve",
+    "cervical nerve tree",
+    "cervical spinal nerve",
+    "nervus cervicalis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfClitoris.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfClitoris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "description": "Any nerve that innervates the clitoris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035650)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035650#nerve-of-clitoris",
+  "name": "nerve of clitoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035650",
+  "synonym": [
+    "clitoral nerve",
+    "clitoris nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfHeadRegion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfHeadRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "description": "A nerve that is part of a head. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011779)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011779#nerve-of-head-region",
+  "name": "nerve of head region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011779",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfPenis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfPenis.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfPenis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "description": "Any nerve that innervates the penis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035649)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035649#nerve-of-penis",
+  "name": "nerve of penis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035649",
+  "synonym": [
+    "penile nerve",
+    "penis nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfThoracicSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfThoracicSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of trunk region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "description": "A nerve that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003824#nerve-of-thoracic-segment",
+  "name": "nerve of thoracic segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003824",
+  "synonym": [
+    "nerve of thorax",
+    "thoracic segment nerve",
+    "thorax nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfTrunkRegion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfTrunkRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "description": "A nerve that is part of the trunk region of the body (not to be confused with a nerve trunk). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003439)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003439#nerve-of-trunk-region",
+  "name": "nerve of trunk region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003439",
+  "synonym": [
+    "nerve of torso",
+    "nerve of trunk",
+    "torso nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveOfTympanicCavity.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveOfTympanicCavity",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "description": "A nerve that is part of a tympanic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004116)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004116#nerve-of-tympanic-cavity",
+  "name": "nerve of tympanic cavity",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004116",
+  "synonym": [
+    "anatomical cavity of middle ear nerve",
+    "cavity of middle ear nerve",
+    "middle ear anatomical cavity nerve",
+    "middle ear cavity nerve",
+    "nerve of anatomical cavity of middle ear",
+    "nerve of cavity of middle ear",
+    "nerve of middle ear anatomical cavity",
+    "nerve of middle ear cavity",
+    "tympanic cavity nerve",
+    "tympanic cavity nerves"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tissue. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "description": "Anatomical junction where subdivisions of two or more neural trees interconnect with one another to form a network through which nerve fibers of the constituent nerve trees become regrouped; together with other nerve plexuses, nerves and ganglia, it constitutes the peripheral nervous system. Examples: cervical nerve plexus, brachial nerve plexus, sacral nerve plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001810#nerve-plexus",
+  "name": "nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001810",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveRoot.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "description": "A continuation of the neuron projection bundle component of a nerve inside, crossing or immediately outside the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002211)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002211#nerve-root",
+  "name": "nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002211",
+  "synonym": [
+    "initial segment of nerve",
+    "radix nervi"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveToQuadratusFemoris.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToQuadratusFemoris",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984) ('is_a' and 'relationship')]",
+  "description": "The nerve to quadratus femoris is a nerve that provides innervation to the quadratus femoris and gemellus inferior muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034984)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034984#nerve-to-quadratus-femoris",
+  "name": "nerve to quadratus femoris",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034984",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveToStylohyoidFromFacialNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToStylohyoidFromFacialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316) ('is_a' and 'relationship')]",
+  "description": "The stylohyoid branch of facial nerve frequently arises in conjunction with the digastric branch; it is long and slender, and enters the Stylohyoideus about its middle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011316)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011316#nerve-to-stylohyoid-from-facial-nerve",
+  "name": "nerve to stylohyoid from facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011316",
+  "synonym": [
+    "facial nerve stylohyoid branch",
+    "nerve to stylohyoid",
+    "ramus stylohyoideus",
+    "ramus stylohyoideus nervus facialis",
+    "stylodigastric nerve",
+    "stylohyoid branch of facial nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveToStylopharyngeusFromGlossopharyngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317) ('is_a' and 'relationship')]",
+  "description": "The stylopharyngeal branch of glossopharyngeal nerve is distributed to the Stylopharyngeus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011317)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011317#nerve-to-stylopharyngeus-from-glossopharyngeal-nerve",
+  "name": "nerve to stylopharyngeus from glossopharyngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011317",
+  "synonym": [
+    "branch of glossopharyngeal nerve to stylopharyngeus",
+    "nerve to stylopharyngeus",
+    "ramus musculi stylopharyngei nervus glossopharyngei",
+    "stylopharyngeal branch of glossopharyngeal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle. Is part of the nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002464) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002464#nerve-trunk",
+  "name": "nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002464",
+  "synonym": [
+    "peripheral nerve trunk",
+    "trunk of nerve",
+    "trunk of peripheral nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nucleusOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusOfPhrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "description": "Neuron cell bodies located in the more medial portions of the anterior horn at cervical levels C3-C7 that innervate the diaphragm via the phrenic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016850#nucleus-of-phrenic-nerve",
+  "name": "nucleus of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016850",
+  "synonym": [
+    "phrenic neural nucleus",
+    "phrenic nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nucleusOfPudendalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusOfPudendalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of spinal cord. Is part of the ventral horn of spinal cord and the sacral spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the ventral part of the anterior horn of the sacral region of the spinal cord that is the origin of the pudendal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022278)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022278#nucleus-of-pudendal-nerve",
+  "name": "nucleus of pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022278",
+  "synonym": [
+    "nucleus of Onuf",
+    "Onuf's nucleus",
+    "pudendal neural nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/obturatorNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/obturatorNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/obturatorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465) ('is_a' and 'relationship')]",
+  "description": "The obturator nerve arises from the ventral divisions of the second, third, and fourth lumbar nerves; the branch from the third is the largest, while that from the second is often very small. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005465)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005465#obturator-nerve",
+  "name": "obturator nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005465",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/octavalNerveMotorNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/octavalNerveMotorNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "description": "Hindbrain nucleus which consists of cell bodies whose axons exit the hindbrain via cranial nerve VIII and innervate hair cells of the lateral line and inner ear. The neurons of these nuclei are unusual in that they extend both contra- and ipsilateral dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002174)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002174#octaval-nerve-motor-nucleus",
+  "name": "octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002174",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/octavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/octavalNerveSensoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000401)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000401#octaval-nerve-sensory-nucleus",
+  "name": "octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000401",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/oculomotorNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/oculomotorNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oculomotorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "description": "Cranial nerve which connects the midbrain to the extra-ocular and intra-ocular muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001643#oculomotor-nerve-1",
+  "name": "oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001643",
+  "synonym": [
+    "nervus oculomotorius",
+    "nervus oculomotorius [III]",
+    "oculomotor III",
+    "oculomotor III nerve",
+    "oculomotor nerve [III]",
+    "oculomotor nerve tree",
+    "third cranial nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/oculomotorNerveRoot.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oculomotorNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Oculomotor nerve root' is a root of cranial nerve. It is part of the midbrain tegmentum.",
-  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain.",
+  "definition": "Is a root of cranial nerve. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668) ('is_a' and 'relationship')]",
+  "description": "Initial segment of the occulomotor nerve as it leaves the midbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107898",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002668#oculomotor-nerve-fibers",
   "name": "oculomotor nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002668",
   "synonym": [
-    "3nf",
     "central part of oculomotor nerve",
-    "fibrae nervi oculomotorii",
     "oculomotor nerve fibers",
-    "oculomotor nerve tract",
     "root of oculomotor nerve"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulbOuterNerveLayer.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulbOuterNerveLayer",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory bulb outer nerve layer' is an olfactory bulb layer.",
-  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
+  "description": "Superficial layer of the main olfactory bulb containing axons from the olfactory nerve and glial cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005978)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107942",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005978#olfactory-bulb-main-olfactory-nerve-layer",
   "name": "olfactory bulb outer nerve layer",
@@ -15,3 +15,4 @@
     "olfactory bulb olfactory nerve layer"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "description": "Nerve that carries information from the olfactory epithelium to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001579#olfactory-nerve-1",
+  "name": "olfactory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001579",
+  "synonym": [
+    "first cranial nerve",
+    "nervus olfactorius [i]",
+    "olfactory I",
+    "olfactory i nerve",
+    "olfactory nerve [I]"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ophthalmicNerve.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ophthalmicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348) ('is_a' and 'relationship')]",
+  "description": "The sensory nerve subdivision of the trigeminal nerve that transmits sensory information from the orbit and its contents, the nasal cavity and the skin of the nose and forehead. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000348)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000348#ophthalmic-nerve",
+  "name": "ophthalmic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000348",
+  "synonym": [
+    "cranial nerve V, branch V1",
+    "first branch of fifth cranial nerve",
+    "first division of fifth cranial nerve",
+    "first division of trigeminal nerve",
+    "nervus ophthalmicus (V1)",
+    "nervus ophthalmicus (Va)",
+    "nervus ophthalmicus [v1]",
+    "nervus ophthalmicus [va]",
+    "ophthalmic division [V1]",
+    "ophthalmic division [Va]",
+    "ophthalmic division of fifth cranial nerve",
+    "ophthalmic division of trigeminal nerve (V1)",
+    "ophthalmic division of trigeminal nerve (Va)",
+    "ophthalmic nerve [V1]",
+    "ophthalmic nerve [Va]",
+    "opthalmic nerve",
+    "ramus opthalmicus profundus (ramus V1)",
+    "rostral branch of trigeminal nerve",
+    "trigeminal V nerve ophthalmic division"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/palmarBranchOfMedianNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palmarBranchOfMedianNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the median nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430) ('is_a' and 'relationship')]",
+  "description": "The palmar branch of the median nerve is a branch of the median nerve which arises at the lower part of the forearm and innervates skin of proximal central palm and thenar eminence. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016430)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016430#palmar-branch-of-median-nerve",
+  "name": "palmar branch of median nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016430",
+  "synonym": [
+    "median nerve palmar branch",
+    "palmar branch of anterior interosseous nerve",
+    "palmar cutaneous branch of median nerve",
+    "ramus palmaris (nervus medianus)",
+    "ramus palmaris nervus interossei antebrachii anterior"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/palpebralBranchOfInfraOrbitalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an eyelid nerve and nerve of head region. Is part of the infra-orbital nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates an eyelid and is a branch of the infra-orbital branch of the maxillary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022297)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022297#palpebral-branch-of-infra-orbital-nerve",
+  "name": "palpebral branch of infra-orbital nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022297",
+  "synonym": [
+    "palpebral branch of maxillary nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parasympatheticNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293) ('is_a' and 'relationship')]",
+  "description": "A nerve that is part of a parasympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004293)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004293#parasympathetic-nerve",
+  "name": "parasympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004293",
+  "synonym": [
+    "nerve of parasympathetic nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pedalDigitNerve.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pedalDigitNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pes nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "description": "A nerve that is part of a toe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003435)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003435#pedal-digit-nerve",
+  "name": "pedal digit nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003435",
+  "synonym": [
+    "digit of foot nerve",
+    "digit of terminal segment of free lower limb nerve",
+    "digitus pedis nerve",
+    "foot digit nerve",
+    "hind limb digit nerve",
+    "nerve of digit of foot",
+    "nerve of digit of terminal segment of free lower limb",
+    "nerve of digitus pedis",
+    "nerve of foot digit",
+    "nerve of terminal segment of free lower limb digit",
+    "nerve of toe",
+    "terminal segment of free lower limb digit nerve",
+    "toe nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pelvicSplanchnicNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvicSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and parasympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "description": "A splanchnic nerves that arises from sacral spinal nerves S2, S3, S4 to provide parasympathetic innervation to the hindgut. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018675#pelvic-splanchnic-nerve",
+  "name": "pelvic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018675",
+  "synonym": [
+    "pelvic splanchnic parasympathetic nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pelvisNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pelvisNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvisNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of abdominal segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "description": "A nerve that is part of a pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003444)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003444#pelvis-nerve",
+  "name": "pelvis nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003444",
+  "synonym": [
+    "nerve of pelvis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/perinealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/perinealNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/perinealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the pudendal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391) ('is_a' and 'relationship')]",
+  "description": "A nerve arising from the pudendal nerve that supplies the perineum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011391#perineal-nerve",
+  "name": "perineal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011391",
+  "synonym": [
+    "perineal branch of pudendal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pesNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pesNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pesNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a hindlimb nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "description": "A nerve that is part of a foot. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003445)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003445#pes-nerve",
+  "name": "pes nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003445",
+  "synonym": [
+    "foot nerve",
+    "nerve of foot"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pharyngealBranchOfVagusNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealBranchOfVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929) ('is_a' and 'relationship')]",
+  "description": "Motor nerve of the pharynx, arises from the upper part of the ganglion nodosum, and consists principally of filaments from the cranial portion of the accessory nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000929#pharyngeal-branch-of-vagus-nerve",
+  "name": "pharyngeal branch of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000929",
+  "synonym": [
+    "pharyngeal branch",
+    "pharyngeal branch of inferior vagal ganglion",
+    "pharyngeal branch of vagus",
+    "ramus pharyngealis nervi vagalis",
+    "ramus pharyngeus",
+    "ramus pharyngeus",
+    "tenth cranial nerve pharyngeal branch",
+    "vagal pharyngeal branch",
+    "vagus nerve pharyngeal branch"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pharyngealNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pharyngealNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "description": "The pharyngeal plexus is a network of nerve fibers innervating most of the palate, larynx, and pharynx. It is located on the surface of the middle pharyngeal constrictor muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011325)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011325#pharyngeal-nerve-plexus",
+  "name": "pharyngeal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011325",
+  "synonym": [
+    "pharyngeal nerve plexus",
+    "pharyngeal plexus of vagus nerve",
+    "plexus pharyngeus nervi vagi",
+    "vagus nerve pharyngeal plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/phrenicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/phrenicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/phrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic cavity nerve. Is part of the nerve of cervical vertebra. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884) ('is_a' and 'relationship')]",
+  "description": "A nerve that arises from the caudal cervical nerves and is primarily the motor nerve of the diaphragm but also sends sensory fibers to the pericardium. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001884)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001884#phrenic-nerve",
+  "name": "phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001884",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/plantarNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/plantarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/plantarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109) ('is_a' and 'relationship')]",
+  "description": "A nerve that innervates the sole of the foot. Planar nerves arise from the posterior branch of the tibial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035109)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035109#plantar-nerve",
+  "name": "plantar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035109",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorAuricularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorAuricularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve innervating pinna. Is part of the cervical nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647) ('is_a' and 'relationship')]",
+  "description": "A branch of the facial nerve that innervates the posterior auricular and intrinsic muscles of the auricle and, through its occipital branch, innervates the occipital belly of the occipitofrontal muscle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035647)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035647#posterior-auricular-nerve",
+  "name": "posterior auricular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035647",
+  "synonym": [
+    "auricularis posterior branch of facial nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "description": "Cranial nerve which enters the brain between cranial nerves VIII and IX; contains afferents and sensory efferents to the posterior lateral line ganglion and middle ganglion. Fibers from the posterior lateral line ganglion innervate the occipital dorsal lateral line and trunk lateral lines. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000175)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000175#posterior-lateral-line-nerve",
+  "name": "posterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000175",
+  "synonym": [
+    "caudal lateral line nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineNervePLLN.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineNervePLLN",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "description": "Sensory nerve of the posterior lateral line component. It develops from de postotic posterior placode. PLLN innervates the trunk lines of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010115)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010115#posterior-lateral-line-nerve-plln",
+  "name": "posterior lateral line nerve (PLLN)",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010115",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorSuperiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorSuperiorAlveolarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a superior alveolar nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "description": "The posterior superior alveolar branches (posterior superior dental branches) arise from the trunk of the maxillary nerve just before it enters the infraorbital groove; they are generally two in number, but sometimes arise by a single trunk. They descend on the tuberosity of the maxilla and give off several twigs to the gums and neighboring parts of the mucous membrane of the cheek. They then enter the posterior alveolar canals on the infratemporal surface of the maxilla, and, passing from behind forward in the substance of the bone, communicate with the middle superior alveolar nerve, and give off branches to the lining membrane of the maxillary sinus and gingival and dental branches to each molar tooth from a superior dental plexus; these branches enter the apical foramina at the roots of the teeth. The posterior superior alveolar nerve innervates the second and third maxillary molars, and two of the three roots of the maxillary first molar (all but the mesiobuccal root). When giving a Posterior Superior Alveolar nerve block, it will anesthetize the mesialbuccal root of the maxillary first molar approximately 72% of the time. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018401)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018401#posterior-superior-alveolar-nerve",
+  "name": "posterior superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018401",
+  "synonym": [
+    "posterior superior dental nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primaryDorsalNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryDorsalNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "description": "A nerve cord in the dorsal mid-line that is the most prominent nerve cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005054)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005054#primary-dorsal-nerve-cord",
+  "name": "primary dorsal nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005054",
+  "synonym": [
+    "dorsal nerve cord",
+    "true dorsal nerve cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primaryNerveCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primaryNerveCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "description": "A cluster of neurons that is the most prominent longitudinally extending condensed part of a nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005053)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005053#primary-nerve-cord",
+  "name": "primary nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005053",
+  "synonym": [
+    "nerve cord",
+    "true nerve cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve.jsonld
@@ -4,11 +4,25 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/principalSensoryNucleusOfTrigeminalNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Principal sensory nucleus of trigeminal nerve' is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. It is part of the pontine tegmentum.",
-  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [WP,unvetted].",
+  "definition": "Is a trigeminal sensory nucleus, brainstem nucleus and hindbrain nucleus. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597) ('is_a' and 'relationship')]",
+  "description": "The principal sensory nucleus (or chief sensory nucleus of V) is a group of second order neurons which have cell bodies in the dorsal Pons. It receives information about discriminative sensation and light touch of the face as well as conscious proprioception of the jaw via first order neurons of CN V. Most of the sensory information crosses the midline and travels to the contralateral ventral posteriomedial (VPM) of the thalamus via the Ventral Trigeminothalamic Tract, but information of the oral cavity travels to the ipsilateral Ventral Posteriomedial (VPM) of the thalamus via the Dorsal Trigeminothalamic Tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002597)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109355",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002597#principal-sensory-nucleus-of-trigeminal-nerve-1",
   "name": "principal sensory nucleus of trigeminal nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002597",
-  "synonym": null
+  "synonym": [
+    "chief sensory nucleus",
+    "main sensory nucleus",
+    "main sensory nucleus of cranial nerve v",
+    "principal sensory nucleus",
+    "principal sensory nucleus of trigeminal nerve",
+    "principal sensory trigeminal nucleus",
+    "principal trigeminal nucleus",
+    "superior trigeminal nucleus",
+    "superior trigeminal sensory nucleus",
+    "trigeminal nerve superior sensory nucleus",
+    "trigeminal V chief sensory nucleus",
+    "trigeminal V principal sensory nucleus"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pterygopalatineNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pterygopalatineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725) ('is_a' and 'relationship')]",
+  "description": "The pharyngeal nerve (pterygopalatine nerve) is a small branch arising from the posterior part of the pterygopalatine ganglion. It passes through the pharyngeal canal with the pharyngeal branch of the maxillary artery, and is distributed to the mucous membrane of the nasal part of the pharynx, behind the auditory tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034725)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034725#pterygopalatine-nerve",
+  "name": "pterygopalatine nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034725",
+  "synonym": [
+    "ganglionic branch of maxillary nerve to pterygopalatine ganglion",
+    "pterygopalatine nerve",
+    "radix sensoria ganglii pterygopalatini",
+    "sensory root of pterygopalatine ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pudendalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pudendalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pudendalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a pelvis nerve. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390) ('is_a' and 'relationship')]",
+  "description": "The pudendal nerve is a somatic nerve in the pelvic region that innervates the external genitalia of both sexes, as well as sphincters for the bladder and the rectum. It originates in Onuf's nucleus in the sacral region of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011390)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011390#pudendal-nerve",
+  "name": "pudendal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011390",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pulmonaryNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pulmonaryNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009) ('is_a' and 'relationship')]",
+  "description": "The pulmonary plexus is an autonomic plexus formed from pulmonary branches of vagus nerve and the sympathetic trunk that supplies the Bronchial tree. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002009)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002009#pulmonary-nerve-plexus",
+  "name": "pulmonary nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002009",
+  "synonym": [
+    "plexus pulmonalis",
+    "pulmonary plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/radialNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/radialNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492) ('is_a' and 'relationship')]",
+  "description": "A nerve that supplies the upper limb, including the triceps brachii muscle of the arm, as well as all 12 muscles in the posterior osteofascial compartment of the forearm, as well as the associated joints and overlying skin. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001492#radial-nerve",
+  "name": "radial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001492",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusAuricularisOfTheVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusAuricularisOfTheVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "description": "An afferent branch of the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010740#ramus-auricularis-of-the-vagus-nerve",
+  "name": "ramus auricularis of the vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010740",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMuscularisOfGlossopharyngeusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726) ('is_a' and 'relationship')]",
+  "description": "Branchiomotor branch of the glossopharyngeus nerve innervating the m. subarcuales rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010726#ramus-muscularis-of-glossopharyngeus-nerve",
+  "name": "ramus muscularis of glossopharyngeus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010726",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusMuscularisOfVagusNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMuscularisOfVagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ramus recurrens. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751) ('is_a' and 'relationship')]",
+  "description": "Motor nervous branch of the vagus innervating m. subarcualis rectus I. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010751)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010751#ramus-muscularis-of-vagus-nerve",
+  "name": "ramus muscularis of vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010751",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/recurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/recurrentLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716) ('is_a' and 'relationship')]",
+  "description": "A branch of the vagus nerve that supplies motor function and sensation to the larynx (voice box). It travels within the endoneurium. It is the nerve of the 6th Branchial Arch. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003716#recurrent-laryngeal-nerve",
+  "name": "recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003716",
+  "synonym": [
+    "nervus laryngeus recurrens",
+    "recurrent laryngeal nerve from vagus nerve",
+    "vagus X nerve recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/renalNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/renalNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/renalNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "description": "The renal plexus is formed by filaments from the celiac plexus, the aorticorenal ganglion, and the aortic plexus. It is joined also by the least splanchnic nerve. The nerves from these sources, fifteen or twenty in number, have a few ganglia developed upon them. They accompany the branches of the renal artery into the kidney; some filaments are distributed to the spermatic plexus and, on the right side, to the inferior vena cava. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018676#renal-nerve-plexus",
+  "name": "renal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018676",
+  "synonym": [
+    "plexus renalis",
+    "renal plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightRecurrentLaryngealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightRecurrentLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a recurrent laryngeal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011767)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011767#right-recurrent-laryngeal-nerve",
+  "name": "right recurrent laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011767",
+  "synonym": [
+    "right recurrent laryngeal branch",
+    "right recurrent laryngeal nerve",
+    "vagus X nerve right recurrent laryngeal branch"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightVagusXNerveTrunk.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightVagusXNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035021)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035021#right-vagus-x-nerve-trunk",
+  "name": "right vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035021",
+  "synonym": [
+    "right vagus neural trunk",
+    "trunk of right vagus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfAbducensNerve.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfAbducensNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Root of abducens nerve' is a root of cranial nerve. It is part of the medulla oblongata.",
-  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum",
+  "definition": "Is a root of cranial nerve. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers arising from motor neurons in the abducens nucleus that are contained within the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002786)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100173",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002786#abducens-nerve-fibers",
   "name": "root of abducens nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002786",
   "synonym": [
     "abducens nerve fibers",
-    "abducens nerve root",
     "abducens nerve tract",
-    "abducens nerve/root",
     "central part of abducens nerve",
-    "fibrae nervi abducentis",
     "root of abducens nerve"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfCervicalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCervicalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009632)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009632#nerve-root-part-of-cervical-spinal-cord",
+  "name": "root of cervical nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009632",
+  "synonym": [
+    "cervical neural root",
+    "cervical spinal root",
+    "nerve root part of cervical spinal cord",
+    "root of cervical spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfCoccygealNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCoccygealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "description": "A spinal nerve root that is part of a coccygeal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009634#root-of-coccygeal-nerve",
+  "name": "root of coccygeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009634",
+  "synonym": [
+    "coccygeal neural root",
+    "coccygeal spinal nerve root",
+    "root of coccygeal spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfCranialNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfCranialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "description": "The initial segment of a cranial nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006843#root-of-cranial-nerve",
+  "name": "root of cranial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006843",
+  "synonym": [
+    "cranial nerve root",
+    "cranial neural root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfLumbarSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfLumbarSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "description": "A spinal nerve root that is part of a lumbar nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009631#nerve-root-part-of-lumbar-spinal-cord",
+  "name": "root of lumbar spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009631",
+  "synonym": [
+    "lumbar spinal nerve root",
+    "lumbar spinal neural root",
+    "nerve root part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfOlfactoryNerve.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfOlfactoryNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The initial segment of an olfactory nerve, leaving the central nervous system.",
-  "description": "'Root of olfactory nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
+  "description": "The initial segment of an olfactory nerve, leaving the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019311)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727253",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019311#olfactory-nerve-root",
   "name": "root of olfactory nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019311",
-  "synonym": null
+  "synonym": [
+    "olfactory nerve root"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfOpticNerve.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfOpticNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A nerve root that extends_fibers_into a nerve connecting eye with brain.",
-  "description": "'Root of optic nerve' is a root of cranial nerve.",
+  "definition": "Is a root of cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
+  "description": "A nerve root that extends fibers into a nerve connecting eye with brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009906)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728874",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009906#optic-nerve-root",
   "name": "root of optic nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009906",
-  "synonym": null
+  "synonym": [
+    "optic nerve root",
+    "optic tract root",
+    "root of optic tract"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfSacralNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfSacralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "description": "A spinal nerve root that is part of a sacral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009633#nerve-root-part-of-sacral-spinal-cord",
+  "name": "root of sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009633",
+  "synonym": [
+    "nerve root part of sacral spinal cord",
+    "root of sacral spinal nerve",
+    "sacral neural root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfThoracicNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfThoracicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "description": "A spinal nerve root that is part of a thoracic nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009630)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009630#nerve-root-part-of-thoracic-spinal-cord",
+  "name": "root of thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009630",
+  "synonym": [
+    "nerve root part of thoracic spinal cord",
+    "thoracic nerve root",
+    "thoracic neural root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfTrochlearNerve.jsonld
@@ -4,20 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfTrochlearNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Root of trochlear nerve' is a root of cranial nerve. It is part of the brainstem.",
-  "description": "",
+  "definition": "Is a root of cranial nerve. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002618) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112003",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002618#trochlear-nerve-fibers",
   "name": "root of trochlear nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002618",
   "synonym": [
-    "4nf",
     "central part of trochlear nerve",
-    "fibrae nervi trochlearis",
     "trochlear nerve fibers",
-    "trochlear nerve or its root",
     "trochlear nerve root",
-    "trochlear nerve tract",
-    "trochlear nerve/root"
+    "trochlear nerve tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rootOfVagusNerve.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rootOfVagusNerve",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A root of cranial nerve that is part of a vagus nerve.",
-  "description": "'Root of vagus nerve' is a nerve root.",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
+  "description": "A root of cranial nerve that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011213)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731734",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011213#vagus-nerve-root",
   "name": "root of vagus nerve",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011213",
-  "synonym": null
+  "synonym": [
+    "rootlet of vagus nerve",
+    "vagal root",
+    "vagus nerve root",
+    "vagus root"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rostralOctavalNerveMotorNucleus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralOctavalNerveMotorNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an octaval nerve motor nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002175#rostral-octaval-nerve-motor-nucleus",
+  "name": "rostral octaval nerve motor nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002175",
+  "synonym": [
+    "ROLE",
+    "rostral cranial nerve VIII motor nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rostralOctavalNerveSensoryNucleus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralOctavalNerveSensoryNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an octaval nerve sensory nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000274)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000274#rostral-octaval-nerve-sensory-nucleus",
+  "name": "rostral octaval nerve sensory nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000274",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rostralRootOfAbducensNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralRootOfAbducensNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of abducens nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009909)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009909#rostral-root-of-abducens-nerve",
+  "name": "rostral root of abducens nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009909",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "description": "The five sacral nerves emerge from the sacrum. Although the vertebral components of the sacrum are fused into a single bone, the sacral vertebrae are still used to number the sacral nerves. Posteriorly, they emerge from the posterior sacral foramina, and form the posterior branches of sacral nerves. Anteriorly, they emerge from the anterior sacral foramina, and contribute to the sacral plexus (S1-S4) and coccygeal plexus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009625)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009625#sacral-nerve",
+  "name": "sacral nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009625",
+  "synonym": [
+    "nervus sacralis",
+    "sacral spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralNervePlexus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbosacral nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "description": "A nerve plexus which provides motor and sensory nerves for the posterior thigh, most of the lower leg, the entire foot, and part of the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034986)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034986#sacral-nerve-plexus",
+  "name": "sacral nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034986",
+  "synonym": [
+    "plexus sacralis",
+    "sacral plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "description": "A splanchnic nerve that connects the inferior hypogastric plexus to the sympathetic trunk in the pelvis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018684)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018684#sacral-splanchnic-nerve",
+  "name": "sacral splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018684",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034902)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034902#sacral-sympathetic-nerve-trunk",
+  "name": "sacral sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034902",
+  "synonym": [
+    "sacral part of sympathetic trunk",
+    "sacral sympathetic chain",
+    "sacral sympathetic trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/saphenousNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/saphenousNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/saphenousNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the femoral nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475) ('is_a' and 'relationship')]",
+  "description": "The largest cutaneous branch of the femoral nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002475)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002475#saphenous-nerve",
+  "name": "saphenous nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002475",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sciaticNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sciaticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sciaticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the lumbosacral nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322) ('is_a' and 'relationship')]",
+  "description": "A large nerve that supplies nearly the whole of the skin of the leg, the muscles of the back of the thigh, and those of the leg and foot. It begins in the lower back and runs through the buttock and down the lower limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001322)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001322#sciatic-nerve-1",
+  "name": "sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001322",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/segmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/segmentalSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005197)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005197#segmental-spinal-nerve",
+  "name": "segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005197",
+  "synonym": [
+    "cervical segmental spinal nerves C1-7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "description": "A nerve that transmits from sensory receptors on the surface of the body to the central nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001027)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001027#sensory-nerve",
+  "name": "sensory nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001027",
+  "synonym": [
+    "nervus sensorius"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryRootOfFacialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryRootOfFacialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a facial nerve root. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699) ('is_a' and 'relationship')]",
+  "description": "The nervus intermedius, or intermediate nerve, is the part of the facial nerve (cranial nerve VII) located between the motor component of the facial nerve and the vestibulocochlear nerve (cranial nerve VIII). It contains the sensory and parasympathetic fibers of the facial nerve. Upon reaching the facial canal, it joins with the motor root of the facial nerve at the geniculate ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001699#sensory-root-of-facial-nerve",
+  "name": "sensory root of facial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001699",
+  "synonym": [
+    "sensory component of the VIIth (facial) nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryRootOfTrigeminalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryRootOfTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009907)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009907#sensory-root-of-trigeminal-nerve",
+  "name": "sensory root of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009907",
+  "synonym": [
+    "radix sensoria (nervus trigeminus [v])",
+    "radix sensoria nervus trigemini"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/shortCiliaryNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/shortCiliaryNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an iris nerve, parasympathetic nerve and nerve of head region. Is part of the main ciliary ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302) ('is_a' and 'relationship')]",
+  "description": "A branch of the ciliary ganglion that innervates the ciliary muscles, the iris, and the tunics of the eyeball. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022302)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022302#short-ciliary-nerve",
+  "name": "short ciliary nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022302",
+  "synonym": [
+    "lower branch of ciliary ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/shoulderNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/shoulderNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/shoulderNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "description": "A nerve that is part of a shoulder. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003436)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003436#shoulder-nerve",
+  "name": "shoulder nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003436",
+  "synonym": [
+    "nerve of shoulder"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "description": "The any of the paired peripheral nerves formed by the union of the dorsal and ventral spinal roots from each spinal cord segment. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001780)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001780#spinal-nerve",
+  "name": "spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001780",
+  "synonym": [
+    "backbone nerve",
+    "nerve of backbone",
+    "nerve of spinal column",
+    "nerve of spine",
+    "nerve of vertebral column",
+    "spinal column nerve",
+    "spinal nerve tree",
+    "spine nerve",
+    "vertebral column nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "description": "An intermingling of fiber fascicles from adjacent spinal nerves to form a network. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001813)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001813#spinal-nerve-plexus",
+  "name": "spinal nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001813",
+  "synonym": [
+    "plexus nervorum spinalium",
+    "plexus of spinal nerves",
+    "somatic nerve plexus",
+    "spinal nerve plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "description": "The paired bundles of nerve fibers entering and leaving the spinal cord at each segment. The dorsal and ventral nerve roots join to form the mixed segmental spinal nerves. The dorsal roots are generally afferent, formed by the central projections of the spinal (dorsal root) ganglia sensory cells, and the ventral roots efferent, comprising the axons of spinal motor and autonomic preganglionic neurons. There are, however, some exceptions to this afferent/efferent rule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009623#spinal-nerve-root",
+  "name": "spinal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009623",
+  "synonym": [
+    "root of spinal nerve",
+    "spinal neural root",
+    "spinal root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476) ('is_a' and 'relationship')]",
+  "description": "Trunk part of spinal nerve, where dorsal and ventral roots meet to form the spinal nerve, before branching off to dorsal and ventral rami. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005476)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005476#spinal-nerve-trunk",
+  "name": "spinal nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005476",
+  "synonym": [
+    "spinal nerve (trunk)",
+    "spinal neural trunk",
+    "trunk of spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalNucleusOfTrigeminalNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalNucleusOfTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal sensory nucleus and nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "description": "Nucleus extending from the upper spinal cord through the pontine tegmentum that receives sensory inputs from the trigeminal nerve. It is continuous caudally with the dorsal gray matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001717)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001717#spinal-nucleus-of-trigeminal-nerve",
+  "name": "spinal nucleus of trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001717",
+  "synonym": [
+    "spinal nucleus of cranial nerve v",
+    "spinal trigeminal nucleus",
+    "trigeminal nerve spinal tract nucleus",
+    "trigeminal spinal nucleus",
+    "trigeminal v spinal sensory nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/splanchnicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/splanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/splanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "description": "The major nerves supplying sympathetic innervation to the abdomen, including the greater, lesser, and lowest (or smallest) splanchnic nerves that are formed by preganglionic fibers from the spinal cord which pass through the paravertebral ganglia and then to the celiac ganglia and plexuses and the lumbar splanchnic nerves carry fibers which pass through the lumbar paravertebral ganglia to the mesenteric and hypogastric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003715#splanchnic-nerve",
+  "name": "splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003715",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/submucousNervePlexus.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/submucousNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an enteric plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "description": "The gangliated plexus of unmyelinated nerve fibers that ramify the stomach and intestinal submucosa. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005304)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005304#submucous-nerve-plexus",
+  "name": "submucous nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005304",
+  "synonym": [
+    "submucosal nerve plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superficialFibularNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superficialFibularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve and fibular nerve. Is part of the common fibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526) ('is_a' and 'relationship')]",
+  "description": "A branch of the common fibular nerve that innervates the fibularis longus and brevis muscles, and via branches innervates parts of the dorsal part of the pes. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035526)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035526#superficial-fibular-nerve",
+  "name": "superficial fibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035526",
+  "synonym": [
+    "superficial peroneal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorAlveolarNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorAlveolarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018398) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018398#superior-alveolar-nerve",
+  "name": "superior alveolar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018398",
+  "synonym": [
+    "superior dental nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorBranchOfOculomotorNerve.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorBranchOfOculomotorNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the oculomotor nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162) ('is_a' and 'relationship')]",
+  "description": "The superior branch of the oculomotor nerve or the superior division, the smaller, passes medialward over the optic nerve. It supplies the Superior rectus and Levator palpebrae superioris. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015162#superior-branch-of-oculomotor-nerve",
+  "name": "superior branch of oculomotor nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015162",
+  "synonym": [
+    "oculomotor nerve superior division",
+    "ramus superior (nervus oculomotorius [III])",
+    "ramus superior nervi oculomotorii",
+    "ramus superior nervus oculomotorii",
+    "superior ramus of oculomotor nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorHypogastricNervePlexus.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorHypogastricNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "description": "The superior hypogastric plexus (in older texts, hypogastric plexus or presacral nerve) is a plexus of nerves situated on the vertebral bodies below the bifurcation of the aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002013)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002013#superior-hypogastric-nerve-plexus",
+  "name": "superior hypogastric nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002013",
+  "synonym": [
+    "nervus presacralis",
+    "plexus hypogastricus superior",
+    "presacral nerve",
+    "superior hypogastric plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorLaryngealNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorLaryngealNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region and laryngeal nerve. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326) ('is_a' and 'relationship')]",
+  "description": "The superior laryngeal nerve is a branch of the vagus nerve. It arises from the middle of the ganglion nodosum and in its course receives a branch from the superior cervical ganglion of the sympathetic. It descends, by the side of the pharynx, behind the internal carotid artery, and divides into two branches: external laryngeal nerve internal laryngeal nerve A superior laryngeal nerve palsy changes the pitch of the voice and causes an inability to make explosive sounds. If no recovery is evident three months after the palsy initially presents, the damage is most likely to be permanent. A bilateral palsy presents as a tiring and hoarse voice. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011326)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011326#superior-laryngeal-nerve",
+  "name": "superior laryngeal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011326",
+  "synonym": [
+    "nervus laryngealis superior",
+    "nervus laryngeus superior",
+    "superior laryngeal branch of inferior vagal ganglion",
+    "superior laryngeal branch of vagus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/suralNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/suralNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/suralNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the tibial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488) ('is_a' and 'relationship')]",
+  "description": "The sural nerve (short saphenous nerve), formed by the junction of the medial sural cutaneous with the peroneal anastomotic branch of the lateral sural cutaneous nerve, passes downward near the lateral margin of the tendo calcaneus, lying close to the small saphenous vein, to the interval between the lateral malleolus and the calcaneus. It runs forward below the lateral malleolus, and is continued as the lateral dorsal cutaneous nerve along the lateral side of the foot and little toe (via a dorsal digital nerve), communicating on the dorsum of the foot with the intermediate dorsal cutaneous nerve, a branch of the superficial peroneal. In the leg, its branches communicate with those of the posterior femoral cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0015488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0015488#sural-nerve",
+  "name": "sural nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0015488",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034729) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034729#sympathetic-nerve",
+  "name": "sympathetic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034729",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticNervePlexus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNervePlexus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic nerve plexus. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373) ('is_a' and 'relationship')]",
+  "description": "A nerve plexus that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012373#sympathetic-nerve-plexus",
+  "name": "sympathetic nerve plexus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012373",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticNerveTrunk.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a sympathetic nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004295)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004295#sympathetic-nerve-trunk",
+  "name": "sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004295",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system",
+    "nerve trunk of sympathetic part of autonomic division of nervous system",
+    "sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/terminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/terminalNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/terminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "description": "The terminal nerve, located anterior to cranial nerve I, is comprised of a group of cells with somata adjacent to the olfactory bulb and processes that extend anteriorly to the olfactory epithelium and posteriorly to the telencephalon. In teleost fish an additional group of axons extends along the optic tract and delivers putative neuromodulators to the retina. It is thought to develop from cranial neural crest. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002924#terminal-nerve-1",
+  "name": "terminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002924",
+  "synonym": [
+    "cranial nerve 0",
+    "cranial nerve zero",
+    "nervus terminalis",
+    "terminalis nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/terminalNerveRoot.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/terminalNerveRoot",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "description": "A nerve root that extends fibers into a terminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014641)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014641#terminal-nerve-root-1",
+  "name": "terminal nerve root",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014641",
+  "synonym": [
+    "cranial nerve 0 root",
+    "root of terminal nerve",
+    "terminal nerve root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicCavityNerve.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicCavityNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "description": "A nerve that is located in a thoracic cavity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003443)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003443#thoracic-cavity-nerve",
+  "name": "thoracic cavity nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003443",
+  "synonym": [
+    "cavity of chest nerve",
+    "cavity of thorax nerve",
+    "chest cavity nerve",
+    "nerve of cavity of chest",
+    "nerve of cavity of thorax",
+    "nerve of chest cavity",
+    "nerve of pectoral cavity",
+    "nerve of thoracic cavity",
+    "pectoral cavity nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "description": "The twelve spinal nerves on each side of the thorax. They include eleven INTERCOSTAL NERVES and one subcostal nerve. Both sensory and motor, they supply the muscles and skin of the thoracic and abdominal walls. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003726#thoracic-nerve",
+  "name": "thoracic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003726",
+  "synonym": [
+    "nervus thoracis",
+    "thoracic spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSplanchnicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSplanchnicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a splanchnic nerve and nerve of thoracic segment. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679) ('is_a' and 'relationship')]",
+  "description": "Thoracic splanchnic nerves are splanchnic nerves that arise from the sympathetic trunk in the thorax and travel inferiorly to provide sympathetic innervation to the abdomen. The nerves contain preganglionic sympathetic and general visceral afferent fibers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018679)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018679#thoracic-splanchnic-nerve",
+  "name": "thoracic splanchnic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018679",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSympatheticNerveTrunk.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSympatheticNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic nerve trunk. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "description": "A sympathetic nerve trunk that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004863)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004863#thoracic-sympathetic-nerve-trunk",
+  "name": "thoracic sympathetic nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004863",
+  "synonym": [
+    "nerve trunk of sympathetic nervous system of thorax",
+    "nerve trunk of sympathetic part of autonomic division of nervous system of thorax",
+    "sympathetic nerve trunk of thorax",
+    "sympathetic nervous system nerve trunk of thorax",
+    "thoracic part of sympathetic trunk",
+    "thoracic sympathetic chain",
+    "thorax nerve trunk of sympathetic nervous system",
+    "thorax nerve trunk of sympathetic part of autonomic division of nervous system",
+    "thorax sympathetic nerve trunk",
+    "thorax sympathetic nervous system nerve trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tibialNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tibialNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tibialNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323) ('is_a' and 'relationship')]",
+  "description": "The tibial nerve is a branch of the sciatic nerve. The tibial nerve passes through the popliteal fossa to pass below the arch of soleus. In the popliteal fossa the nerve gives off branches to gastrocnemius, popliteus, soleus and plantaris muscles, an articular branch to the knee joint, and a cutaneous branch that will become the sural nerve. The sural nerve is joined by fibres from the common peroneal nerve and runs down the calf to supply the lateral side of the foot. Below the soleus muscle the nerve lies close to the tibia and supplies the tibialis posterior, the flexor digitorum longus and the flexor hallucis longus. The nerve passes into the foot running posterior to the medial malleolus. Here it is bound down by the flexor retinaculum in company with the posterior tibial artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001323)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001323#tibial-nerve",
+  "name": "tibial nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001323",
+  "synonym": [
+    "medial popliteal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "description": "Cranial nerve that has three branches - the ophthalmic (supplying the skin of the nose and upper jaw), the maxillary and the mandibular (supplying the lower jaw). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001645)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001645#trigeminal-nerve-1",
+  "name": "trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001645",
+  "synonym": [
+    "fifth cranial nerve",
+    "nervus trigeminus",
+    "nervus trigeminus [v]",
+    "trigeminal nerve [V]",
+    "trigeminal nerve tree",
+    "trigeminal V",
+    "trigeminal v nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerveFibers.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerveFibers",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "A nerve fiber that is part of a trigeminal nerve.",
-  "description": "'Trigeminal nerve fibers' is a nerve fiber. It is part of the trigeminal nerve.",
+  "definition": "Is a nerve fiber. Is part of the trigeminal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041) ('is_a' and 'relationship')]",
+  "description": "A nerve fiber that is part of a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003041)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111965",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003041#trigeminal-nerve-fibers-1",
   "name": "trigeminal nerve fibers",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003041",
   "synonym": [
     "central part of trigeminal nerve",
-    "fibrae nervi trigemini",
     "trigeminal nerve fibers",
     "trigeminal nerve tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trigeminalNerveRoot.jsonld
@@ -4,11 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Trigeminal nerve root' is a root of cranial nerve. It is part of the metencephalon.",
-  "description": "A nerve root that extends_fibers_into a trigeminal nerve.",
+  "definition": "Is a root of cranial nerve. Is part of the metencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673) ('is_a' and 'relationship')]",
+  "description": "A nerve root that extends fibers into a trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004673)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111966",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004673#trigeminal-nerve-root-1",
   "name": "trigeminal nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004673",
-  "synonym": null
+  "synonym": [
+    "radix descendens nervi trigemini",
+    "root of trigeminal nerve",
+    "root of trigeminal V nerve",
+    "trigeminal nerve root",
+    "trigeminal neural root"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trochlearNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trochlearNerve.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trochlearNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "description": "A cranial nerve that runs to the eye muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001644)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001644#trochlear-nerve-1",
+  "name": "trochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001644",
+  "synonym": [
+    "cranial nerve IV",
+    "fourth cranial nerve",
+    "nervus trochlearis [IV]",
+    "superior oblique nerve",
+    "trochlear IV nerve",
+    "trochlear nerve [IV]",
+    "trochlear nerve tree"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkOfIntercostalNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfIntercostalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the intercostal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002327) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002327#trunk-of-intercostal-nerve",
+  "name": "trunk of intercostal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002327",
+  "synonym": [
+    "intercostal nerve trunk",
+    "intercostal neural trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkOfPhrenicNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfPhrenicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the phrenic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001889) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001889#trunk-of-phrenic-nerve",
+  "name": "trunk of phrenic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001889",
+  "synonym": [
+    "phrenic nerve trunk",
+    "phrenic neural trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkOfSciaticNerve.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfSciaticNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the sciatic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002004) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002004#trunk-of-sciatic-nerve",
+  "name": "trunk of sciatic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002004",
+  "synonym": [
+    "sciatic nerve trunk",
+    "sciatic neural trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkOfSegmentalSpinalNerve.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkOfSegmentalSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve trunk. Is part of the segmental spinal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035022) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035022#trunk-of-segmental-spinal-nerve",
+  "name": "trunk of segmental spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035022",
+  "synonym": [
+    "segmental spinal nerve trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tympanicNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tympanicNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tympanicNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the glossopharyngeal nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216) ('is_a' and 'relationship')]",
+  "description": "The tympanic nerve (nerve of Jacobson) is a branch of the glossopharyngeal nerve found near the ear. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036216)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036216#tympanic-nerve",
+  "name": "tympanic nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036216",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ulnarNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ulnarNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ulnarNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. Is part of the brachial nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494) ('is_a' and 'relationship')]",
+  "description": "A nerve which runs near the ulna bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001494)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001494#ulnar-nerve",
+  "name": "ulnar nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001494",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/unmyelinatedNerveFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/unmyelinatedNerveFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve fiber. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006136)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006136#unmyelinated-nerve-fiber",
+  "name": "unmyelinated nerve fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006136",
+  "synonym": [
+    "non-myelinated nerve fiber"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/upperArmNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/upperArmNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperArmNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an arm nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "description": "A nerve that is part of a forelimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004217)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004217#upper-arm-nerve",
+  "name": "upper arm nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004217",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/upperEyelidNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperEyelidNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an eyelid nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "description": "A nerve that innervates an upper eyelid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022299#upper-eyelid-nerve",
+  "name": "upper eyelid nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022299",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/upperLegNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/upperLegNerve.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/upperLegNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a leg nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "description": "A nerve that is part of a hindlimb stylopod. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004214)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004214#upper-leg-nerve",
+  "name": "upper leg nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004214",
+  "synonym": [
+    "hind limb stylopod nerve",
+    "hindlimb stylopod nerve",
+    "lower extremity stylopod nerve",
+    "thigh RELATED"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalNerveFiberBundle.jsonld
@@ -4,18 +4,21 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalNerveFiberBundle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Vagal nerve fiber bundle' is a neuron projection bundle and central nervous system cell part cluster. It is part of the medulla oblongata.",
-  "description": "",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006116) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112236",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006116#vagal-nerve-fiber-bundle-1",
   "name": "vagal nerve fiber bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006116",
   "synonym": [
     "central part of vagus nerve",
-    "fibrae nervi vagi",
+    "central part of vagus nerve",
+    "tenth cranial nerve fibers",
     "tenth cranial nerve fibers",
     "vagal nerve fiber bundle",
+    "vagal nerve fibers",
     "vagal nerve fibers",
     "vagal nerve tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagusNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagusNerve.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "description": "Cranial nerve that branches into the lateral (to body sense organs) and the intestino-accessorial (to the skin, muscles of shoulder, hyoid, larynx, gut, lungs, and heart). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001759#vagus-nerve-1",
+  "name": "vagus nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001759",
+  "synonym": [
+    "nervus vagus [x]",
+    "tenth cranial nerve",
+    "vagus",
+    "vagus nerve [X]",
+    "vagus nerve tree",
+    "vagus X nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagusNerveNucleus.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusNerveNucleus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve nucleus and hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "description": "A cranial nerve nucleus that is associated with a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011775#vagus-nerve-nucleus",
+  "name": "vagus nerve nucleus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011775",
+  "synonym": [
+    "nucleus of vagal nerve",
+    "nucleus of vagal X nerve",
+    "nucleus of vagus nerve",
+    "nucleus of Xth nerve",
+    "tenth cranial nerve nucleus",
+    "vagal nucleus",
+    "vagal X nucleus",
+    "vagus nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagusXNerveTrunk.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusXNerveTrunk",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve trunk. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535) ('is_a' and 'relationship')]",
+  "description": "A nerve trunk that is part of a vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003535#vagus-x-nerve-trunk",
+  "name": "vagus X nerve trunk",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003535",
+  "synonym": [
+    "trunk of vagal nerve",
+    "trunk of vagus nerve",
+    "vagal nerve trunk",
+    "vagal X nerve trunk",
+    "vagus nerve trunk",
+    "vagus neural trunk"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralAnteriorLateralLineNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line nerve. Is part of the anterior lateral line nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers originating from the ventral anterior lateral line ganglion. These rami innervate the mandibular and opercular neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001481)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001481#ventral-anterior-lateral-line-nerve",
+  "name": "ventral anterior lateral line nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001481",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralMotorNucleusTrigeminalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralMotorNucleusTrigeminalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a motor nucleus of trigeminal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000703)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000703#ventral-motor-nucleus-trigeminal-nerve",
+  "name": "ventral motor nucleus trigeminal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000703",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralNerveCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralNerveCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a primary nerve cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "description": "The pair of closely united ventral longitudinal nerves with their segmental ganglia that is characteristic of many elongate invertebrates (as earthworms). A large process bundle that runs along the vental mid-line extending from the ventral region of the nerve ring. The ventral cord is one of the distinguishing traits of the central nervous system of all arthropods (such as insects, crustaceans and arachnids) as well as many other invertebrates, such as the annelid worms. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000934)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000934#ventral-nerve-cord",
+  "name": "ventral nerve cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000934",
+  "synonym": [
+    "ventral cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral root of spinal cord and root of cervical nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "description": "A ventral root of spinal cord that overlaps a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014634)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014634#ventral-nerve-root-of-cervical-spinal-cord-1",
+  "name": "ventral nerve root of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014634",
+  "synonym": [
+    "ventral nerve root of cervical spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfLumbarSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of lumbar spinal nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0024382)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0024382#ventral-nerve-root-of-lumbar-spinal-cord-1",
+  "name": "ventral nerve root of lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0024382",
+  "synonym": [
+    "ventral nerve root of lumbar spinal cord",
+    "ventral nerve root of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfSacralSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfSacralSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of sacral nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023623)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023623#ventral-nerve-root-of-sacral-spinal-cord-1",
+  "name": "ventral nerve root of sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023623",
+  "synonym": [
+    "ventral nerve root of sacral spinal cord",
+    "ventral nerve root of sacral spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralNerveRootOfThoracicSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a root of thoracic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014617)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014617#ventral-nerve-root-of-thoracic-spinal-cord-1",
+  "name": "ventral nerve root of thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014617",
+  "synonym": [
+    "ventral nerve root of thoracic spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralRamusOfSpinalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralRamusOfSpinalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve. Is part of the spinal nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838) ('is_a' and 'relationship')]",
+  "description": "Branch of spinal nerve that innervates the hypaxial muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006838)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006838#ventral-ramus-of-spinal-nerve",
+  "name": "ventral ramus of spinal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006838",
+  "synonym": [
+    "anterior primary ramus of spinal nerve",
+    "anterior ramus of spinal nerve",
+    "ventral ramus of spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibularNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibularNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the vestibulocochlear nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723) ('is_a' and 'relationship')]",
+  "description": "The vestibular nerve is one of the two branches of the Vestibulocochlear nerve (the cochlear nerve being the other). It goes to the semicircular canals via the vestibular ganglion. It receives positional information. Axons of the vestibular nerve synapse in the vestibular nucleus on the lateral floor and wall of the fourth ventricle in the pons and medulla. It arises from bipolar cells in the vestibular ganglion, ganglion of Scarpa, which is situated in the upper part of the outer end of the internal auditory meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003723#vestibular-nerve",
+  "name": "vestibular nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003723",
+  "synonym": [
+    "vestibular root of acoustic nerve",
+    "vestibular root of eighth cranial nerve",
+    "vestibulocochlear VIII nerve vestibular component"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearNerve.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "description": "Cranial nerve that transmits sound and equilibrium (balance) information from the inner ear to the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001648)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001648#vestibulocochlear-nerve-1",
+  "name": "vestibulocochlear nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001648",
+  "synonym": [
+    "acoustic nerve",
+    "acoustic nerve (Crosby)",
+    "acoustic VIII nerve",
+    "CN-VIII",
+    "cochlear-vestibular nerve",
+    "cochleovestibular nerve",
+    "cranial nerve VIII",
+    "eighth cranial nerve",
+    "nervus vestibulocochlearis [viii]",
+    "stato-acoustic nerve",
+    "vestibulocochlear nerve [VIII]",
+    "vestibulocochlear nerve tree",
+    "vestibulocochlear VIII nerve",
+    "VIII nerve",
+    "VIIIth cranial nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearNerveRoot.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearNerveRoot",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Vestibulocochlear nerve root' is a root of cranial nerve. It is part of the pontine tegmentum.",
-  "description": "Either of the two roots that come of the vestibulocochlear nerve",
+  "definition": "Is a root of cranial nerve. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731) ('is_a' and 'relationship')]",
+  "description": "Either of the two roots that come of the vestibulocochlear nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002731)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112460",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002731#vestibulocochlear-nerve-fiber-bundle",
   "name": "vestibulocochlear nerve root",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002731",
   "synonym": [
-    "8cn",
     "central part of vestibulocochlear nerve",
     "fibrae nervi statoacustici",
     "root of vestibulocochlear nerve",
     "statoacoustic nerve fibers",
-    "vestibular root of vestibulocochlear nerve",
     "vestibulocochlear nerve fibers",
     "vestibulocochlear nerve roots",
     "vestibulocochlear nerve tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vidianNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vidianNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vidianNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412) ('is_a' and 'relationship')]",
+  "description": "A nerve that is formed by the junction of the great petrosal nerve and the deep petrosal nerve and continues on to innervate the palate, nose and lacrimal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018412)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018412#vidian-nerve",
+  "name": "vidian nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018412",
+  "synonym": [
+    "nerve of pterygoid canal",
+    "pterygoid canal nerve",
+    "vidian nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vomeronasalNerve.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vomeronasalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "description": "Nerve carrying fibers from the vomeronasal organ epithelium to the accessory olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009121)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009121#vomeronasal-nerve",
+  "name": "vomeronasal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009121",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wristNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wristNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wristNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a manus nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "description": "A nerve that is part of a wrist. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003434)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003434#wrist-nerve",
+  "name": "wrist nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003434",
+  "synonym": [
+    "carpal region nerve",
+    "nerve of carpal region",
+    "nerve of wrist"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/zygomaticotemporalNerve.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/zygomaticotemporalNerve",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264) ('is_a' and 'relationship')]",
+  "description": "The zygomaticotemporal nerve or zygomaticotemporal branch (temporal branch) is derived from the maxillary branch of the trigeminal nerve (Cranial nerve V). It runs along the lateral wall of the orbit in a groove in the zygomatic bone, receives a branch of communication from the lacrimal, and passes through zygomaticotemporal foramen in the zygomatic bone to enter the temporal fossa. It ascends between the bone, and substance of the Temporalis muscle, pierces the temporal fascia about 2.5 cm. above the zygomatic arch, and is distributed to the skin of the side of the forehead, and communicates with the facial nerve and with the auriculotemporal branch of the mandibular nerve. As it pierces the temporal fascia, it gives off a slender twig, which runs between the two layers of the fascia to the lateral angle of the orbit. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036264#zygomaticotemporal-nerve",
+  "name": "zygomaticotemporal nerve",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036264",
+  "synonym": [
+    "ramus zygomaticotemporalis (Nervus zygomaticus)",
+    "ramus zygomaticotemporalis nervus zygomatici",
+    "zygomaticotemporal branch of zygomatic nerve"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'nerve' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.

The spellcheck will fail because it reacts to 'opthalamic nerve' which is listed as a synonym for 'ophthalamic' (extra h between op and thalamic). Technically, the spellcheck is correct because it is not commonly used. What should we do? remove it from the list of synonyms or ignore the spell check?