### PR TITLE
Border related UBERON terms

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderBetweenSublaminarLayers",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740) ('is_a' and 'relationship')]",
+  "description": "A region of the retina corresponding to a portion of two adjacent substratum layers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009740#border-between-sublaminar-layers",
+  "name": "border between sublaminar layers",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009740",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS1AndS2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S1 or S2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between layers S1 and S2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009738#border-of-sublaminar-layers-s1-and-s2",
+  "name": "border of sublaminar layers S1 and S2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009738",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS2AndS3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S2 or S3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S2 and S3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009852#border-of-sublaminar-layers-s2-and-s3",
+  "name": "border of sublaminar layers S2 and S3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009852",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS3AndS4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S3 or S4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between sublaminar layers S3 and S4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009739#border-of-sublaminar-layers-s3-and-s4",
+  "name": "border of sublaminar layers S3 and S4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009739",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS4AndS5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S4 or S5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S4 and S5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009851#border-of-sublaminar-layers-s4-and-s5",
+  "name": "border of sublaminar layers S4 and S5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009851",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/diencephalonLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005591)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005591#diencephalon-lateral-wall",
+  "name": "diencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005591",
+  "synonym": [
+    "lateral wall diencephalic region",
+    "lateral wall diencephalon"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/midbrainLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the midbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005495)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005495#midbrain-lateral-wall",
+  "name": "midbrain lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005495",
+  "synonym": [
+    "lateral wall midbrain",
+    "lateral wall midbrain region"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralTubeLateralWallMantleLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tube mantle layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005883)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005883#neural-tube-lateral-wall-mantle-layer",
+  "name": "neural tube lateral wall mantle layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005883",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005567#rhombomere-lateral-wall",
+  "name": "rhombomere 1 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005567",
+  "synonym": [
+    "lateral wall rhombomere 1"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005571#rhombomere-2-lateral-wall",
+  "name": "rhombomere 2 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005571",
+  "synonym": [
+    "lateral wall rhombomere 2"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005574#rhombomere-3-lateral-wall",
+  "name": "rhombomere 3 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005574",
+  "synonym": [
+    "lateral wall rhombomere 3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005577#rhombomere-4-lateral-wall",
+  "name": "rhombomere 4 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005577",
+  "synonym": [
+    "lateral wall rhombomere 4"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005580#rhombomere-5-lateral-wall",
+  "name": "rhombomere 5 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005580",
+  "synonym": [
+    "lateral wall rhombomere 5"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005583#rhombomere-6-lateral-wall",
+  "name": "rhombomere 6 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005583",
+  "synonym": [
+    "lateral wall rhombomere 6"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005586#rhombomere-7-lateral-wall",
+  "name": "rhombomere 7 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005586",
+  "synonym": [
+    "lateral wall rhombomere 7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005589#rhombomere-8-lateral-wall",
+  "name": "rhombomere 8 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005589",
+  "synonym": [
+    "lateral wall rhombomere 8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "description": "A neural tube lateral wall that is part of a rhombomere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005501#rhombomere-lateral-wall",
+  "name": "rhombomere lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005501",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009582)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009582#spinal-cord-lateral-wall",
+  "name": "spinal cord lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009582",
+  "synonym": [
+    "lateral wall spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalonLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the telencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005561)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005561#telencephalon-lateral-wall",
+  "name": "telencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005561",
+  "synonym": [
+    "lateral wall telencephalic region",
+    "lateral wall telencephalon"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036658) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036658",
+  "synonym": [
+    "wall of central canal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfCerebralAqueduct",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036655) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of cerebral aqueduct",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036655",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfFourthVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036657) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of fourth ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036657",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036654) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036654",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036656) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036656",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/borderBetweenSublaminarLayers",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740) ('is_a' and 'relationship')]",
+  "description": "A region of the retina corresponding to a portion of two adjacent substratum layers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009740#border-between-sublaminar-layers",
+  "name": "border between sublaminar layers",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009740",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/borderOfSublaminarLayersS1AndS2",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S1 or S2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between layers S1 and S2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009738#border-of-sublaminar-layers-s1-and-s2",
+  "name": "border of sublaminar layers S1 and S2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009738",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/borderOfSublaminarLayersS2AndS3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S2 or S3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S2 and S3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009852#border-of-sublaminar-layers-s2-and-s3",
+  "name": "border of sublaminar layers S2 and S3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009852",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/borderOfSublaminarLayersS3AndS4",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S3 or S4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between sublaminar layers S3 and S4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009739#border-of-sublaminar-layers-s3-and-s4",
+  "name": "border of sublaminar layers S3 and S4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009739",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/borderOfSublaminarLayersS4AndS5",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S4 or S5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S4 and S5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009851#border-of-sublaminar-layers-s4-and-s5",
+  "name": "border of sublaminar layers S4 and S5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009851",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/diencephalonLateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005591)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005591#diencephalon-lateral-wall",
+  "name": "diencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005591",
+  "synonym": [
+    "lateral wall diencephalic region",
+    "lateral wall diencephalon"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/midbrainLateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the midbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005495)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005495#midbrain-lateral-wall",
+  "name": "midbrain lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005495",
+  "synonym": [
+    "lateral wall midbrain",
+    "lateral wall midbrain region"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/neuralTubeLateralWallMantleLayer",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural tube mantle layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005883)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005883#neural-tube-lateral-wall-mantle-layer",
+  "name": "neural tube lateral wall mantle layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005883",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere1LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005567#rhombomere-lateral-wall",
+  "name": "rhombomere 1 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005567",
+  "synonym": [
+    "lateral wall rhombomere 1"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere2LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005571#rhombomere-2-lateral-wall",
+  "name": "rhombomere 2 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005571",
+  "synonym": [
+    "lateral wall rhombomere 2"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere3LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005574#rhombomere-3-lateral-wall",
+  "name": "rhombomere 3 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005574",
+  "synonym": [
+    "lateral wall rhombomere 3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere4LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005577#rhombomere-4-lateral-wall",
+  "name": "rhombomere 4 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005577",
+  "synonym": [
+    "lateral wall rhombomere 4"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere5LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005580#rhombomere-5-lateral-wall",
+  "name": "rhombomere 5 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005580",
+  "synonym": [
+    "lateral wall rhombomere 5"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere6LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005583#rhombomere-6-lateral-wall",
+  "name": "rhombomere 6 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005583",
+  "synonym": [
+    "lateral wall rhombomere 6"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere7LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005586#rhombomere-7-lateral-wall",
+  "name": "rhombomere 7 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005586",
+  "synonym": [
+    "lateral wall rhombomere 7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere8LateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005589#rhombomere-8-lateral-wall",
+  "name": "rhombomere 8 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005589",
+  "synonym": [
+    "lateral wall rhombomere 8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomereLateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "description": "A neural tube lateral wall that is part of a rhombomere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005501#rhombomere-lateral-wall",
+  "name": "rhombomere lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005501",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordLateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009582)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009582#spinal-cord-lateral-wall",
+  "name": "spinal cord lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009582",
+  "synonym": [
+    "lateral wall spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telencephalonLateralWall",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the telencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005561)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005561#telencephalon-lateral-wall",
+  "name": "telencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005561",
+  "synonym": [
+    "lateral wall telencephalic region",
+    "lateral wall telencephalon"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036658) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036658",
+  "synonym": [
+    "wall of central canal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfCerebralAqueduct",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036655) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of cerebral aqueduct",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036655",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfFourthVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036657) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of fourth ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036657",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfLateralVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036654) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036654",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/wallOfThirdVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036656) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036656",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/borderBetweenSublaminarLayers.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderBetweenSublaminarLayers",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system cell part layer. Is part of the retina. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740) ('is_a' and 'relationship')]",
+  "description": "A region of the retina corresponding to a portion of two adjacent substratum layers. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009740)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009740#border-between-sublaminar-layers",
+  "name": "border between sublaminar layers",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009740",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS1AndS2.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS1AndS2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S1 or S2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between layers S1 and S2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009738)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009738#border-of-sublaminar-layers-s1-and-s2",
+  "name": "border of sublaminar layers S1 and S2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009738",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS2AndS3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS2AndS3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S2 or S3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S2 and S3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009852#border-of-sublaminar-layers-s2-and-s3",
+  "name": "border of sublaminar layers S2 and S3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009852",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS3AndS4.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS3AndS4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S3 or S4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739) ('is_a' and 'relationship')]",
+  "description": "The region extending out from the boundary between sublaminar layers S3 and S4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009739)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009739#border-of-sublaminar-layers-s3-and-s4",
+  "name": "border of sublaminar layers S3 and S4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009739",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/borderOfSublaminarLayersS4AndS5.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/borderOfSublaminarLayersS4AndS5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a border between sublaminar layers. Is part of the sublaminar layers S4 or S5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851) ('is_a' and 'relationship')]",
+  "description": "The intersection of sublaminar layers S4 and S5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009851)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009851#border-of-sublaminar-layers-s4-and-s5",
+  "name": "border of sublaminar layers S4 and S5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009851",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/diencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/diencephalonLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the diencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005591)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005591#diencephalon-lateral-wall",
+  "name": "diencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005591",
+  "synonym": [
+    "lateral wall diencephalic region",
+    "lateral wall diencephalon"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/midbrainLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/midbrainLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the midbrain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005495)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005495#midbrain-lateral-wall",
+  "name": "midbrain lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005495",
+  "synonym": [
+    "lateral wall midbrain",
+    "lateral wall midbrain region"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/neuralTubeLateralWallMantleLayer.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralTubeLateralWallMantleLayer",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tube mantle layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005883)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005883#neural-tube-lateral-wall-mantle-layer",
+  "name": "neural tube lateral wall mantle layer",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005883",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere1LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005567)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005567#rhombomere-lateral-wall",
+  "name": "rhombomere 1 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005567",
+  "synonym": [
+    "lateral wall rhombomere 1"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere2LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005571)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005571#rhombomere-2-lateral-wall",
+  "name": "rhombomere 2 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005571",
+  "synonym": [
+    "lateral wall rhombomere 2"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere3LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005574)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005574#rhombomere-3-lateral-wall",
+  "name": "rhombomere 3 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005574",
+  "synonym": [
+    "lateral wall rhombomere 3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere4LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005577#rhombomere-4-lateral-wall",
+  "name": "rhombomere 4 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005577",
+  "synonym": [
+    "lateral wall rhombomere 4"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere5LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005580)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005580#rhombomere-5-lateral-wall",
+  "name": "rhombomere 5 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005580",
+  "synonym": [
+    "lateral wall rhombomere 5"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere6LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005583)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005583#rhombomere-6-lateral-wall",
+  "name": "rhombomere 6 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005583",
+  "synonym": [
+    "lateral wall rhombomere 6"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere7LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005586)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005586#rhombomere-7-lateral-wall",
+  "name": "rhombomere 7 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005586",
+  "synonym": [
+    "lateral wall rhombomere 7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere8LateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8LateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere lateral wall. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589) ('is_a' and 'relationship')]",
+  "description": "A rhombomere lateral wall that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005589)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005589#rhombomere-8-lateral-wall",
+  "name": "rhombomere 8 lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005589",
+  "synonym": [
+    "lateral wall rhombomere 8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomereLateralWall.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "description": "A neural tube lateral wall that is part of a rhombomere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005501)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005501#rhombomere-lateral-wall",
+  "name": "rhombomere lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005501",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralWall.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009582)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009582#spinal-cord-lateral-wall",
+  "name": "spinal cord lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009582",
+  "synonym": [
+    "lateral wall spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telencephalonLateralWall.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalonLateralWall",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the telencephalon. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005561)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005561#telencephalon-lateral-wall",
+  "name": "telencephalon lateral wall",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005561",
+  "synonym": [
+    "lateral wall telencephalic region",
+    "lateral wall telencephalon"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventricle of nervous system. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036658) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036658",
+  "synonym": [
+    "wall of central canal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfCerebralAqueduct.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfCerebralAqueduct",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036655) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of cerebral aqueduct",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036655",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfFourthVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfFourthVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036657) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of fourth ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036657",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfLateralVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036654) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036654",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/wallOfThirdVentricle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/wallOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a wall of ventricular system of brain. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036656) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "wall of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036656",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'border' or 'wall' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.