### PR TITLE
UBERON terms with 'ganglion' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/GruenebergGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "description": "An olfactory ganglion at the entrance of the nose of mammals that is involved in the detection of alarm pheromones and cold temperatures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013208#grueneberg-ganglion",
+  "name": "Grueneberg ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013208",
+  "synonym": [
+    "Grüneberg ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/abdominalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/abdominalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/abdominalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trunk ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "description": "A ganglion that is part of a abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009758#abdominal-ganglion",
+  "name": "abdominal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009758",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/abdominalGanglionOfVisceralHump",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "description": "An unpaired knot of nerves in The visceral sacs that innervates the pallial organs as well as the inner organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008964#abdominal-ganglion-of-visceral-hump",
+  "name": "abdominal ganglion of visceral hump",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008964",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryCiliaryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "description": "A parasympathetic ganglion located on the short ciliary nerve differentiated from the main ciliary ganglion by virtue of the fact that it had no root derived directly from the inferior trunk of the oculomotor nerve and it never attaches to this nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035776#accessory-ciliary-ganglion",
+  "name": "accessory ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035776",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012175#acoustico-facial-vii-viii-ganglion-complex",
+  "name": "acoustico-facial VII-VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012175",
+  "synonym": [
+    "acousticofacial ganglion",
+    "facio-acoustic ganglion",
+    "facio-acoustic ganglion complex VII-VIII"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "description": "The anteror lateral line ganglia develops from cranial ectodermal placodes and contain sensory neurons that innervate the anterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001391#anterior-lateral-line-ganglion",
+  "name": "anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001391",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/areaXOfBasalGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Area X of basal ganglion' is a nucleus of brain. It is part of the basal ganglion.",
-  "description": "A nucleus in the basal ganglion of songbirds.",
+  "definition": "Is a nucleus of brain. Is part of the basal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the basal ganglion of songbirds. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731535",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035807#area-x-of-basal-ganglion",
   "name": "area X of basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035807",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/autonomicGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/autonomicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/autonomicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion of peripheral nervous system. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805) ('is_a' and 'relationship')]",
+  "description": "Ganglion that has dendrites that form a junction between autonomic nerves originating from the central nervous system and autonomic nerves innervating their target organs in the periphery. There are two subtypes, sympathetic ganglion and parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001805#autonomic-ganglion",
+  "name": "autonomic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001805",
+  "synonym": [
+    "autonomic nervous system ganglion",
+    "ganglion of autonomic nervous system",
+    "ganglion of visceral nervous system",
+    "visceral nervous system ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/basalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/basalGanglion.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/basalGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Basal ganglion' is a brain gray matter and nuclear complex of neuraxis. It is part of the collection of basal ganglia.",
-  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum[NIF,modified].",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. Is part of the collection of basal ganglia. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420) ('is_a' and 'relationship')]",
+  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002420#basal-ganglion",
   "name": "basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002420",
-  "synonym": null
+  "synonym": [
+    "basal ganglion of telencephalon"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/cardiacGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cardiacGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cardiacGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "description": "Any of the parasympathetic ganglia of the cardiac plexus between the arch of the aorta and the bifurcation of the pulmonary artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014463#cardiac-ganglion",
+  "name": "cardiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014463",
+  "synonym": [
+    "cardiac ganglia set",
+    "cardiac ganglion of Wrisberg",
+    "ganglia cardiaca",
+    "ganglion of Wrisberg",
+    "Wrisberg ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudalGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026) ('is_a' and 'relationship')]",
+  "description": "The caudally located, distinct elevation of a transient proliferating cell mass of the fetal subventricular zone, located adjacent to the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004026#caudal-ganglionic-eminence",
+  "name": "caudal ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004026",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/celiacGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/celiacGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/celiacGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "description": "The celiac ganglia are two large irregularly shaped masses of nerve tissue in the upper abdomen. Part of the sympathetic subdivision of the autonomic nervous system (ANS), the two celiac ganglia are the largest ganglia in the ANS, and they innervate most of the digestive tract. They have the appearance of lymph glands and are placed on either side of the midline in front of the crura of the diaphragm, close to the suprarenal glands (also called adrenal glands). The ganglion on the right side is placed behind the inferior vena cava. They are sometimes referred to as the semilunar ganglia or the solar ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002262#celiac-ganglion",
+  "name": "celiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002262",
+  "synonym": [
+    "coeliac ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002834)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002834#cervical-dorsal-root-ganglion-1",
+  "name": "cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002834",
+  "synonym": [
+    "cervical dorsal root ganglion",
+    "cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "description": "The cervical ganglia are paravertebral ganglia of the sympathetic nervous system. They consist of three paravertebral ganglia: superior cervical ganglion middle cervical ganglion inferior cervical ganglion. The inferior ganglion may be fused with the first thoracic ganglion to form a single structure, the stellate ganglion. Nerves emerging from cervical sympathetic ganglia contribute to the cardiac plexus, among other things. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001991#cervical-ganglion",
+  "name": "cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001991",
+  "synonym": [
+    "cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicothoracicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "description": "The group of neurons formed by the fusion of the inferior cervical and first thoracic ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002441#cervicothoracic-ganglion",
+  "name": "cervicothoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002441",
+  "synonym": [
+    "cervicothoracic sympathetic ganglion",
+    "ganglion cervicothoracicum",
+    "ganglion stellatum",
+    "stellate ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cochlearGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cochlearGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cochlearGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395) ('is_a' and 'relationship')]",
+  "description": "The group of nerve cell bodies that conveys auditory sensation from the organ of Corti to the hindbrain and resides on the cochlear part of the vestibulocochlear nerve (eighth cranial nerve). distributed to the hair cells of the spiral organ. The cochlear fibers arise in bipolar cells in the spiral ganglion in the modiolus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000395#cochlear-ganglion",
+  "name": "cochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000395",
+  "synonym": [
+    "cochlear part of vestibulocochlear ganglion",
+    "Corti's ganglion",
+    "ganglion of Corti",
+    "spiral ganglion",
+    "vestibulocochlear VIII ganglion cochlear component"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cranialGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cranialGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cranialGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "description": "The groups of nerve cell bodies associated with the twelve cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001714#cranial-ganglion-part-of-peripheral-nervous-system",
+  "name": "cranial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001714",
+  "synonym": [
+    "cranial ganglion",
+    "cranial ganglion part of peripheral nervous system",
+    "cranial ganglion/nerve",
+    "cranial nerve ganglion",
+    "cranial neural ganglion",
+    "cranial neural tree organ ganglion",
+    "ganglion of cranial nerve",
+    "ganglion of cranial neural tree organ"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cranialSensoryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "description": "The ganglion found on the root of each cranial nerve, containing the cell bodies of afferent (sensory) neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009992#cranial-sensory-ganglion",
+  "name": "cranial sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009992",
+  "synonym": [
+    "cranial nerve sensory ganglion",
+    "ganglion sensorium cranialium",
+    "ganglion sensorium nervi cranialis",
+    "sensory ganglion of cranial nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalAnteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001312)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001312#dorsal-anterior-lateral-line-ganglion",
+  "name": "dorsal anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001312",
+  "synonym": [
+    "anterodorsal lateral line ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalLateralGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lateral ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264) ('is_a' and 'relationship')]",
+  "description": "The dorsal region of the lateral ganglionic eminence. The cells in this area give rise to embryonic interneuron precursors that will migrate tangentially to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018264#dorsal-lateral-ganglionic-eminence",
+  "name": "dorsal lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018264",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "description": "Sensory ganglia located on the dorsal spinal roots within the vertebral column. The spinal ganglion cells are pseudounipolar. The single primary branch bifurcates sending a peripheral process to carry sensory information from the periphery and a central branch which relays that information to the spinal cord or brain. (MSH) * ganglion found on the posterior root of each spinal nerve, composed of the unipolar nerve cell bodies of the sensory neurons of the nerve. (CSP) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000044#dorsal-root-ganglion-1",
+  "name": "dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000044",
+  "synonym": [
+    "dorsal root ganglion",
+    "ganglion of dorsal root",
+    "ganglion spinalis",
+    "spinal ganglion",
+    "spinal ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002844#eighth-cervical-dorsal-root-ganglion-1",
+  "name": "eighth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002844",
+  "synonym": [
+    "eighth cervical dorsal root ganglion",
+    "eighth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002851)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002851#eighth-thoracic-dorsal-root-ganglion-1",
+  "name": "eighth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002851",
+  "synonym": [
+    "eighth thoracic dorsal root ganglion",
+    "eighth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eleventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002854)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002854#eleventh-thoracic-dorsal-root-ganglion-1",
+  "name": "eleventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002854",
+  "synonym": [
+    "eleventh thoracic dorsal root ganglion",
+    "eleventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/entericGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/entericGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/entericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. Is part of the enteric nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001809) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001809#enteric-ganglion",
+  "name": "enteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001809",
+  "synonym": [
+    "intramural ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/epibranchialGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "description": "Cranial ganglion which develops from an epibranchial placode. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009127#epibranchial-ganglion",
+  "name": "epibranchial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009127",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006232) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006232#facio-acoustic-vii-viii-preganglion-complex",
+  "name": "facio-acoustic VII-VIII preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006232",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002842)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002842#fifth-cervical-dorsal-root-ganglion-1",
+  "name": "fifth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002842",
+  "synonym": [
+    "C5 dorsal root ganglion",
+    "fifth cervical dorsal root ganglion",
+    "fifth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fifth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002859#fifth-lumbar-dorsal-root-ganglion-1",
+  "name": "fifth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002859",
+  "synonym": [
+    "fifth lumbar dorsal root ganglion",
+    "fifth lumbar spinal ganglion",
+    "L5 dorsal root ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002863)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002863#fifth-sacral-dorsal-root-ganglion-1",
+  "name": "fifth sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002863",
+  "synonym": [
+    "fifth sacral dorsal root ganglion",
+    "fifth sacral spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002848)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002848#fifth-thoracic-dorsal-root-ganglion-1",
+  "name": "fifth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002848",
+  "synonym": [
+    "fifth thoracic dorsal root ganglion",
+    "fifth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002838#first-cervical-dorsal-root-ganglion-1",
+  "name": "first cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002838",
+  "synonym": [
+    "first cervical dorsal root ganglion",
+    "first cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002857)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002857#first-lumbar-dorsal-root-ganglion-1",
+  "name": "first lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002857",
+  "synonym": [
+    "first lumbar dorsal root ganglion",
+    "first lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002860)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002860#first-sacral-dorsal-root-ganglion-1",
+  "name": "first sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002860",
+  "synonym": [
+    "first sacral dorsal root ganglion",
+    "first sacral spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002845)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002845#first-thoracic-dorsal-root-ganglion-1",
+  "name": "first thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002845",
+  "synonym": [
+    "first thoracic dorsal root ganglion",
+    "first thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002841)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002841#fourth-cervical-dorsal-root-ganglion-1",
+  "name": "fourth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002841",
+  "synonym": [
+    "C4 dorsal root ganglion",
+    "fourth cervical dorsal root ganglion",
+    "fourth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fourth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003943#forth-lumbar-dorsal-root-ganglion",
+  "name": "fourth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003943",
+  "synonym": [
+    "forth lumbar dorsal root ganglion",
+    "fourth lumbar dorsal root ganglion",
+    "fourth lumbar spinal ganglion",
+    "L4 dorsal root ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthSacralSpinalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007713)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007713#forth-sacral-dorsal-root-ganglion",
+  "name": "fourth sacral spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007713",
+  "synonym": [
+    "forth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthThoracicSpinalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007712)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007712#fourth-thoracic-dorsal-root-ganglion",
+  "name": "fourth thoracic spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007712",
+  "synonym": [
+    "forth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045) ('is_a' and 'relationship')]",
+  "description": "A biological tissue mass, most commonly a mass of nerve cell bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000045#ganglion-1",
+  "name": "ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000045",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ganglionicEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ganglionicEminence.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023) ('is_a' and 'relationship')]",
+  "description": "The transient proliferative population of neurons that expands exponentially during late prenatal development; it is a continuous germinal zone distinct from the ventricular zone that surrounds the brain ventricles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004023#ganglionic-eminence",
+  "name": "ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004023",
+  "synonym": [
+    "embryonic subventricular zone",
+    "embryonic/fetal subventricular zone",
+    "fetal subventricular zone",
+    "subependymal layer"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/gasserianGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/gasserianGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gasserianGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3011045)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3011045#gasserian-ganglion",
+  "name": "gasserian ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3011045",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gastropodCerebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "description": "The cerebral ganglia are primarily sensual centres, that compute information from the eyes as well as from the tactile and position sensors (statocystes). Besides coordination they also serve the locational memory of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008942#gastropod-cerebral-ganglion",
+  "name": "gastropod cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008942",
+  "synonym": [
+    "cerebral ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/geniculateGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/geniculateGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/geniculateGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory ganglion and epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "description": "The group of sensory neuron cell bodies associated with the facial nerve (seventh cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001700#geniculate-ganglion",
+  "name": "geniculate ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001700",
+  "synonym": [
+    "facial VII ganglion",
+    "ganglion genicularum",
+    "genicular ganglion",
+    "genicular ganglion",
+    "gVII"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "description": "The group of neuron cell bodies associated with the ninth cranial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001701#glossopharyngeal-ganglion",
+  "name": "glossopharyngeal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001701",
+  "synonym": [
+    "ganglion of glossopharyngeal nerve",
+    "ganglion of glosspharyngeal nerve",
+    "glossopharyngeal IX ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealIXPreganglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006243) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006243#glossopharyngeal-ix-preganglion",
+  "name": "glossopharyngeal IX preganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006243",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013500#glossopharyngeal-vagus-ix-x-ganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013500",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013499) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013499#glossopharyngeal-vagus-ix-x-preganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013499",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "description": "The inferior cervical ganglion is situated between the base of the transverse process of the last cervical vertebra and the neck of the first rib, on the medial side of the costocervical artery. Its form is irregular; it is larger in size than the middle cervical ganglion, and is frequently fused with the first thoracic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002440#inferior-cervical-ganglion",
+  "name": "inferior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002440",
+  "synonym": [
+    "variant cervical ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "description": "The lower group of sensory neuron cell bodies associated with the glossopharyngeal nerve. It is situated in a depression in the lower border of the petrous portion of the temporal bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005360#inferior-glossopharyngeal-ix-ganglion",
+  "name": "inferior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005360",
+  "synonym": [
+    "extracraniale ganglion",
+    "ganglion inferius (nervus glossopharygeus)",
+    "ganglion inferius nervus glossopharyngei",
+    "ganglion of andersch",
+    "glossopharyngeal nerve inferior ganglion",
+    "glossopharyngeal nerve petrous ganglion",
+    "inferior ganglion of glossopharyngeal nerve",
+    "inferior glossopharyngeal ganglion",
+    "inferior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve",
+    "ninth cranial nerve inferior ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorMesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the inferior mesenteric nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453) ('is_a' and 'relationship')]",
+  "description": "A ganglion located near where the inferior mesenteric artery branches from the abdominal aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005453#inferior-mesenteric-ganglion",
+  "name": "inferior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005453",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorPartOfVestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002826)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002826#inferior-part-of-vestibular-ganglion-1",
+  "name": "inferior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002826",
+  "synonym": [
+    "pars inferior ganglionis vestibularis",
+    "vestibular ganglion inferior part"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorVagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "description": "The large group of sensory neuron cell bodies, anterior to the jugular vein, associated with the vagus nerve (tenth cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005363#inferior-vagus-x-ganglion",
+  "name": "inferior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005363",
+  "synonym": [
+    "ganglion inferius (nervus vagus)",
+    "ganglion inferius nervi vagi",
+    "ganglion inferius nervus vagi",
+    "ganglion nodosum",
+    "inferior ganglion of vagus",
+    "inferior ganglion of vagus nerve",
+    "nodose ganglion",
+    "tenth cranial nerve nodose ganglion",
+    "vagus nerve inferior ganglion",
+    "vagus nerve nodose ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the striatum; however, neocortex, thalamus, septum and olfactory bulb neurons are also partly derived from the LGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004025#lateral-ganglionic-eminence",
+  "name": "lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004025",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "description": "Ganglion that develops from a cranial ectodermal placode and contains sensory neurons that innervate a lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000120#lateral-line-ganglion",
+  "name": "lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000120",
+  "synonym": [
+    "LLG"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the lumbar vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002836#lumbar-dorsal-root-ganglion-1",
+  "name": "lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002836",
+  "synonym": [
+    "lumbar dorsal root ganglion",
+    "lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mainCiliaryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "description": "A parasympathetic ganglion located in the posterior orbit that contains preganglionic nerves and postganglionic neurons of the oculomotor nerve, connects to the Edinger-Westphal nucleus via the oculomotor nerve and the eye muscles via the short ciliary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002058#main-ciliary-ganglion",
+  "name": "main ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002058",
+  "synonym": [
+    "ciliary ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035601) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035601#maxillomandibular-part-of-trigeminal-ganglion-complex",
+  "name": "maxillomandibular part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035601",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the neocortex; however, hippocampal neurons, thalamus, septum and olfactory bulb neurons are also partly derived from the MGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004024#medial-ganglionic-eminence",
+  "name": "medial ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004024",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mesentericGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. Is part of the mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035769) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035769#mesenteric-ganglion",
+  "name": "mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035769",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/middleCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "description": "The small ganglion located at the level of the cricoid cartilage of the laryngeal wall. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001990#middle-cervical-ganglion",
+  "name": "middle cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001990",
+  "synonym": [
+    "middle cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/middleLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "description": "The middle lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the middle lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001483#middle-lateral-line-ganglion",
+  "name": "middle lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001483",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ninthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002852)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002852#ninth-thoracic-dorsal-root-ganglion-1",
+  "name": "ninth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002852",
+  "synonym": [
+    "ninth thoracic dorsal root ganglion",
+    "ninth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/oticGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/oticGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion and parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "description": "The ganglion that supplies nerve fibers to the parotid gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003963#otic-ganglion",
+  "name": "otic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003963",
+  "synonym": [
+    "Arnold's ganglion",
+    "otic parasympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808) ('is_a' and 'relationship')]",
+  "description": "Ganglion containing neurons that receive innervation from parasympathetic neurons in the central nervous system and subserves parasympathetic functions through innervation of smooth muscle, cardiac muscle and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001808#parasympathetic-ganglion",
+  "name": "parasympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001808",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/paravertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion and trunk ganglion. Is part of the sympathetic trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807) ('is_a' and 'relationship')]",
+  "description": "Trunk ganglion which is part of a bilaterally paired set of sympathetic ganglia located anterior and lateral to the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001807#paravertebral-ganglion",
+  "name": "paravertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001807",
+  "synonym": [
+    "ganglion of sympathetic trunk",
+    "ganglion trunci sympathetici",
+    "ganglion trunci sympathici",
+    "sympathetic chain ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/parietalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parietalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "description": "A lateral ganglion that innervates pallial cavity, gills and skin of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008940#parietal-ganglion",
+  "name": "parietal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008940",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pedalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pedalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pedalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "description": "The pedal ganglia mainly are necessary for coordination of locomotion of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008939#pedal-ganglion",
+  "name": "pedal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008939",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pelvicGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pelvicGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016508)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016508#pelvic-ganglion",
+  "name": "pelvic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016508",
+  "synonym": [
+    "inferior hypogastric ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pleuralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pleuralGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pleuralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "description": "A knot of nerves in The pallial cavity that innervates the mantle of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008941#pleural-ganglion",
+  "name": "pleural ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008941",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "description": "The posterior lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the posterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001314#posterior-lateral-line-ganglion",
+  "name": "posterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001314",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicAutonomicFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from cell bodies of autonomic ganglia to synapses on target organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011924#postganglionic-autonomic-fiber",
+  "name": "postganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011924",
+  "synonym": [
+    "postganglionic nerve fiber"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicParasympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from a parasympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011929#postganglionic-parasympathetic-fiber",
+  "name": "postganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011929",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicSympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926) ('is_a' and 'relationship')]",
+  "description": "A noradrenergic or adrenergic axonal fiber projecting from a sympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011926#postganglionic-sympathetic-fiber",
+  "name": "postganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011926",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicAutonomicFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from the central nervous system to autonomic ganglia. In the sympathetic division most preganglionic fibers originate with neurons in the intermediolateral column of the spinal cord, exit via ventral roots from upper thoracic through lower lumbar segments, and project to the paravertebral ganglia; there they either terminate in synapses or continue through the splanchnic nerves to the prevertebral ganglia. In the parasympathetic division the fibers originate in neurons of the brain stem and sacral spinal cord. In both divisions the principal transmitter is acetylcholine but peptide cotransmitters may also be released. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011925#preganglionic-autonomic-fiber",
+  "name": "preganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011925",
+  "synonym": [
+    "preganglionic nerve fiber"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicParasympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fibers projecting from the CNS to a parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011930#preganglionic-parasympathetic-fiber",
+  "name": "preganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011930",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicSympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from the CNS to a sympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011927#preganglionic-sympathetic-fiber",
+  "name": "preganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011927",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/prevertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "description": "The sympathetic ganglia located in front of the vertebral column and are associated with the major branches of the abdominal aorta; these include the celiac, aorticorenal, superior and inferior mesenteric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003964#prevertebral-ganglion",
+  "name": "prevertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003964",
+  "synonym": [
+    "collateral ganglion",
+    "previsceral ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035599) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035599#profundal-part-of-trigeminal-ganglion-complex",
+  "name": "profundal part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035599",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pterygopalatineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "description": "The small parasympathetic ganglion that supplies nerve fibers to the lacrimal, nasal, palatine and pharyngeal glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003962#pterygopalatine-ganglion",
+  "name": "pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003962",
+  "synonym": [
+    "Meckel ganglion",
+    "Meckel's ganglion",
+    "nasal ganglion",
+    "palatine ganglion",
+    "pterygopalatine ganglia",
+    "sphenopalatine ganglion",
+    "sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002837)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002837#sacral-dorsal-root-ganglion-1",
+  "name": "sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002837",
+  "synonym": [
+    "sacral dorsal root ganglion",
+    "sacral spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002839)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002839#second-cervical-dorsal-root-ganglion-1",
+  "name": "second cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002839",
+  "synonym": [
+    "C2 dorsal root ganglion",
+    "second cervical dorsal root ganglion",
+    "second cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002856)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002856#second-lumbar-dorsal-root-ganglion-1",
+  "name": "second lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002856",
+  "synonym": [
+    "second lumbar dorsal root ganglion",
+    "second lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002861)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002861#second-sacral-dorsal-root-ganglion-1",
+  "name": "second sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002861",
+  "synonym": [
+    "second sacral dorsal root ganglion",
+    "second sacral spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002846)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002846#second-thoracic-dorsal-root-ganglion-1",
+  "name": "second thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002846",
+  "synonym": [
+    "second thoracic dorsal root ganglion",
+    "second thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sensoryGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sensoryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "description": "The clusters of neurons in the somatic peripheral nervous system which contain the cell bodies of sensory nerve axons, interneurons and non-neuronal supporting cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001800#sensory-ganglion",
+  "name": "sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001800",
+  "synonym": [
+    "ganglion sensorium"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002843)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002843#seventh-cervical-dorsal-root-ganglion-1",
+  "name": "seventh cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002843",
+  "synonym": [
+    "C7 dorsal root ganglion",
+    "seventh cervical dorsal root ganglion",
+    "seventh cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002850)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002850#seventh-thoracic-dorsal-root-ganglion-1",
+  "name": "seventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002850",
+  "synonym": [
+    "seventh thoracic dorsal root ganglion",
+    "seventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007711)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007711#sixth-cervical-dorsal-root-ganglion-1",
+  "name": "sixth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007711",
+  "synonym": [
+    "C6 dorsal root ganglion",
+    "sixth cervical dorsal root ganglia",
+    "sixth cervical dorsal root ganglion",
+    "sixth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002849)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002849#sixth-thoracic-dorsal-root-ganglion-1",
+  "name": "sixth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002849",
+  "synonym": [
+    "sixth thoracic dorsal root ganglion",
+    "sixth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sublingualGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sublingualGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sublingualGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "description": "The small parasympathetic ganglion found anterior to the submandibular gland that provides postsynaptic fibers to the sublingual gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005407#sublingual-ganglion",
+  "name": "sublingual ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005407",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/submandibularGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/submandibularGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/submandibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "description": "The ganglion associated with the lingual nerve that provides postsynaptic fibers to the submandibular and sublingual glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002059#submandibular-ganglion",
+  "name": "submandibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002059",
+  "synonym": [
+    "mandibular ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "description": "Trunk ganglion which is bilaterally paired and located at the anterior end of the sympathetic ganglion chain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001989#superior-cervical-ganglion",
+  "name": "superior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001989",
+  "synonym": [
+    "superior cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "description": "The upper ganglion of the glossopharyngeal nerve. is situated in the upper part of the groove in which the glossopharyngeal nerve is lodged during its passage through the jugular foramen. It is very small, and is usually regarded as a detached portion of the inferior ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005361#superior-glossopharyngeal-ix-ganglion",
+  "name": "superior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005361",
+  "synonym": [
+    "Ehrenritter's ganglion",
+    "ganglion superius (nervus glossopharyngeus)",
+    "ganglion superius nervus glossopharyngei",
+    "glossopharyngeal nerve jugular ganglion",
+    "glossopharyngeal nerve superior ganglion",
+    "intracranial ganglion",
+    "ninth cranial nerve superior ganglion",
+    "superior ganglion of glossopharyngeal nerve",
+    "superior glossopharyngeal ganglia",
+    "superior glossopharyngeal ganglion",
+    "superior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorMesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the superior mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479) ('is_a' and 'relationship')]",
+  "description": "A ganglion in the upper part of the superior mesenteric plexus that is the synapsing point for one of the pre- and post-synaptic nerves of the sympathetic division of the autonomous nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005479#superior-mesenteric-ganglion",
+  "name": "superior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005479",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorPartOfVestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "description": "The part of the vestibular ganglion that receives fibers from the maculae of the utricle and the sacculae and the ampullae of the anterior and lateral semicircular ducts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002825#superior-part-of-vestibular-ganglion-1",
+  "name": "superior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002825",
+  "synonym": [
+    "pars superior ganglionis vestibularis",
+    "vestibular ganglion superior part"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorVagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "description": "The upper ganglion of the vagus nerve located at the jugular foramen. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005364#superior-vagus-x-ganglion",
+  "name": "superior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005364",
+  "synonym": [
+    "ganglion superius (nervus vagus)",
+    "ganglion superius nervus vagi",
+    "superior ganglion of vagus",
+    "superior ganglion of vagus nerve",
+    "superior vagus ganglion",
+    "tenth cranial nerve jugular ganglion",
+    "vagus nerve jugular ganglion",
+    "vagus nerve superior ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806) ('is_a' and 'relationship')]",
+  "description": "A ganglion of the sympathetic nervous system. Examples: paravertebral and the prevertebral ganglia, which include the sympathetic chain ganglia, the superior, middle, and inferior cervical ganglia, and the aorticorenal, celiac, and stellate ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001806#sympathetic-ganglion",
+  "name": "sympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001806",
+  "synonym": [
+    "ganglion of sympathetic nervous system",
+    "ganglion of sympathetic part of autonomic division of nervous system",
+    "ganglion sympatheticum",
+    "sympathetic nervous system ganglion",
+    "sympathetic part of autonomic division of nervous system ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tenthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002853)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002853#tenth-thoracic-dorsal-root-ganglion-1",
+  "name": "tenth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002853",
+  "synonym": [
+    "tenth thoracic dorsal root ganglion",
+    "tenth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002840#third-cervical-dorsal-root-ganglion-1",
+  "name": "third cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002840",
+  "synonym": [
+    "C3 dorsal root ganglion",
+    "third cervical dorsal root ganglion",
+    "third cervical spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002858)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002858#third-lumbar-dorsal-root-ganglion-1",
+  "name": "third lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002858",
+  "synonym": [
+    "third lumbar dorsal root ganglion",
+    "third lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002862)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002862#third-sacral-dorsal-root-ganglion-1",
+  "name": "third sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002862",
+  "synonym": [
+    "third sacral dorsal root ganglion",
+    "third sacral spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002847)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002847#third-thoracic-dorsal-root-ganglion-1",
+  "name": "third thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002847",
+  "synonym": [
+    "third thoracic dorsal root ganglion",
+    "third thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion and thoracic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "description": "A dorsal root ganglion that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002835#thoracic-dorsal-root-ganglion-1",
+  "name": "thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002835",
+  "synonym": [
+    "dorsal root ganglion of thorax",
+    "ganglion of dorsal root of thorax",
+    "ganglion spinalis of thorax",
+    "thoracic dorsal root ganglion",
+    "thoracic spinal ganglion",
+    "thorax dorsal root ganglion",
+    "thorax ganglion of dorsal root",
+    "thorax ganglion spinalis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961) ('is_a' and 'relationship')]",
+  "description": "The thoracic ganglia are paravertebral ganglia. The thoracic portion of the sympathetic trunk typically has 12 thoracic ganglia. Emerging from the ganglia are thoracic splancic nerves (the cardiopulmonary, the greater, lesser, and least splanchic nerves) that help provide sympathetic innervation to abdominal structures. Also, the ganglia of the thoracic sympathetic trunk have both white and gray rami communicantes. The white rami carry sympathetic fibers arising in the spinal cord into the sympathetic trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000961#thoracic-ganglion",
+  "name": "thoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000961",
+  "synonym": [
+    "ganglion of thorax",
+    "ganglion thoracicum splanchnicum",
+    "thoracic paravertebral ganglion",
+    "thoracic splanchnic ganglion",
+    "thoracic sympathetic ganglion",
+    "thorax ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "description": "The cranial ganglion that is associated with and extends fibers into the trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001675#trigeminal-ganglion",
+  "name": "trigeminal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001675",
+  "synonym": [
+    "5th ganglion",
+    "fifth ganglion",
+    "ganglion of trigeminal complex",
+    "Gasserian ganglion",
+    "semilunar ganglion",
+    "trigeminal V ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trunkGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trunkGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "description": "Ganglion which is located in the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007134#trunk-ganglion",
+  "name": "trunk ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007134",
+  "synonym": [
+    "body ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/twelfthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002855)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002855#twelfth-thoracic-dorsal-root-ganglion-1",
+  "name": "twelfth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002855",
+  "synonym": [
+    "twelfth thoracic dorsal root ganglion",
+    "twelfth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalGanglion1.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalGanglion1.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001302)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001302#vagal-ganglion-1",
+  "name": "vagal ganglion 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001302",
+  "synonym": [
+    "gX1",
+    "nodose ganglion 1"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalGanglion2.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalGanglion2.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001303)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001303#vagal-ganglion-2",
+  "name": "vagal ganglion 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001303",
+  "synonym": [
+    "gX2",
+    "nodose ganglion 2"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalGanglion3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalGanglion3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001304)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001304#vagal-ganglion-3",
+  "name": "vagal ganglion 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001304",
+  "synonym": [
+    "gX3",
+    "nodose ganglion 3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalGanglion4.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalGanglion4.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001305)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001305#vagal-ganglion-4",
+  "name": "vagal ganglion 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001305",
+  "synonym": [
+    "gX4",
+    "nodose ganglion 4"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vagusXGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagusXGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "description": "The group of sensory neuron cell bodies associated with the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005362#vagus-x-ganglion",
+  "name": "vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005362",
+  "synonym": [
+    "ganglion of vagus nerve",
+    "right glossopharyngeal ganglion",
+    "vagal ganglion",
+    "vagus ganglion",
+    "vagus neural ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralAnteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001313)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001313#ventral-anterior-lateral-line-ganglion",
+  "name": "ventral anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001313",
+  "synonym": [
+    "anteroventral lateral line ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vertebralGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vertebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the cervical ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408) ('is_a' and 'relationship')]",
+  "description": "Any of a group of sympathetic ganglia which form two chains extending from the base of the skull to the coccyx along the sides of the spinal column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000408#vertebral-ganglion",
+  "name": "vertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000408",
+  "synonym": [
+    "intermediate ganglion"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibularGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibularGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion, sensory ganglion, ganglion of peripheral nervous system and vestibular organ. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824) ('is_a' and 'relationship')]",
+  "description": "The ganglion of the vestibular nerve. It contains the cell bodies of the bipolar primary afferent neurons whose peripheral processes form synaptic contact with hair cells of the vestibular sensory end organs. Distributed to the maculae of the utricle and saccule and to the ampullary crests of the semicircular ducts. The vestibular fibers arise in bipolar cells in the vestibular ganglion in the internal acoustic meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002824#vestibular-ganglion-1",
+  "name": "vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002824",
+  "synonym": [
+    "Scarpa's ganglion",
+    "vestibular part of vestibulocochlear ganglion",
+    "vestibulocochlear VIII ganglion vestibular component"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013498)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013498#vestibulo-cochlear-viii-ganglion-complex",
+  "name": "vestibulo-cochlear VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013498",
+  "synonym": [
+    "vestibulocochlear ganglion complex",
+    "vestibulocochlear VIII ganglion complex"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "description": "The group of neuron cell bodies associated with the eighth cranial nerve during embryogenesis; splits in later development to form the cochlear and vestibular ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002827#auditory-ganglion",
+  "name": "vestibulocochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002827",
+  "synonym": [
+    "acoustic ganglion VIII",
+    "acoustico-vestibular VIII ganglion",
+    "auditory ganglion",
+    "ganglion VIII",
+    "gVIII",
+    "statoacoustic (VIII) ganglion",
+    "statoacoustic ganglia",
+    "statoacoustic ganglion",
+    "vestibulocochlear VIII ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/GruenebergGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "description": "An olfactory ganglion at the entrance of the nose of mammals that is involved in the detection of alarm pheromones and cold temperatures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013208#grueneberg-ganglion",
+  "name": "Grueneberg ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013208",
+  "synonym": [
+    "Grüneberg ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/abdominalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/abdominalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/abdominalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a trunk ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "description": "A ganglion that is part of a abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009758#abdominal-ganglion",
+  "name": "abdominal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009758",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/abdominalGanglionOfVisceralHump",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "description": "An unpaired knot of nerves in The visceral sacs that innervates the pallial organs as well as the inner organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008964#abdominal-ganglion-of-visceral-hump",
+  "name": "abdominal ganglion of visceral hump",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008964",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/accessoryCiliaryGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "description": "A parasympathetic ganglion located on the short ciliary nerve differentiated from the main ciliary ganglion by virtue of the fact that it had no root derived directly from the inferior trunk of the oculomotor nerve and it never attaches to this nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035776#accessory-ciliary-ganglion",
+  "name": "accessory ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035776",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012175#acoustico-facial-vii-viii-ganglion-complex",
+  "name": "acoustico-facial VII-VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012175",
+  "synonym": [
+    "acousticofacial ganglion",
+    "facio-acoustic ganglion",
+    "facio-acoustic ganglion complex VII-VIII"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/anteriorLateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "description": "The anteror lateral line ganglia develops from cranial ectodermal placodes and contain sensory neurons that innervate the anterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001391#anterior-lateral-line-ganglion",
+  "name": "anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001391",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/areaXOfBasalGanglion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Area X of basal ganglion' is a nucleus of brain. It is part of the basal ganglion.",
-  "description": "A nucleus in the basal ganglion of songbirds.",
+  "definition": "Is a nucleus of brain. Is part of the basal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the basal ganglion of songbirds. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731535",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035807#area-x-of-basal-ganglion",
   "name": "area X of basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035807",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/autonomicGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/autonomicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/autonomicGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion of peripheral nervous system. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805) ('is_a' and 'relationship')]",
+  "description": "Ganglion that has dendrites that form a junction between autonomic nerves originating from the central nervous system and autonomic nerves innervating their target organs in the periphery. There are two subtypes, sympathetic ganglion and parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001805#autonomic-ganglion",
+  "name": "autonomic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001805",
+  "synonym": [
+    "autonomic nervous system ganglion",
+    "ganglion of autonomic nervous system",
+    "ganglion of visceral nervous system",
+    "visceral nervous system ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/basalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/basalGanglion.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/basalGanglion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Basal ganglion' is a brain gray matter and nuclear complex of neuraxis. It is part of the collection of basal ganglia.",
-  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum[NIF,modified].",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. Is part of the collection of basal ganglia. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420) ('is_a' and 'relationship')]",
+  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002420#basal-ganglion",
   "name": "basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002420",
-  "synonym": null
+  "synonym": [
+    "basal ganglion of telencephalon"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cardiacGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cardiacGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cardiacGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "description": "Any of the parasympathetic ganglia of the cardiac plexus between the arch of the aorta and the bifurcation of the pulmonary artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014463#cardiac-ganglion",
+  "name": "cardiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014463",
+  "synonym": [
+    "cardiac ganglia set",
+    "cardiac ganglion of Wrisberg",
+    "ganglia cardiaca",
+    "ganglion of Wrisberg",
+    "Wrisberg ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/caudalGanglionicEminence",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026) ('is_a' and 'relationship')]",
+  "description": "The caudally located, distinct elevation of a transient proliferating cell mass of the fetal subventricular zone, located adjacent to the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004026#caudal-ganglionic-eminence",
+  "name": "caudal ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004026",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/celiacGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/celiacGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/celiacGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "description": "The celiac ganglia are two large irregularly shaped masses of nerve tissue in the upper abdomen. Part of the sympathetic subdivision of the autonomic nervous system (ANS), the two celiac ganglia are the largest ganglia in the ANS, and they innervate most of the digestive tract. They have the appearance of lymph glands and are placed on either side of the midline in front of the crura of the diaphragm, close to the suprarenal glands (also called adrenal glands). The ganglion on the right side is placed behind the inferior vena cava. They are sometimes referred to as the semilunar ganglia or the solar ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002262#celiac-ganglion",
+  "name": "celiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002262",
+  "synonym": [
+    "coeliac ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002834)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002834#cervical-dorsal-root-ganglion-1",
+  "name": "cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002834",
+  "synonym": [
+    "cervical dorsal root ganglion",
+    "cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "description": "The cervical ganglia are paravertebral ganglia of the sympathetic nervous system. They consist of three paravertebral ganglia: superior cervical ganglion middle cervical ganglion inferior cervical ganglion. The inferior ganglion may be fused with the first thoracic ganglion to form a single structure, the stellate ganglion. Nerves emerging from cervical sympathetic ganglia contribute to the cardiac plexus, among other things. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001991#cervical-ganglion",
+  "name": "cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001991",
+  "synonym": [
+    "cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicothoracicGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "description": "The group of neurons formed by the fusion of the inferior cervical and first thoracic ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002441#cervicothoracic-ganglion",
+  "name": "cervicothoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002441",
+  "synonym": [
+    "cervicothoracic sympathetic ganglion",
+    "ganglion cervicothoracicum",
+    "ganglion stellatum",
+    "stellate ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cochlearGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cochlearGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cochlearGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395) ('is_a' and 'relationship')]",
+  "description": "The group of nerve cell bodies that conveys auditory sensation from the organ of Corti to the hindbrain and resides on the cochlear part of the vestibulocochlear nerve (eighth cranial nerve). distributed to the hair cells of the spiral organ. The cochlear fibers arise in bipolar cells in the spiral ganglion in the modiolus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000395#cochlear-ganglion",
+  "name": "cochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000395",
+  "synonym": [
+    "cochlear part of vestibulocochlear ganglion",
+    "Corti's ganglion",
+    "ganglion of Corti",
+    "spiral ganglion",
+    "vestibulocochlear VIII ganglion cochlear component"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cranialGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cranialGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cranialGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "description": "The groups of nerve cell bodies associated with the twelve cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001714#cranial-ganglion-part-of-peripheral-nervous-system",
+  "name": "cranial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001714",
+  "synonym": [
+    "cranial ganglion",
+    "cranial ganglion part of peripheral nervous system",
+    "cranial ganglion/nerve",
+    "cranial nerve ganglion",
+    "cranial neural ganglion",
+    "cranial neural tree organ ganglion",
+    "ganglion of cranial nerve",
+    "ganglion of cranial neural tree organ"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cranialSensoryGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "description": "The ganglion found on the root of each cranial nerve, containing the cell bodies of afferent (sensory) neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009992#cranial-sensory-ganglion",
+  "name": "cranial sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009992",
+  "synonym": [
+    "cranial nerve sensory ganglion",
+    "ganglion sensorium cranialium",
+    "ganglion sensorium nervi cranialis",
+    "sensory ganglion of cranial nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalAnteriorLateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001312)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001312#dorsal-anterior-lateral-line-ganglion",
+  "name": "dorsal anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001312",
+  "synonym": [
+    "anterodorsal lateral line ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalLateralGanglionicEminence",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lateral ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264) ('is_a' and 'relationship')]",
+  "description": "The dorsal region of the lateral ganglionic eminence. The cells in this area give rise to embryonic interneuron precursors that will migrate tangentially to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018264#dorsal-lateral-ganglionic-eminence",
+  "name": "dorsal lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018264",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "description": "Sensory ganglia located on the dorsal spinal roots within the vertebral column. The spinal ganglion cells are pseudounipolar. The single primary branch bifurcates sending a peripheral process to carry sensory information from the periphery and a central branch which relays that information to the spinal cord or brain. (MSH) * ganglion found on the posterior root of each spinal nerve, composed of the unipolar nerve cell bodies of the sensory neurons of the nerve. (CSP) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000044#dorsal-root-ganglion-1",
+  "name": "dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000044",
+  "synonym": [
+    "dorsal root ganglion",
+    "ganglion of dorsal root",
+    "ganglion spinalis",
+    "spinal ganglion",
+    "spinal ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/eighthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002844#eighth-cervical-dorsal-root-ganglion-1",
+  "name": "eighth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002844",
+  "synonym": [
+    "eighth cervical dorsal root ganglion",
+    "eighth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/eighthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002851)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002851#eighth-thoracic-dorsal-root-ganglion-1",
+  "name": "eighth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002851",
+  "synonym": [
+    "eighth thoracic dorsal root ganglion",
+    "eighth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/eleventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002854)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002854#eleventh-thoracic-dorsal-root-ganglion-1",
+  "name": "eleventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002854",
+  "synonym": [
+    "eleventh thoracic dorsal root ganglion",
+    "eleventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/entericGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/entericGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/entericGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. Is part of the enteric nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001809) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001809#enteric-ganglion",
+  "name": "enteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001809",
+  "synonym": [
+    "intramural ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/epibranchialGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "description": "Cranial ganglion which develops from an epibranchial placode. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009127#epibranchial-ganglion",
+  "name": "epibranchial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009127",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006232) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006232#facio-acoustic-vii-viii-preganglion-complex",
+  "name": "facio-acoustic VII-VIII preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006232",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002842)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002842#fifth-cervical-dorsal-root-ganglion-1",
+  "name": "fifth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002842",
+  "synonym": [
+    "C5 dorsal root ganglion",
+    "fifth cervical dorsal root ganglion",
+    "fifth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fifth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002859#fifth-lumbar-dorsal-root-ganglion-1",
+  "name": "fifth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002859",
+  "synonym": [
+    "fifth lumbar dorsal root ganglion",
+    "fifth lumbar spinal ganglion",
+    "L5 dorsal root ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthSacralDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002863)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002863#fifth-sacral-dorsal-root-ganglion-1",
+  "name": "fifth sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002863",
+  "synonym": [
+    "fifth sacral dorsal root ganglion",
+    "fifth sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002848)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002848#fifth-thoracic-dorsal-root-ganglion-1",
+  "name": "fifth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002848",
+  "synonym": [
+    "fifth thoracic dorsal root ganglion",
+    "fifth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002838#first-cervical-dorsal-root-ganglion-1",
+  "name": "first cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002838",
+  "synonym": [
+    "first cervical dorsal root ganglion",
+    "first cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstLumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002857)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002857#first-lumbar-dorsal-root-ganglion-1",
+  "name": "first lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002857",
+  "synonym": [
+    "first lumbar dorsal root ganglion",
+    "first lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstSacralDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002860)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002860#first-sacral-dorsal-root-ganglion-1",
+  "name": "first sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002860",
+  "synonym": [
+    "first sacral dorsal root ganglion",
+    "first sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002845)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002845#first-thoracic-dorsal-root-ganglion-1",
+  "name": "first thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002845",
+  "synonym": [
+    "first thoracic dorsal root ganglion",
+    "first thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002841)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002841#fourth-cervical-dorsal-root-ganglion-1",
+  "name": "fourth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002841",
+  "synonym": [
+    "C4 dorsal root ganglion",
+    "fourth cervical dorsal root ganglion",
+    "fourth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fourth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003943#forth-lumbar-dorsal-root-ganglion",
+  "name": "fourth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003943",
+  "synonym": [
+    "forth lumbar dorsal root ganglion",
+    "fourth lumbar dorsal root ganglion",
+    "fourth lumbar spinal ganglion",
+    "L4 dorsal root ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthSacralSpinalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007713)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007713#forth-sacral-dorsal-root-ganglion",
+  "name": "fourth sacral spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007713",
+  "synonym": [
+    "forth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthThoracicSpinalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007712)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007712#fourth-thoracic-dorsal-root-ganglion",
+  "name": "fourth thoracic spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007712",
+  "synonym": [
+    "forth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045) ('is_a' and 'relationship')]",
+  "description": "A biological tissue mass, most commonly a mass of nerve cell bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000045#ganglion-1",
+  "name": "ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000045",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ganglionicEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ganglionicEminence.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ganglionicEminence",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023) ('is_a' and 'relationship')]",
+  "description": "The transient proliferative population of neurons that expands exponentially during late prenatal development; it is a continuous germinal zone distinct from the ventricular zone that surrounds the brain ventricles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004023#ganglionic-eminence",
+  "name": "ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004023",
+  "synonym": [
+    "embryonic subventricular zone",
+    "embryonic/fetal subventricular zone",
+    "fetal subventricular zone",
+    "subependymal layer"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/gasserianGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/gasserianGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/gasserianGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3011045)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3011045#gasserian-ganglion",
+  "name": "gasserian ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3011045",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/gastropodCerebralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "description": "The cerebral ganglia are primarily sensual centres, that compute information from the eyes as well as from the tactile and position sensors (statocystes). Besides coordination they also serve the locational memory of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008942#gastropod-cerebral-ganglion",
+  "name": "gastropod cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008942",
+  "synonym": [
+    "cerebral ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/geniculateGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/geniculateGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/geniculateGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory ganglion and epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "description": "The group of sensory neuron cell bodies associated with the facial nerve (seventh cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001700#geniculate-ganglion",
+  "name": "geniculate ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001700",
+  "synonym": [
+    "facial VII ganglion",
+    "ganglion genicularum",
+    "genicular ganglion",
+    "genicular ganglion",
+    "gVII"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glossopharyngealGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "description": "The group of neuron cell bodies associated with the ninth cranial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001701#glossopharyngeal-ganglion",
+  "name": "glossopharyngeal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001701",
+  "synonym": [
+    "ganglion of glossopharyngeal nerve",
+    "ganglion of glosspharyngeal nerve",
+    "glossopharyngeal IX ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glossopharyngealIXPreganglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006243) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006243#glossopharyngeal-ix-preganglion",
+  "name": "glossopharyngeal IX preganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006243",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013500#glossopharyngeal-vagus-ix-x-ganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013500",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013499) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013499#glossopharyngeal-vagus-ix-x-preganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013499",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorCervicalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "description": "The inferior cervical ganglion is situated between the base of the transverse process of the last cervical vertebra and the neck of the first rib, on the medial side of the costocervical artery. Its form is irregular; it is larger in size than the middle cervical ganglion, and is frequently fused with the first thoracic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002440#inferior-cervical-ganglion",
+  "name": "inferior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002440",
+  "synonym": [
+    "variant cervical ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "description": "The lower group of sensory neuron cell bodies associated with the glossopharyngeal nerve. It is situated in a depression in the lower border of the petrous portion of the temporal bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005360#inferior-glossopharyngeal-ix-ganglion",
+  "name": "inferior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005360",
+  "synonym": [
+    "extracraniale ganglion",
+    "ganglion inferius (nervus glossopharygeus)",
+    "ganglion inferius nervus glossopharyngei",
+    "ganglion of andersch",
+    "glossopharyngeal nerve inferior ganglion",
+    "glossopharyngeal nerve petrous ganglion",
+    "inferior ganglion of glossopharyngeal nerve",
+    "inferior glossopharyngeal ganglion",
+    "inferior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve",
+    "ninth cranial nerve inferior ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorMesentericGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the inferior mesenteric nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453) ('is_a' and 'relationship')]",
+  "description": "A ganglion located near where the inferior mesenteric artery branches from the abdominal aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005453#inferior-mesenteric-ganglion",
+  "name": "inferior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005453",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorPartOfVestibularGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002826)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002826#inferior-part-of-vestibular-ganglion-1",
+  "name": "inferior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002826",
+  "synonym": [
+    "pars inferior ganglionis vestibularis",
+    "vestibular ganglion inferior part"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorVagusXGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "description": "The large group of sensory neuron cell bodies, anterior to the jugular vein, associated with the vagus nerve (tenth cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005363#inferior-vagus-x-ganglion",
+  "name": "inferior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005363",
+  "synonym": [
+    "ganglion inferius (nervus vagus)",
+    "ganglion inferius nervi vagi",
+    "ganglion inferius nervus vagi",
+    "ganglion nodosum",
+    "inferior ganglion of vagus",
+    "inferior ganglion of vagus nerve",
+    "nodose ganglion",
+    "tenth cranial nerve nodose ganglion",
+    "vagus nerve inferior ganglion",
+    "vagus nerve nodose ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralGanglionicEminence",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the striatum; however, neocortex, thalamus, septum and olfactory bulb neurons are also partly derived from the LGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004025#lateral-ganglionic-eminence",
+  "name": "lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004025",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "description": "Ganglion that develops from a cranial ectodermal placode and contains sensory neurons that innervate a lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000120#lateral-line-ganglion",
+  "name": "lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000120",
+  "synonym": [
+    "LLG"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the lumbar vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002836#lumbar-dorsal-root-ganglion-1",
+  "name": "lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002836",
+  "synonym": [
+    "lumbar dorsal root ganglion",
+    "lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mainCiliaryGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion and ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "description": "A parasympathetic ganglion located in the posterior orbit that contains preganglionic nerves and postganglionic neurons of the oculomotor nerve, connects to the Edinger-Westphal nucleus via the oculomotor nerve and the eye muscles via the short ciliary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002058#main-ciliary-ganglion",
+  "name": "main ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002058",
+  "synonym": [
+    "ciliary ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035601) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035601#maxillomandibular-part-of-trigeminal-ganglion-complex",
+  "name": "maxillomandibular part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035601",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/medialGanglionicEminence",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the neocortex; however, hippocampal neurons, thalamus, septum and olfactory bulb neurons are also partly derived from the MGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004024#medial-ganglionic-eminence",
+  "name": "medial ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004024",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mesentericGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mesentericGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. Is part of the mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035769) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035769#mesenteric-ganglion",
+  "name": "mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035769",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/middleCervicalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "description": "The small ganglion located at the level of the cricoid cartilage of the laryngeal wall. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001990#middle-cervical-ganglion",
+  "name": "middle cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001990",
+  "synonym": [
+    "middle cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/middleLateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "description": "The middle lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the middle lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001483#middle-lateral-line-ganglion",
+  "name": "middle lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001483",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ninthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002852)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002852#ninth-thoracic-dorsal-root-ganglion-1",
+  "name": "ninth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002852",
+  "synonym": [
+    "ninth thoracic dorsal root ganglion",
+    "ninth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/oticGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/oticGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/oticGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion and parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "description": "The ganglion that supplies nerve fibers to the parotid gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003963#otic-ganglion",
+  "name": "otic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003963",
+  "synonym": [
+    "Arnold's ganglion",
+    "otic parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parasympatheticGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808) ('is_a' and 'relationship')]",
+  "description": "Ganglion containing neurons that receive innervation from parasympathetic neurons in the central nervous system and subserves parasympathetic functions through innervation of smooth muscle, cardiac muscle and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001808#parasympathetic-ganglion",
+  "name": "parasympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001808",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/paravertebralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion and trunk ganglion. Is part of the sympathetic trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807) ('is_a' and 'relationship')]",
+  "description": "Trunk ganglion which is part of a bilaterally paired set of sympathetic ganglia located anterior and lateral to the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001807#paravertebral-ganglion",
+  "name": "paravertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001807",
+  "synonym": [
+    "ganglion of sympathetic trunk",
+    "ganglion trunci sympathetici",
+    "ganglion trunci sympathici",
+    "sympathetic chain ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parietalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parietalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parietalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "description": "A lateral ganglion that innervates pallial cavity, gills and skin of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008940#parietal-ganglion",
+  "name": "parietal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008940",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pedalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pedalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pedalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "description": "The pedal ganglia mainly are necessary for coordination of locomotion of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008939#pedal-ganglion",
+  "name": "pedal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008939",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pelvicGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pelvicGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pelvicGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016508)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016508#pelvic-ganglion",
+  "name": "pelvic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016508",
+  "synonym": [
+    "inferior hypogastric ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pleuralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pleuralGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pleuralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "description": "A knot of nerves in The pallial cavity that innervates the mantle of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008941#pleural-ganglion",
+  "name": "pleural ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008941",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorLateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "description": "The posterior lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the posterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001314#posterior-lateral-line-ganglion",
+  "name": "posterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001314",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postganglionicAutonomicFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from cell bodies of autonomic ganglia to synapses on target organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011924#postganglionic-autonomic-fiber",
+  "name": "postganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011924",
+  "synonym": [
+    "postganglionic nerve fiber"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postganglionicParasympatheticFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from a parasympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011929#postganglionic-parasympathetic-fiber",
+  "name": "postganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011929",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postganglionicSympatheticFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926) ('is_a' and 'relationship')]",
+  "description": "A noradrenergic or adrenergic axonal fiber projecting from a sympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011926#postganglionic-sympathetic-fiber",
+  "name": "postganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011926",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preganglionicAutonomicFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from the central nervous system to autonomic ganglia. In the sympathetic division most preganglionic fibers originate with neurons in the intermediolateral column of the spinal cord, exit via ventral roots from upper thoracic through lower lumbar segments, and project to the paravertebral ganglia; there they either terminate in synapses or continue through the splanchnic nerves to the prevertebral ganglia. In the parasympathetic division the fibers originate in neurons of the brain stem and sacral spinal cord. In both divisions the principal transmitter is acetylcholine but peptide cotransmitters may also be released. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011925#preganglionic-autonomic-fiber",
+  "name": "preganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011925",
+  "synonym": [
+    "preganglionic nerve fiber"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preganglionicParasympatheticFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fibers projecting from the CNS to a parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011930#preganglionic-parasympathetic-fiber",
+  "name": "preganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011930",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preganglionicSympatheticFiber",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from the CNS to a sympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011927#preganglionic-sympathetic-fiber",
+  "name": "preganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011927",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/prevertebralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "description": "The sympathetic ganglia located in front of the vertebral column and are associated with the major branches of the abdominal aorta; these include the celiac, aorticorenal, superior and inferior mesenteric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003964#prevertebral-ganglion",
+  "name": "prevertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003964",
+  "synonym": [
+    "collateral ganglion",
+    "previsceral ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035599) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035599#profundal-part-of-trigeminal-ganglion-complex",
+  "name": "profundal part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035599",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pterygopalatineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "description": "The small parasympathetic ganglion that supplies nerve fibers to the lacrimal, nasal, palatine and pharyngeal glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003962#pterygopalatine-ganglion",
+  "name": "pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003962",
+  "synonym": [
+    "Meckel ganglion",
+    "Meckel's ganglion",
+    "nasal ganglion",
+    "palatine ganglion",
+    "pterygopalatine ganglia",
+    "sphenopalatine ganglion",
+    "sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002837)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002837#sacral-dorsal-root-ganglion-1",
+  "name": "sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002837",
+  "synonym": [
+    "sacral dorsal root ganglion",
+    "sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002839)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002839#second-cervical-dorsal-root-ganglion-1",
+  "name": "second cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002839",
+  "synonym": [
+    "C2 dorsal root ganglion",
+    "second cervical dorsal root ganglion",
+    "second cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondLumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002856)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002856#second-lumbar-dorsal-root-ganglion-1",
+  "name": "second lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002856",
+  "synonym": [
+    "second lumbar dorsal root ganglion",
+    "second lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondSacralDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002861)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002861#second-sacral-dorsal-root-ganglion-1",
+  "name": "second sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002861",
+  "synonym": [
+    "second sacral dorsal root ganglion",
+    "second sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002846)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002846#second-thoracic-dorsal-root-ganglion-1",
+  "name": "second thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002846",
+  "synonym": [
+    "second thoracic dorsal root ganglion",
+    "second thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sensoryGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sensoryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sensoryGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "description": "The clusters of neurons in the somatic peripheral nervous system which contain the cell bodies of sensory nerve axons, interneurons and non-neuronal supporting cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001800#sensory-ganglion",
+  "name": "sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001800",
+  "synonym": [
+    "ganglion sensorium"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/seventhCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002843)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002843#seventh-cervical-dorsal-root-ganglion-1",
+  "name": "seventh cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002843",
+  "synonym": [
+    "C7 dorsal root ganglion",
+    "seventh cervical dorsal root ganglion",
+    "seventh cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/seventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002850)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002850#seventh-thoracic-dorsal-root-ganglion-1",
+  "name": "seventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002850",
+  "synonym": [
+    "seventh thoracic dorsal root ganglion",
+    "seventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sixthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007711)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007711#sixth-cervical-dorsal-root-ganglion-1",
+  "name": "sixth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007711",
+  "synonym": [
+    "C6 dorsal root ganglion",
+    "sixth cervical dorsal root ganglia",
+    "sixth cervical dorsal root ganglion",
+    "sixth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sixthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002849)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002849#sixth-thoracic-dorsal-root-ganglion-1",
+  "name": "sixth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002849",
+  "synonym": [
+    "sixth thoracic dorsal root ganglion",
+    "sixth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sublingualGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sublingualGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sublingualGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "description": "The small parasympathetic ganglion found anterior to the submandibular gland that provides postsynaptic fibers to the sublingual gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005407#sublingual-ganglion",
+  "name": "sublingual ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005407",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/submandibularGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/submandibularGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/submandibularGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "description": "The ganglion associated with the lingual nerve that provides postsynaptic fibers to the submandibular and sublingual glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002059#submandibular-ganglion",
+  "name": "submandibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002059",
+  "synonym": [
+    "mandibular ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorCervicalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "description": "Trunk ganglion which is bilaterally paired and located at the anterior end of the sympathetic ganglion chain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001989#superior-cervical-ganglion",
+  "name": "superior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001989",
+  "synonym": [
+    "superior cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "description": "The upper ganglion of the glossopharyngeal nerve. is situated in the upper part of the groove in which the glossopharyngeal nerve is lodged during its passage through the jugular foramen. It is very small, and is usually regarded as a detached portion of the inferior ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005361#superior-glossopharyngeal-ix-ganglion",
+  "name": "superior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005361",
+  "synonym": [
+    "Ehrenritter's ganglion",
+    "ganglion superius (nervus glossopharyngeus)",
+    "ganglion superius nervus glossopharyngei",
+    "glossopharyngeal nerve jugular ganglion",
+    "glossopharyngeal nerve superior ganglion",
+    "intracranial ganglion",
+    "ninth cranial nerve superior ganglion",
+    "superior ganglion of glossopharyngeal nerve",
+    "superior glossopharyngeal ganglia",
+    "superior glossopharyngeal ganglion",
+    "superior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorMesentericGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the superior mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479) ('is_a' and 'relationship')]",
+  "description": "A ganglion in the upper part of the superior mesenteric plexus that is the synapsing point for one of the pre- and post-synaptic nerves of the sympathetic division of the autonomous nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005479#superior-mesenteric-ganglion",
+  "name": "superior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005479",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorPartOfVestibularGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "description": "The part of the vestibular ganglion that receives fibers from the maculae of the utricle and the sacculae and the ampullae of the anterior and lateral semicircular ducts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002825#superior-part-of-vestibular-ganglion-1",
+  "name": "superior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002825",
+  "synonym": [
+    "pars superior ganglionis vestibularis",
+    "vestibular ganglion superior part"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorVagusXGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "description": "The upper ganglion of the vagus nerve located at the jugular foramen. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005364#superior-vagus-x-ganglion",
+  "name": "superior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005364",
+  "synonym": [
+    "ganglion superius (nervus vagus)",
+    "ganglion superius nervus vagi",
+    "superior ganglion of vagus",
+    "superior ganglion of vagus nerve",
+    "superior vagus ganglion",
+    "tenth cranial nerve jugular ganglion",
+    "vagus nerve jugular ganglion",
+    "vagus nerve superior ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sympatheticGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806) ('is_a' and 'relationship')]",
+  "description": "A ganglion of the sympathetic nervous system. Examples: paravertebral and the prevertebral ganglia, which include the sympathetic chain ganglia, the superior, middle, and inferior cervical ganglia, and the aorticorenal, celiac, and stellate ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001806#sympathetic-ganglion",
+  "name": "sympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001806",
+  "synonym": [
+    "ganglion of sympathetic nervous system",
+    "ganglion of sympathetic part of autonomic division of nervous system",
+    "ganglion sympatheticum",
+    "sympathetic nervous system ganglion",
+    "sympathetic part of autonomic division of nervous system ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tenthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002853)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002853#tenth-thoracic-dorsal-root-ganglion-1",
+  "name": "tenth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002853",
+  "synonym": [
+    "tenth thoracic dorsal root ganglion",
+    "tenth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdCervicalDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002840#third-cervical-dorsal-root-ganglion-1",
+  "name": "third cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002840",
+  "synonym": [
+    "C3 dorsal root ganglion",
+    "third cervical dorsal root ganglion",
+    "third cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdLumbarDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002858)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002858#third-lumbar-dorsal-root-ganglion-1",
+  "name": "third lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002858",
+  "synonym": [
+    "third lumbar dorsal root ganglion",
+    "third lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdSacralDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002862)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002862#third-sacral-dorsal-root-ganglion-1",
+  "name": "third sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002862",
+  "synonym": [
+    "third sacral dorsal root ganglion",
+    "third sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002847)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002847#third-thoracic-dorsal-root-ganglion-1",
+  "name": "third thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002847",
+  "synonym": [
+    "third thoracic dorsal root ganglion",
+    "third thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion and thoracic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "description": "A dorsal root ganglion that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002835#thoracic-dorsal-root-ganglion-1",
+  "name": "thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002835",
+  "synonym": [
+    "dorsal root ganglion of thorax",
+    "ganglion of dorsal root of thorax",
+    "ganglion spinalis of thorax",
+    "thoracic dorsal root ganglion",
+    "thoracic spinal ganglion",
+    "thorax dorsal root ganglion",
+    "thorax ganglion of dorsal root",
+    "thorax ganglion spinalis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961) ('is_a' and 'relationship')]",
+  "description": "The thoracic ganglia are paravertebral ganglia. The thoracic portion of the sympathetic trunk typically has 12 thoracic ganglia. Emerging from the ganglia are thoracic splancic nerves (the cardiopulmonary, the greater, lesser, and least splanchic nerves) that help provide sympathetic innervation to abdominal structures. Also, the ganglia of the thoracic sympathetic trunk have both white and gray rami communicantes. The white rami carry sympathetic fibers arising in the spinal cord into the sympathetic trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000961#thoracic-ganglion",
+  "name": "thoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000961",
+  "synonym": [
+    "ganglion of thorax",
+    "ganglion thoracicum splanchnicum",
+    "thoracic paravertebral ganglion",
+    "thoracic splanchnic ganglion",
+    "thoracic sympathetic ganglion",
+    "thorax ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trigeminalGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "description": "The cranial ganglion that is associated with and extends fibers into the trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001675#trigeminal-ganglion",
+  "name": "trigeminal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001675",
+  "synonym": [
+    "5th ganglion",
+    "fifth ganglion",
+    "ganglion of trigeminal complex",
+    "Gasserian ganglion",
+    "semilunar ganglion",
+    "trigeminal V ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trunkGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trunkGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trunkGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "description": "Ganglion which is located in the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007134#trunk-ganglion",
+  "name": "trunk ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007134",
+  "synonym": [
+    "body ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/twelfthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002855)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002855#twelfth-thoracic-dorsal-root-ganglion-1",
+  "name": "twelfth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002855",
+  "synonym": [
+    "twelfth thoracic dorsal root ganglion",
+    "twelfth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion1.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion1.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalGanglion1",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001302)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001302#vagal-ganglion-1",
+  "name": "vagal ganglion 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001302",
+  "synonym": [
+    "gX1",
+    "nodose ganglion 1"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion2.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion2.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalGanglion2",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001303)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001303#vagal-ganglion-2",
+  "name": "vagal ganglion 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001303",
+  "synonym": [
+    "gX2",
+    "nodose ganglion 2"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalGanglion3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001304)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001304#vagal-ganglion-3",
+  "name": "vagal ganglion 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001304",
+  "synonym": [
+    "gX3",
+    "nodose ganglion 3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion4.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalGanglion4.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalGanglion4",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001305)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001305#vagal-ganglion-4",
+  "name": "vagal ganglion 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001305",
+  "synonym": [
+    "gX4",
+    "nodose ganglion 4"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagusXGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagusXGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagusXGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "description": "The group of sensory neuron cell bodies associated with the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005362#vagus-x-ganglion",
+  "name": "vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005362",
+  "synonym": [
+    "ganglion of vagus nerve",
+    "right glossopharyngeal ganglion",
+    "vagal ganglion",
+    "vagus ganglion",
+    "vagus neural ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralAnteriorLateralLineGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001313)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001313#ventral-anterior-lateral-line-ganglion",
+  "name": "ventral anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001313",
+  "synonym": [
+    "anteroventral lateral line ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vertebralGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vertebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vertebralGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the cervical ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408) ('is_a' and 'relationship')]",
+  "description": "Any of a group of sympathetic ganglia which form two chains extending from the base of the skull to the coccyx along the sides of the spinal column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000408#vertebral-ganglion",
+  "name": "vertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000408",
+  "synonym": [
+    "intermediate ganglion"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibularGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibularGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibularGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion, sensory ganglion, ganglion of peripheral nervous system and vestibular organ. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824) ('is_a' and 'relationship')]",
+  "description": "The ganglion of the vestibular nerve. It contains the cell bodies of the bipolar primary afferent neurons whose peripheral processes form synaptic contact with hair cells of the vestibular sensory end organs. Distributed to the maculae of the utricle and saccule and to the ampullary crests of the semicircular ducts. The vestibular fibers arise in bipolar cells in the vestibular ganglion in the internal acoustic meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002824#vestibular-ganglion-1",
+  "name": "vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002824",
+  "synonym": [
+    "Scarpa's ganglion",
+    "vestibular part of vestibulocochlear ganglion",
+    "vestibulocochlear VIII ganglion vestibular component"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013498)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013498#vestibulo-cochlear-viii-ganglion-complex",
+  "name": "vestibulo-cochlear VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013498",
+  "synonym": [
+    "vestibulocochlear ganglion complex",
+    "vestibulocochlear VIII ganglion complex"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibulocochlearGanglion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "description": "The group of neuron cell bodies associated with the eighth cranial nerve during embryogenesis; splits in later development to form the cochlear and vestibular ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002827#auditory-ganglion",
+  "name": "vestibulocochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002827",
+  "synonym": [
+    "acoustic ganglion VIII",
+    "acoustico-vestibular VIII ganglion",
+    "auditory ganglion",
+    "ganglion VIII",
+    "gVIII",
+    "statoacoustic (VIII) ganglion",
+    "statoacoustic ganglia",
+    "statoacoustic ganglion",
+    "vestibulocochlear VIII ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/GruenebergGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/GruenebergGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "description": "An olfactory ganglion at the entrance of the nose of mammals that is involved in the detection of alarm pheromones and cold temperatures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013208)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013208#grueneberg-ganglion",
+  "name": "Grueneberg ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013208",
+  "synonym": [
+    "Grüneberg ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/abdominalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/abdominalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/abdominalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trunk ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "description": "A ganglion that is part of a abdominal segment of trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009758)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009758#abdominal-ganglion",
+  "name": "abdominal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009758",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/abdominalGanglionOfVisceralHump.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/abdominalGanglionOfVisceralHump",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "description": "An unpaired knot of nerves in The visceral sacs that innervates the pallial organs as well as the inner organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008964#abdominal-ganglion-of-visceral-hump",
+  "name": "abdominal ganglion of visceral hump",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008964",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/accessoryCiliaryGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryCiliaryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "description": "A parasympathetic ganglion located on the short ciliary nerve differentiated from the main ciliary ganglion by virtue of the fact that it had no root derived directly from the inferior trunk of the oculomotor nerve and it never attaches to this nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035776)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035776#accessory-ciliary-ganglion",
+  "name": "accessory ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035776",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/acousticoFacialVIIVIIIGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0012175)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0012175#acoustico-facial-vii-viii-ganglion-complex",
+  "name": "acoustico-facial VII-VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0012175",
+  "synonym": [
+    "acousticofacial ganglion",
+    "facio-acoustic ganglion",
+    "facio-acoustic ganglion complex VII-VIII"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/anteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "description": "The anteror lateral line ganglia develops from cranial ectodermal placodes and contain sensory neurons that innervate the anterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001391)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001391#anterior-lateral-line-ganglion",
+  "name": "anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001391",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/areaXOfBasalGanglion.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/areaXOfBasalGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Area X of basal ganglion' is a nucleus of brain. It is part of the basal ganglion.",
-  "description": "A nucleus in the basal ganglion of songbirds.",
+  "definition": "Is a nucleus of brain. Is part of the basal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807) ('is_a' and 'relationship')]",
+  "description": "A nucleus in the basal ganglion of songbirds. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035807)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0731535",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035807#area-x-of-basal-ganglion",
   "name": "area X of basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035807",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/autonomicGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/autonomicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/autonomicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion of peripheral nervous system. Is part of the autonomic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805) ('is_a' and 'relationship')]",
+  "description": "Ganglion that has dendrites that form a junction between autonomic nerves originating from the central nervous system and autonomic nerves innervating their target organs in the periphery. There are two subtypes, sympathetic ganglion and parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001805#autonomic-ganglion",
+  "name": "autonomic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001805",
+  "synonym": [
+    "autonomic nervous system ganglion",
+    "ganglion of autonomic nervous system",
+    "ganglion of visceral nervous system",
+    "visceral nervous system ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/basalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/basalGanglion.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/basalGanglion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Basal ganglion' is a brain gray matter and nuclear complex of neuraxis. It is part of the collection of basal ganglia.",
-  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum[NIF,modified].",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. Is part of the collection of basal ganglia. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420) ('is_a' and 'relationship')]",
+  "description": "An individual member of a collection of basal ganglia. Basal ganglia are subcortical masses of gray matter in the forebrain and midbrain that are richly interconnected and so viewed as a functional system. The nuclei usually included are the caudate nucleus (caudoputamen in rodents), putamen, globus pallidus, substantia nigra (pars compacta and pars reticulata) and the subthalamic nucleus. Some also include the nucleus accumbens and ventral pallidum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002420)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002420#basal-ganglion",
   "name": "basal ganglion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002420",
-  "synonym": null
+  "synonym": [
+    "basal ganglion of telencephalon"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cardiacGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cardiacGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cardiacGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "description": "Any of the parasympathetic ganglia of the cardiac plexus between the arch of the aorta and the bifurcation of the pulmonary artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014463)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014463#cardiac-ganglion",
+  "name": "cardiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014463",
+  "synonym": [
+    "cardiac ganglia set",
+    "cardiac ganglion of Wrisberg",
+    "ganglia cardiaca",
+    "ganglion of Wrisberg",
+    "Wrisberg ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/caudalGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudalGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026) ('is_a' and 'relationship')]",
+  "description": "The caudally located, distinct elevation of a transient proliferating cell mass of the fetal subventricular zone, located adjacent to the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004026)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004026#caudal-ganglionic-eminence",
+  "name": "caudal ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004026",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/celiacGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/celiacGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/celiacGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "description": "The celiac ganglia are two large irregularly shaped masses of nerve tissue in the upper abdomen. Part of the sympathetic subdivision of the autonomic nervous system (ANS), the two celiac ganglia are the largest ganglia in the ANS, and they innervate most of the digestive tract. They have the appearance of lymph glands and are placed on either side of the midline in front of the crura of the diaphragm, close to the suprarenal glands (also called adrenal glands). The ganglion on the right side is placed behind the inferior vena cava. They are sometimes referred to as the semilunar ganglia or the solar ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002262)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002262#celiac-ganglion",
+  "name": "celiac ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002262",
+  "synonym": [
+    "coeliac ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002834)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002834#cervical-dorsal-root-ganglion-1",
+  "name": "cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002834",
+  "synonym": [
+    "cervical dorsal root ganglion",
+    "cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "description": "The cervical ganglia are paravertebral ganglia of the sympathetic nervous system. They consist of three paravertebral ganglia: superior cervical ganglion middle cervical ganglion inferior cervical ganglion. The inferior ganglion may be fused with the first thoracic ganglion to form a single structure, the stellate ganglion. Nerves emerging from cervical sympathetic ganglia contribute to the cardiac plexus, among other things. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001991#cervical-ganglion",
+  "name": "cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001991",
+  "synonym": [
+    "cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicothoracicGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicothoracicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "description": "The group of neurons formed by the fusion of the inferior cervical and first thoracic ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002441)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002441#cervicothoracic-ganglion",
+  "name": "cervicothoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002441",
+  "synonym": [
+    "cervicothoracic sympathetic ganglion",
+    "ganglion cervicothoracicum",
+    "ganglion stellatum",
+    "stellate ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cochlearGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cochlearGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cochlearGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395) ('is_a' and 'relationship')]",
+  "description": "The group of nerve cell bodies that conveys auditory sensation from the organ of Corti to the hindbrain and resides on the cochlear part of the vestibulocochlear nerve (eighth cranial nerve). distributed to the hair cells of the spiral organ. The cochlear fibers arise in bipolar cells in the spiral ganglion in the modiolus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000395)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000395#cochlear-ganglion",
+  "name": "cochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000395",
+  "synonym": [
+    "cochlear part of vestibulocochlear ganglion",
+    "Corti's ganglion",
+    "ganglion of Corti",
+    "spiral ganglion",
+    "vestibulocochlear VIII ganglion cochlear component"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cranialGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cranialGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cranialGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "description": "The groups of nerve cell bodies associated with the twelve cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001714#cranial-ganglion-part-of-peripheral-nervous-system",
+  "name": "cranial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001714",
+  "synonym": [
+    "cranial ganglion",
+    "cranial ganglion part of peripheral nervous system",
+    "cranial ganglion/nerve",
+    "cranial nerve ganglion",
+    "cranial neural ganglion",
+    "cranial neural tree organ ganglion",
+    "ganglion of cranial nerve",
+    "ganglion of cranial neural tree organ"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cranialSensoryGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cranialSensoryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "description": "The ganglion found on the root of each cranial nerve, containing the cell bodies of afferent (sensory) neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009992#cranial-sensory-ganglion",
+  "name": "cranial sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009992",
+  "synonym": [
+    "cranial nerve sensory ganglion",
+    "ganglion sensorium cranialium",
+    "ganglion sensorium nervi cranialis",
+    "sensory ganglion of cranial nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalAnteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001312)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001312#dorsal-anterior-lateral-line-ganglion",
+  "name": "dorsal anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001312",
+  "synonym": [
+    "anterodorsal lateral line ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalLateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalLateralGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lateral ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264) ('is_a' and 'relationship')]",
+  "description": "The dorsal region of the lateral ganglionic eminence. The cells in this area give rise to embryonic interneuron precursors that will migrate tangentially to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0018264)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0018264#dorsal-lateral-ganglionic-eminence",
+  "name": "dorsal lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0018264",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalRootGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "description": "Sensory ganglia located on the dorsal spinal roots within the vertebral column. The spinal ganglion cells are pseudounipolar. The single primary branch bifurcates sending a peripheral process to carry sensory information from the periphery and a central branch which relays that information to the spinal cord or brain. (MSH) * ganglion found on the posterior root of each spinal nerve, composed of the unipolar nerve cell bodies of the sensory neurons of the nerve. (CSP) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000044)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000044#dorsal-root-ganglion-1",
+  "name": "dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000044",
+  "synonym": [
+    "dorsal root ganglion",
+    "ganglion of dorsal root",
+    "ganglion spinalis",
+    "spinal ganglion",
+    "spinal ganglion part of peripheral nervous system"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/eighthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002844#eighth-cervical-dorsal-root-ganglion-1",
+  "name": "eighth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002844",
+  "synonym": [
+    "eighth cervical dorsal root ganglion",
+    "eighth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/eighthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002851)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002851#eighth-thoracic-dorsal-root-ganglion-1",
+  "name": "eighth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002851",
+  "synonym": [
+    "eighth thoracic dorsal root ganglion",
+    "eighth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/eleventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eleventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002854)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002854#eleventh-thoracic-dorsal-root-ganglion-1",
+  "name": "eleventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002854",
+  "synonym": [
+    "eleventh thoracic dorsal root ganglion",
+    "eleventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/entericGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/entericGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/entericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. Is part of the enteric nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001809) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001809#enteric-ganglion",
+  "name": "enteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001809",
+  "synonym": [
+    "intramural ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/epibranchialGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/epibranchialGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "description": "Cranial ganglion which develops from an epibranchial placode. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009127#epibranchial-ganglion",
+  "name": "epibranchial ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009127",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/facioAcousticVIIVIIIPreganglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006232) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006232#facio-acoustic-vii-viii-preganglion-complex",
+  "name": "facio-acoustic VII-VIII preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006232",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002842)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002842#fifth-cervical-dorsal-root-ganglion-1",
+  "name": "fifth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002842",
+  "synonym": [
+    "C5 dorsal root ganglion",
+    "fifth cervical dorsal root ganglion",
+    "fifth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fifth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002859)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002859#fifth-lumbar-dorsal-root-ganglion-1",
+  "name": "fifth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002859",
+  "synonym": [
+    "fifth lumbar dorsal root ganglion",
+    "fifth lumbar spinal ganglion",
+    "L5 dorsal root ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002863)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002863#fifth-sacral-dorsal-root-ganglion-1",
+  "name": "fifth sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002863",
+  "synonym": [
+    "fifth sacral dorsal root ganglion",
+    "fifth sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002848)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002848#fifth-thoracic-dorsal-root-ganglion-1",
+  "name": "fifth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002848",
+  "synonym": [
+    "fifth thoracic dorsal root ganglion",
+    "fifth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002838#first-cervical-dorsal-root-ganglion-1",
+  "name": "first cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002838",
+  "synonym": [
+    "first cervical dorsal root ganglion",
+    "first cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002857)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002857#first-lumbar-dorsal-root-ganglion-1",
+  "name": "first lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002857",
+  "synonym": [
+    "first lumbar dorsal root ganglion",
+    "first lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002860)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002860#first-sacral-dorsal-root-ganglion-1",
+  "name": "first sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002860",
+  "synonym": [
+    "first sacral dorsal root ganglion",
+    "first sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002845)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002845#first-thoracic-dorsal-root-ganglion-1",
+  "name": "first thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002845",
+  "synonym": [
+    "first thoracic dorsal root ganglion",
+    "first thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002841)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002841#fourth-cervical-dorsal-root-ganglion-1",
+  "name": "fourth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002841",
+  "synonym": [
+    "C4 dorsal root ganglion",
+    "fourth cervical dorsal root ganglion",
+    "fourth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the fourth lumbar vertebra. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003943#forth-lumbar-dorsal-root-ganglion",
+  "name": "fourth lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003943",
+  "synonym": [
+    "forth lumbar dorsal root ganglion",
+    "fourth lumbar dorsal root ganglion",
+    "fourth lumbar spinal ganglion",
+    "L4 dorsal root ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthSacralSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthSacralSpinalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007713)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007713#forth-sacral-dorsal-root-ganglion",
+  "name": "fourth sacral spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007713",
+  "synonym": [
+    "forth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion",
+    "fourth sacral dorsal root ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthThoracicSpinalGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthThoracicSpinalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007712)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007712#fourth-thoracic-dorsal-root-ganglion",
+  "name": "fourth thoracic spinal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007712",
+  "synonym": [
+    "forth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion",
+    "fourth thoracic dorsal root ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045) ('is_a' and 'relationship')]",
+  "description": "A biological tissue mass, most commonly a mass of nerve cell bodies. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000045)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000045#ganglion-1",
+  "name": "ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000045",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ganglionicEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ganglionicEminence.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ganglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023) ('is_a' and 'relationship')]",
+  "description": "The transient proliferative population of neurons that expands exponentially during late prenatal development; it is a continuous germinal zone distinct from the ventricular zone that surrounds the brain ventricles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004023)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004023#ganglionic-eminence",
+  "name": "ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004023",
+  "synonym": [
+    "embryonic subventricular zone",
+    "embryonic/fetal subventricular zone",
+    "fetal subventricular zone",
+    "subependymal layer"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/gasserianGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/gasserianGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gasserianGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3011045)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3011045#gasserian-ganglion",
+  "name": "gasserian ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3011045",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/gastropodCerebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gastropodCerebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "description": "The cerebral ganglia are primarily sensual centres, that compute information from the eyes as well as from the tactile and position sensors (statocystes). Besides coordination they also serve the locational memory of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008942)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008942#gastropod-cerebral-ganglion",
+  "name": "gastropod cerebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008942",
+  "synonym": [
+    "cerebral ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/geniculateGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/geniculateGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/geniculateGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory ganglion and epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "description": "The group of sensory neuron cell bodies associated with the facial nerve (seventh cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001700)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001700#geniculate-ganglion",
+  "name": "geniculate ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001700",
+  "synonym": [
+    "facial VII ganglion",
+    "ganglion genicularum",
+    "genicular ganglion",
+    "genicular ganglion",
+    "gVII"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "description": "The group of neuron cell bodies associated with the ninth cranial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001701)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001701#glossopharyngeal-ganglion",
+  "name": "glossopharyngeal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001701",
+  "synonym": [
+    "ganglion of glossopharyngeal nerve",
+    "ganglion of glosspharyngeal nerve",
+    "glossopharyngeal IX ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealIXPreganglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealIXPreganglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006243) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006243#glossopharyngeal-ix-preganglion",
+  "name": "glossopharyngeal IX preganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006243",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealVagusIXXGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013500#glossopharyngeal-vagus-ix-x-ganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013500",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealVagusIXXPreganglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cranial ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013499) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013499#glossopharyngeal-vagus-ix-x-preganglion-complex",
+  "name": "glossopharyngeal-vagus IX-X preganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013499",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "description": "The inferior cervical ganglion is situated between the base of the transverse process of the last cervical vertebra and the neck of the first rib, on the medial side of the costocervical artery. Its form is irregular; it is larger in size than the middle cervical ganglion, and is frequently fused with the first thoracic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002440)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002440#inferior-cervical-ganglion",
+  "name": "inferior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002440",
+  "synonym": [
+    "variant cervical ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "description": "The lower group of sensory neuron cell bodies associated with the glossopharyngeal nerve. It is situated in a depression in the lower border of the petrous portion of the temporal bone. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005360)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005360#inferior-glossopharyngeal-ix-ganglion",
+  "name": "inferior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005360",
+  "synonym": [
+    "extracraniale ganglion",
+    "ganglion inferius (nervus glossopharygeus)",
+    "ganglion inferius nervus glossopharyngei",
+    "ganglion of andersch",
+    "glossopharyngeal nerve inferior ganglion",
+    "glossopharyngeal nerve petrous ganglion",
+    "inferior ganglion of glossopharyngeal nerve",
+    "inferior glossopharyngeal ganglion",
+    "inferior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve",
+    "ninth cranial nerve inferior ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorMesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the inferior mesenteric nerve plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453) ('is_a' and 'relationship')]",
+  "description": "A ganglion located near where the inferior mesenteric artery branches from the abdominal aorta. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005453)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005453#inferior-mesenteric-ganglion",
+  "name": "inferior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005453",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorPartOfVestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002826)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002826#inferior-part-of-vestibular-ganglion-1",
+  "name": "inferior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002826",
+  "synonym": [
+    "pars inferior ganglionis vestibularis",
+    "vestibular ganglion inferior part"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorVagusXGanglion.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorVagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "description": "The large group of sensory neuron cell bodies, anterior to the jugular vein, associated with the vagus nerve (tenth cranial nerve) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005363)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005363#inferior-vagus-x-ganglion",
+  "name": "inferior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005363",
+  "synonym": [
+    "ganglion inferius (nervus vagus)",
+    "ganglion inferius nervi vagi",
+    "ganglion inferius nervus vagi",
+    "ganglion nodosum",
+    "inferior ganglion of vagus",
+    "inferior ganglion of vagus nerve",
+    "nodose ganglion",
+    "tenth cranial nerve nodose ganglion",
+    "vagus nerve inferior ganglion",
+    "vagus nerve nodose ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the striatum; however, neocortex, thalamus, septum and olfactory bulb neurons are also partly derived from the LGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004025)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004025#lateral-ganglionic-eminence",
+  "name": "lateral ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004025",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "description": "Ganglion that develops from a cranial ectodermal placode and contains sensory neurons that innervate a lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000120)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000120#lateral-line-ganglion",
+  "name": "lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000120",
+  "synonym": [
+    "LLG"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "description": "The group of nerve cell bodies located on the dorsal spinal roots within the vertebral column at the level of the lumbar vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002836#lumbar-dorsal-root-ganglion-1",
+  "name": "lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002836",
+  "synonym": [
+    "lumbar dorsal root ganglion",
+    "lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mainCiliaryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mainCiliaryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and ganglion of ciliary nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "description": "A parasympathetic ganglion located in the posterior orbit that contains preganglionic nerves and postganglionic neurons of the oculomotor nerve, connects to the Edinger-Westphal nucleus via the oculomotor nerve and the eye muscles via the short ciliary nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002058)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002058#main-ciliary-ganglion",
+  "name": "main ciliary ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002058",
+  "synonym": [
+    "ciliary ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/maxillomandibularPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035601) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035601#maxillomandibular-part-of-trigeminal-ganglion-complex",
+  "name": "maxillomandibular part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035601",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/medialGanglionicEminence.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialGanglionicEminence",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the ganglionic eminence. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024) ('is_a' and 'relationship')]",
+  "description": "A distinct elevation of a transient proliferating cell mass of the fetal subventricular zone; this mass contributes most of its cells to the neocortex; however, hippocampal neurons, thalamus, septum and olfactory bulb neurons are also partly derived from the MGE. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004024)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004024#medial-ganglionic-eminence",
+  "name": "medial ganglionic eminence",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004024",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mesentericGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. Is part of the mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035769) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035769#mesenteric-ganglion",
+  "name": "mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035769",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/middleCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/middleCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "description": "The small ganglion located at the level of the cricoid cartilage of the laryngeal wall. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001990#middle-cervical-ganglion",
+  "name": "middle cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001990",
+  "synonym": [
+    "middle cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/middleLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/middleLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "description": "The middle lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the middle lateral line. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001483)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001483#middle-lateral-line-ganglion",
+  "name": "middle lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001483",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ninthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ninthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002852)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002852#ninth-thoracic-dorsal-root-ganglion-1",
+  "name": "ninth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002852",
+  "synonym": [
+    "ninth thoracic dorsal root ganglion",
+    "ninth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/oticGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/oticGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/oticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion and parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "description": "The ganglion that supplies nerve fibers to the parotid gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003963)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003963#otic-ganglion",
+  "name": "otic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003963",
+  "synonym": [
+    "Arnold's ganglion",
+    "otic parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parasympatheticGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parasympatheticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the parasympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808) ('is_a' and 'relationship')]",
+  "description": "Ganglion containing neurons that receive innervation from parasympathetic neurons in the central nervous system and subserves parasympathetic functions through innervation of smooth muscle, cardiac muscle and glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001808#parasympathetic-ganglion",
+  "name": "parasympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001808",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/paravertebralGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/paravertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion and trunk ganglion. Is part of the sympathetic trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807) ('is_a' and 'relationship')]",
+  "description": "Trunk ganglion which is part of a bilaterally paired set of sympathetic ganglia located anterior and lateral to the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001807#paravertebral-ganglion",
+  "name": "paravertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001807",
+  "synonym": [
+    "ganglion of sympathetic trunk",
+    "ganglion trunci sympathetici",
+    "ganglion trunci sympathici",
+    "sympathetic chain ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parietalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parietalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "description": "A lateral ganglion that innervates pallial cavity, gills and skin of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008940)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008940#parietal-ganglion",
+  "name": "parietal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008940",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pedalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pedalGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pedalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "description": "The pedal ganglia mainly are necessary for coordination of locomotion of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008939)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008939#pedal-ganglion",
+  "name": "pedal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008939",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pelvicGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pelvicGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pelvicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a prevertebral ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016508)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016508#pelvic-ganglion",
+  "name": "pelvic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016508",
+  "synonym": [
+    "inferior hypogastric ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pleuralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pleuralGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pleuralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "description": "A knot of nerves in The pallial cavity that innervates the mantle of a snail. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008941)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008941#pleural-ganglion",
+  "name": "pleural ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008941",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorLateralLineGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "description": "The posterior lateral line ganglion develops from a cranial ectodermal placode and contains sensory neurons that innervate the posterior lateral line system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001314)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001314#posterior-lateral-line-ganglion",
+  "name": "posterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001314",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicAutonomicFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from cell bodies of autonomic ganglia to synapses on target organs. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011924#postganglionic-autonomic-fiber",
+  "name": "postganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011924",
+  "synonym": [
+    "postganglionic nerve fiber"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicParasympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from a parasympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011929)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011929#postganglionic-parasympathetic-fiber",
+  "name": "postganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011929",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postganglionicSympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a postganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926) ('is_a' and 'relationship')]",
+  "description": "A noradrenergic or adrenergic axonal fiber projecting from a sympathetic ganglion to an effector organ. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011926)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011926#postganglionic-sympathetic-fiber",
+  "name": "postganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011926",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preganglionicAutonomicFiber.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicAutonomicFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a trigeminal nerve fibers. Is part of the autonomic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925) ('is_a' and 'relationship')]",
+  "description": "Nerve fibers which project from the central nervous system to autonomic ganglia. In the sympathetic division most preganglionic fibers originate with neurons in the intermediolateral column of the spinal cord, exit via ventral roots from upper thoracic through lower lumbar segments, and project to the paravertebral ganglia; there they either terminate in synapses or continue through the splanchnic nerves to the prevertebral ganglia. In the parasympathetic division the fibers originate in neurons of the brain stem and sacral spinal cord. In both divisions the principal transmitter is acetylcholine but peptide cotransmitters may also be released. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011925)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011925#preganglionic-autonomic-fiber",
+  "name": "preganglionic autonomic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011925",
+  "synonym": [
+    "preganglionic nerve fiber"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preganglionicParasympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicParasympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the parasympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fibers projecting from the CNS to a parasympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011930)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011930#preganglionic-parasympathetic-fiber",
+  "name": "preganglionic parasympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011930",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preganglionicSympatheticFiber.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preganglionicSympatheticFiber",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a preganglionic autonomic fiber. Is part of the sympathetic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927) ('is_a' and 'relationship')]",
+  "description": "A cholinergic axonal fiber projecting from the CNS to a sympathetic ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011927)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011927#preganglionic-sympathetic-fiber",
+  "name": "preganglionic sympathetic fiber",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011927",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/prevertebralGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/prevertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "description": "The sympathetic ganglia located in front of the vertebral column and are associated with the major branches of the abdominal aorta; these include the celiac, aorticorenal, superior and inferior mesenteric ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003964)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003964#prevertebral-ganglion",
+  "name": "prevertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003964",
+  "synonym": [
+    "collateral ganglion",
+    "previsceral ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/profundalPartOfTrigeminalGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. Is part of the trigeminal ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035599) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035599#profundal-part-of-trigeminal-ganglion-complex",
+  "name": "profundal part of trigeminal ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035599",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pterygopalatineGanglion.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pterygopalatineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "description": "The small parasympathetic ganglion that supplies nerve fibers to the lacrimal, nasal, palatine and pharyngeal glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003962)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003962#pterygopalatine-ganglion",
+  "name": "pterygopalatine ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003962",
+  "synonym": [
+    "Meckel ganglion",
+    "Meckel's ganglion",
+    "nasal ganglion",
+    "palatine ganglion",
+    "pterygopalatine ganglia",
+    "sphenopalatine ganglion",
+    "sphenopalatine parasympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002837)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002837#sacral-dorsal-root-ganglion-1",
+  "name": "sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002837",
+  "synonym": [
+    "sacral dorsal root ganglion",
+    "sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002839)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002839#second-cervical-dorsal-root-ganglion-1",
+  "name": "second cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002839",
+  "synonym": [
+    "C2 dorsal root ganglion",
+    "second cervical dorsal root ganglion",
+    "second cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002856)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002856#second-lumbar-dorsal-root-ganglion-1",
+  "name": "second lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002856",
+  "synonym": [
+    "second lumbar dorsal root ganglion",
+    "second lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002861)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002861#second-sacral-dorsal-root-ganglion-1",
+  "name": "second sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002861",
+  "synonym": [
+    "second sacral dorsal root ganglion",
+    "second sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002846)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002846#second-thoracic-dorsal-root-ganglion-1",
+  "name": "second thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002846",
+  "synonym": [
+    "second thoracic dorsal root ganglion",
+    "second thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sensoryGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sensoryGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sensoryGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "description": "The clusters of neurons in the somatic peripheral nervous system which contain the cell bodies of sensory nerve axons, interneurons and non-neuronal supporting cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001800)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001800#sensory-ganglion",
+  "name": "sensory ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001800",
+  "synonym": [
+    "ganglion sensorium"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/seventhCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002843)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002843#seventh-cervical-dorsal-root-ganglion-1",
+  "name": "seventh cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002843",
+  "synonym": [
+    "C7 dorsal root ganglion",
+    "seventh cervical dorsal root ganglion",
+    "seventh cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/seventhThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002850)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002850#seventh-thoracic-dorsal-root-ganglion-1",
+  "name": "seventh thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002850",
+  "synonym": [
+    "seventh thoracic dorsal root ganglion",
+    "seventh thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sixthCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007711)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007711#sixth-cervical-dorsal-root-ganglion-1",
+  "name": "sixth cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007711",
+  "synonym": [
+    "C6 dorsal root ganglion",
+    "sixth cervical dorsal root ganglia",
+    "sixth cervical dorsal root ganglion",
+    "sixth cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sixthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002849)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002849#sixth-thoracic-dorsal-root-ganglion-1",
+  "name": "sixth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002849",
+  "synonym": [
+    "sixth thoracic dorsal root ganglion",
+    "sixth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sublingualGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sublingualGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sublingualGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "description": "The small parasympathetic ganglion found anterior to the submandibular gland that provides postsynaptic fibers to the sublingual gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005407)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005407#sublingual-ganglion",
+  "name": "sublingual ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005407",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/submandibularGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/submandibularGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/submandibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parasympathetic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "description": "The ganglion associated with the lingual nerve that provides postsynaptic fibers to the submandibular and sublingual glands. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002059#submandibular-ganglion",
+  "name": "submandibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002059",
+  "synonym": [
+    "mandibular ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorCervicalGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorCervicalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "description": "Trunk ganglion which is bilaterally paired and located at the anterior end of the sympathetic ganglion chain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001989)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001989#superior-cervical-ganglion",
+  "name": "superior cervical ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001989",
+  "synonym": [
+    "superior cervical sympathetic ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorGlossopharyngealIXGanglion.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorGlossopharyngealIXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a glossopharyngeal ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "description": "The upper ganglion of the glossopharyngeal nerve. is situated in the upper part of the groove in which the glossopharyngeal nerve is lodged during its passage through the jugular foramen. It is very small, and is usually regarded as a detached portion of the inferior ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005361)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005361#superior-glossopharyngeal-ix-ganglion",
+  "name": "superior glossopharyngeal IX ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005361",
+  "synonym": [
+    "Ehrenritter's ganglion",
+    "ganglion superius (nervus glossopharyngeus)",
+    "ganglion superius nervus glossopharyngei",
+    "glossopharyngeal nerve jugular ganglion",
+    "glossopharyngeal nerve superior ganglion",
+    "intracranial ganglion",
+    "ninth cranial nerve superior ganglion",
+    "superior ganglion of glossopharyngeal nerve",
+    "superior glossopharyngeal ganglia",
+    "superior glossopharyngeal ganglion",
+    "superior glossopharyngeal ganglion of the glossopharyngeal (IX) nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorMesentericGanglion.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorMesentericGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a mesenteric ganglion. Is part of the superior mesenteric plexus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479) ('is_a' and 'relationship')]",
+  "description": "A ganglion in the upper part of the superior mesenteric plexus that is the synapsing point for one of the pre- and post-synaptic nerves of the sympathetic division of the autonomous nervous system. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005479)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005479#superior-mesenteric-ganglion",
+  "name": "superior mesenteric ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005479",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorPartOfVestibularGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorPartOfVestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibular ganglion. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "description": "The part of the vestibular ganglion that receives fibers from the maculae of the utricle and the sacculae and the ampullae of the anterior and lateral semicircular ducts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002825)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002825#superior-part-of-vestibular-ganglion-1",
+  "name": "superior part of vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002825",
+  "synonym": [
+    "pars superior ganglionis vestibularis",
+    "vestibular ganglion superior part"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superiorVagusXGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorVagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a vagus X ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "description": "The upper ganglion of the vagus nerve located at the jugular foramen. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005364)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005364#superior-vagus-x-ganglion",
+  "name": "superior vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005364",
+  "synonym": [
+    "ganglion superius (nervus vagus)",
+    "ganglion superius nervus vagi",
+    "superior ganglion of vagus",
+    "superior ganglion of vagus nerve",
+    "superior vagus ganglion",
+    "tenth cranial nerve jugular ganglion",
+    "vagus nerve jugular ganglion",
+    "vagus nerve superior ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sympatheticGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sympatheticGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an autonomic ganglion. Is part of the sympathetic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806) ('is_a' and 'relationship')]",
+  "description": "A ganglion of the sympathetic nervous system. Examples: paravertebral and the prevertebral ganglia, which include the sympathetic chain ganglia, the superior, middle, and inferior cervical ganglia, and the aorticorenal, celiac, and stellate ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001806#sympathetic-ganglion",
+  "name": "sympathetic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001806",
+  "synonym": [
+    "ganglion of sympathetic nervous system",
+    "ganglion of sympathetic part of autonomic division of nervous system",
+    "ganglion sympatheticum",
+    "sympathetic nervous system ganglion",
+    "sympathetic part of autonomic division of nervous system ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tenthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tenthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002853)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002853#tenth-thoracic-dorsal-root-ganglion-1",
+  "name": "tenth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002853",
+  "synonym": [
+    "tenth thoracic dorsal root ganglion",
+    "tenth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdCervicalDorsalRootGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdCervicalDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002840#third-cervical-dorsal-root-ganglion-1",
+  "name": "third cervical dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002840",
+  "synonym": [
+    "C3 dorsal root ganglion",
+    "third cervical dorsal root ganglion",
+    "third cervical spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdLumbarDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdLumbarDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002858)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002858#third-lumbar-dorsal-root-ganglion-1",
+  "name": "third lumbar dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002858",
+  "synonym": [
+    "third lumbar dorsal root ganglion",
+    "third lumbar spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdSacralDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdSacralDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002862)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002862#third-sacral-dorsal-root-ganglion-1",
+  "name": "third sacral dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002862",
+  "synonym": [
+    "third sacral dorsal root ganglion",
+    "third sacral spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002847)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002847#third-thoracic-dorsal-root-ganglion-1",
+  "name": "third thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002847",
+  "synonym": [
+    "third thoracic dorsal root ganglion",
+    "third thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal root ganglion and thoracic ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "description": "A dorsal root ganglion that is part of a thorax. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002835#thoracic-dorsal-root-ganglion-1",
+  "name": "thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002835",
+  "synonym": [
+    "dorsal root ganglion of thorax",
+    "ganglion of dorsal root of thorax",
+    "ganglion spinalis of thorax",
+    "thoracic dorsal root ganglion",
+    "thoracic spinal ganglion",
+    "thorax dorsal root ganglion",
+    "thorax ganglion of dorsal root",
+    "thorax ganglion spinalis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the thoracic sympathetic nerve trunk. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961) ('is_a' and 'relationship')]",
+  "description": "The thoracic ganglia are paravertebral ganglia. The thoracic portion of the sympathetic trunk typically has 12 thoracic ganglia. Emerging from the ganglia are thoracic splancic nerves (the cardiopulmonary, the greater, lesser, and least splanchic nerves) that help provide sympathetic innervation to abdominal structures. Also, the ganglia of the thoracic sympathetic trunk have both white and gray rami communicantes. The white rami carry sympathetic fibers arising in the spinal cord into the sympathetic trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000961)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000961#thoracic-ganglion",
+  "name": "thoracic ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000961",
+  "synonym": [
+    "ganglion of thorax",
+    "ganglion thoracicum splanchnicum",
+    "thoracic paravertebral ganglion",
+    "thoracic splanchnic ganglion",
+    "thoracic sympathetic ganglion",
+    "thorax ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trigeminalGanglion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminalGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion and sensory ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "description": "The cranial ganglion that is associated with and extends fibers into the trigeminal nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001675)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001675#trigeminal-ganglion",
+  "name": "trigeminal ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001675",
+  "synonym": [
+    "5th ganglion",
+    "fifth ganglion",
+    "ganglion of trigeminal complex",
+    "Gasserian ganglion",
+    "semilunar ganglion",
+    "trigeminal V ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trunkGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trunkGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trunkGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "description": "Ganglion which is located in the trunk. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007134)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007134#trunk-ganglion",
+  "name": "trunk ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007134",
+  "synonym": [
+    "body ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/twelfthThoracicDorsalRootGanglion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/twelfthThoracicDorsalRootGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic dorsal root ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002855)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002855#twelfth-thoracic-dorsal-root-ganglion-1",
+  "name": "twelfth thoracic dorsal root ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002855",
+  "synonym": [
+    "twelfth thoracic dorsal root ganglion",
+    "twelfth thoracic spinal ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion1.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion1.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001302)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001302#vagal-ganglion-1",
+  "name": "vagal ganglion 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001302",
+  "synonym": [
+    "gX1",
+    "nodose ganglion 1"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion2.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion2.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001303)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001303#vagal-ganglion-2",
+  "name": "vagal ganglion 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001303",
+  "synonym": [
+    "gX2",
+    "nodose ganglion 2"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion3.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001304)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001304#vagal-ganglion-3",
+  "name": "vagal ganglion 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001304",
+  "synonym": [
+    "gX3",
+    "nodose ganglion 3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion4.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalGanglion4.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalGanglion4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001305)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001305#vagal-ganglion-4",
+  "name": "vagal ganglion 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001305",
+  "synonym": [
+    "gX4",
+    "nodose ganglion 4"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagusXGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagusXGanglion.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagusXGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an epibranchial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "description": "The group of sensory neuron cell bodies associated with the vagus nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005362)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005362#vagus-x-ganglion",
+  "name": "vagus X ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005362",
+  "synonym": [
+    "ganglion of vagus nerve",
+    "right glossopharyngeal ganglion",
+    "vagal ganglion",
+    "vagus ganglion",
+    "vagus neural ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralAnteriorLateralLineGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralAnteriorLateralLineGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterior lateral line ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001313)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001313#ventral-anterior-lateral-line-ganglion",
+  "name": "ventral anterior lateral line ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001313",
+  "synonym": [
+    "anteroventral lateral line ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vertebralGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vertebralGanglion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vertebralGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paravertebral ganglion. Is part of the cervical ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408) ('is_a' and 'relationship')]",
+  "description": "Any of a group of sympathetic ganglia which form two chains extending from the base of the skull to the coccyx along the sides of the spinal column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0000408)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0000408#vertebral-ganglion",
+  "name": "vertebral ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0000408",
+  "synonym": [
+    "intermediate ganglion"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibularGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibularGanglion.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibularGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion, sensory ganglion, ganglion of peripheral nervous system and vestibular organ. Is part of the vestibulocochlear ganglion. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824) ('is_a' and 'relationship')]",
+  "description": "The ganglion of the vestibular nerve. It contains the cell bodies of the bipolar primary afferent neurons whose peripheral processes form synaptic contact with hair cells of the vestibular sensory end organs. Distributed to the maculae of the utricle and saccule and to the ampullary crests of the semicircular ducts. The vestibular fibers arise in bipolar cells in the vestibular ganglion in the internal acoustic meatus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002824)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002824#vestibular-ganglion-1",
+  "name": "vestibular ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002824",
+  "synonym": [
+    "Scarpa's ganglion",
+    "vestibular part of vestibulocochlear ganglion",
+    "vestibulocochlear VIII ganglion vestibular component"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibuloCochlearVIIIGanglionComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013498)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013498#vestibulo-cochlear-viii-ganglion-complex",
+  "name": "vestibulo-cochlear VIII ganglion complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013498",
+  "synonym": [
+    "vestibulocochlear ganglion complex",
+    "vestibulocochlear VIII ganglion complex"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibulocochlearGanglion.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulocochlearGanglion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cranial ganglion. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "description": "The group of neuron cell bodies associated with the eighth cranial nerve during embryogenesis; splits in later development to form the cochlear and vestibular ganglia. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002827)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002827#auditory-ganglion",
+  "name": "vestibulocochlear ganglion",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002827",
+  "synonym": [
+    "acoustic ganglion VIII",
+    "acoustico-vestibular VIII ganglion",
+    "auditory ganglion",
+    "ganglion VIII",
+    "gVIII",
+    "statoacoustic (VIII) ganglion",
+    "statoacoustic ganglia",
+    "statoacoustic ganglion",
+    "vestibulocochlear VIII ganglion"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'ganglion' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.