### PR TITLE
UBERON terms with 'spinal cord' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C1SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "description": "The segment of the spinal cord that corresponds to the first cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#first-cervical-spinal-cord-segment",
+  "name": "C1 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006469",
+  "synonym": [
+    "C1 cervical spinal cord",
+    "C1 segment",
+    "C1 spinal cord segment",
+    "first cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C2SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "description": "The segment of the spinal cord that corresponds to the second cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006489#second-cervical-spinal-cord-segment",
+  "name": "C2 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006489",
+  "synonym": [
+    "C2 segment",
+    "C2 spinal cord segment",
+    "second cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C3SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "description": "The segment of the spinal cord that corresponds to the third cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006488#third-cervical-spinal-cord-segment",
+  "name": "C3 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006488",
+  "synonym": [
+    "C3 segment",
+    "C3 spinal cord segment",
+    "third cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C4SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "description": "The segment of the spinal cord that corresponds to the fourth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006490#forth-cervical-spinal-cord-segment",
+  "name": "C4 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006490",
+  "synonym": [
+    "C4 segment",
+    "C4 spinal cord segment",
+    "forth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C5SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "description": "The segment of the spinal cord that corresponds to the fifth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006491#fifth-cervical-spinal-cord-segment",
+  "name": "C5 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006491",
+  "synonym": [
+    "C5 segment",
+    "C5 spinal cord segment",
+    "fifth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C6SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "description": "The segment of the spinal cord that corresponds to the sixth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006492#sixth-cervical-spinal-cord-segment",
+  "name": "C6 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006492",
+  "synonym": [
+    "C6 segment",
+    "C6 spinal cord segment",
+    "sixth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C7SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "description": "The segment of the spinal cord that corresponds to the seventh cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006493#seventh-cervical-spinal-cord-segment",
+  "name": "C7 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006493",
+  "synonym": [
+    "C7 segment",
+    "C7 spinal cord segment",
+    "seventh cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C8SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006470)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#eighth-cervical-spinal-cord-segment",
+  "name": "C8 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006470",
+  "synonym": [
+    "C8 segment",
+    "C8 spinal cord segment",
+    "eighth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014622) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014622#apex-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "apex of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014622",
+  "synonym": [
+    "apex of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014632) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014632#apex-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "apex of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014632",
+  "synonym": [
+    "apex of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004678)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004678#apex-of-spinal-cord-dorsal-horn-1",
+  "name": "apex of spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004678",
+  "synonym": [
+    "apex columnae posterioris",
+    "apex cornu posterioris medullae spinalis",
+    "apex of dorsal gray column",
+    "apex of dorsal gray column of spinal cord",
+    "apex of dorsal horn of spinal cord",
+    "apex of posterior horn of spinal cord",
+    "apex of spinal cord dorsal horn",
+    "apex of spinal cord posterior horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014611) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014611#apex-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "apex of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014611",
+  "synonym": [
+    "apex of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudalSegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "description": "A spinal cord segment that adjacent to a caudal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005845#caudal-segment-of-spinal-cord",
+  "name": "caudal segment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005845",
+  "synonym": [
+    "coccygeal segment of spinal cord",
+    "coccygeal segments of spinal cord [1-3]",
+    "pars coccygea medullae spinalis",
+    "segmenta coccygea medullae spinalis [1-3]"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord and the ventricular system of central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "description": "Spinal cord structure that is part of the ventricular system and is filled with cerebral-spinal fluid and runs the length of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002291#spinal-cord-central-canal",
+  "name": "central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002291",
+  "synonym": [
+    "canalis centralis",
+    "central canal",
+    "central canal of spinal cord",
+    "spinal cord central canal",
+    "ventricle of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "description": "A spinal cord segment that adjacent to a cervical region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002726#cervical-spinal-cord-1",
+  "name": "cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002726",
+  "synonym": [
+    "cervical segment of spinal cord",
+    "cervical segments of spinal cord [1-8]",
+    "cervical spinal cord",
+    "pars cervicalis medullae spinalis",
+    "segmenta cervicalia medullae spinalis [1-8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005841#cervical-spinal-cord-dorsal-column-1",
+  "name": "cervical spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005841",
+  "synonym": [
+    "cervical segment of dorsal funiculus of spinal cord",
+    "cervical spinal cord posterior column",
+    "dorsal funiculus of cervical segment of spinal cord",
+    "dorsal white column of cervical segment of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014620#cervical-spinal-cord-dorsal-horn-1",
+  "name": "cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014620",
+  "synonym": [
+    "cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical spinal cord gray matter and dorsal gray commissure of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029626)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029626#cervical-spinal-cord-gray-commissure-1",
+  "name": "cervical spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029626",
+  "synonym": [
+    "cervical spinal cord gray commissure",
+    "cervical spinal cord gray commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014613#cervical-spinal-cord-gray-matter-1",
+  "name": "cervical spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014613",
+  "synonym": [
+    "cervical spinal cord gray matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005849#cervical-spinal-cord-lateral-column-1",
+  "name": "cervical spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005849",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014619#cervical-spinal-cord-lateral-horn-1",
+  "name": "cervical spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014619",
+  "synonym": [
+    "cervical spinal cord lateral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005854#cervical-spinal-cord-ventral-column-1",
+  "name": "cervical spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005854",
+  "synonym": [
+    "cervical spinal cord anterior column"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007836#cervical-spinal-cord-ventral-commissure-1",
+  "name": "cervical spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007836",
+  "synonym": [
+    "cervical spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014621#cervical-spinal-cord-ventral-horn-1",
+  "name": "cervical spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014621",
+  "synonym": [
+    "cervical spinal cord ventral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014614#cervical-spinal-cord-white-matter-1",
+  "name": "cervical spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014614",
+  "synonym": [
+    "cervical spinal cord white matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007714) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007714#segment-part-of-cervical-spinal-cord",
+  "name": "cervical subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007714",
+  "synonym": [
+    "segment part of cervical spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cuneateFasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cuneate fasciculus, fasciculus of spinal cord and tract of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835) ('is_a' and 'relationship')]",
+  "description": "An axon tract in the spinal cord which primarily transmits information from the forelimb and trunk. It is part of the posterior column-medial lemniscus pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005835#cuneate-fasciculus-of-spinal-cord",
+  "name": "cuneate fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005835",
+  "synonym": [
+    "burdach's tract",
+    "cuneate fascicle of spinal cord",
+    "fasciculus cuneatus",
+    "tract of Burdach"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "description": "The white substance of the spinal cord lying on either side between the posterior median sulcus and the dorsal root. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002258#dorsal-funiculus-of-spinal-cord",
+  "name": "dorsal funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002258",
+  "synonym": [
+    "dorsal funiculus",
+    "dorsal funiculus of spinal cord",
+    "dorsal white column of spinal cord",
+    "funiculus dorsalis",
+    "funiculus posterior medullae spinalis",
+    "posterior funiculus",
+    "posterior funiculus of spinal cord",
+    "posterior white column of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631) ('is_a' and 'relationship')]",
+  "description": "The part of the gray commissure in the spinal central gray posterior to the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014631#spinal-cord-posterior-gray-commissure",
+  "name": "dorsal gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014631",
+  "synonym": [
+    "commissura grisea posterior medullae spinalis",
+    "dorsal gray commissure",
+    "dorsal grey commissure of spinal cord",
+    "posterior grey commissure of spinal cord",
+    "spinal cord posterior gray commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalHornOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256) ('is_a' and 'relationship')]",
+  "description": "The pronounced, dorsolaterally oriented ridge of grey matter in each lateral half of the spinal cord. the dorsal (more towards the back) grey matter of the spinal cord. It receives several types of sensory information from the body, including light touch, proprioception, and vibration. This information is sent from receptors of the skin, bones, and joints through sensory neurons whose cell bodies lie in the dorsal root ganglion. The dorsal region of the mature spinal cord contains neurons that process and relay sensory input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002256#spinal-cord-dorsal-horn",
+  "name": "dorsal horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002256",
+  "synonym": [
+    "columna grisea posterior medullae spinalis",
+    "cornu dorsale",
+    "cornu posterius medullae spinalis",
+    "dorsal gray column of spinal cord",
+    "dorsal gray horn",
+    "dorsal gray matter of spinal cord",
+    "dorsal grey column of spinal cord",
+    "dorsal horn spinal cord",
+    "posterior gray column of spinal cord",
+    "posterior gray horn of spinal cord",
+    "posterior grey column of spinal cord",
+    "posterior horn of spinal cord",
+    "spinal cord dorsal horn",
+    "spinal cord posterior horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalRootOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "description": "The dorsal roots contain afferent sensory axons. The dorsal roots of each side continue outwards, along the way forming a dorsal root ganglion (also called a spinal ganglion). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002261#dorsal-root-of-spinal-cord",
+  "name": "dorsal root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002261",
+  "synonym": [
+    "dorsal root",
+    "dorsal root of spinal nerve",
+    "dorsal spinal nerve root",
+    "dorsal spinal root",
+    "posterior root of spinal nerve",
+    "radix dorsalis",
+    "radix posterior (nervus spinalis)",
+    "radix sensoria (nervus spinalis)",
+    "sensory root of spinal nerve"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006456)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006456#eighth-thoracic-spinal-cord-segment-1",
+  "name": "eighth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006456",
+  "synonym": [
+    "eighth thoracic spinal cord segment",
+    "t8 segment",
+    "T8 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eleventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006467)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006467#eleventh-thoracic-spinal-cord-segment-1",
+  "name": "eleventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006467",
+  "synonym": [
+    "eleventh thoracic spinal cord segment",
+    "t11 segment",
+    "T11 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve fasciculus and central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837) ('is_a' and 'relationship')]",
+  "description": "A fascicle that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005837#fasciculus-of-spinal-cord",
+  "name": "fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005837",
+  "synonym": [
+    "spinal cord fasciculus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006447)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006447#fifth-lumbar-spinal-cord-segment-1",
+  "name": "fifth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006447",
+  "synonym": [
+    "fifth lumbar spinal cord segment",
+    "L5 segment",
+    "L5 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006464)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006464#fifth-sacral-spinal-cord-segment-1",
+  "name": "fifth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006464",
+  "synonym": [
+    "fifth sacral spinal cord segment",
+    "S5 segment",
+    "S5 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006453)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006453#fifth-thoracic-spinal-cord-segment-1",
+  "name": "fifth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006453",
+  "synonym": [
+    "fifth thoracic spinal cord segment",
+    "t5 segment",
+    "T5 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006448)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006448#first-lumbar-spinal-cord-segment-1",
+  "name": "first lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006448",
+  "synonym": [
+    "first lumbar spinal cord segment",
+    "L1 segment",
+    "L1 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006460)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006460#first-sacral-spinal-cord-segment-1",
+  "name": "first sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006460",
+  "synonym": [
+    "first sacral spinal cord segment",
+    "S1 segment",
+    "S1 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006457)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006457#first-thoracic-spinal-cord-segment-1",
+  "name": "first thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006457",
+  "synonym": [
+    "first thoracic spinal cord segment",
+    "t1 segment",
+    "T1 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/floorPlateSpinalCordRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "description": "A multi-tissue structure that is part of a spinal cord and is part of a floor plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005723#floor-plate-spinal-cord-region",
+  "name": "floor plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005723",
+  "synonym": [
+    "floor plate spinal cord",
+    "floorplate spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006451)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006451#forth-lumbar-spinal-cord-segment",
+  "name": "fourth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006451",
+  "synonym": [
+    "L4 segment",
+    "L4 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006463)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006463#forth-sacral-spinal-cord-segment",
+  "name": "fourth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006463",
+  "synonym": [
+    "S4 segment",
+    "S4 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006452)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006452#forth-thoracic-spinal-cord-segment",
+  "name": "fourth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006452",
+  "synonym": [
+    "T4 segment",
+    "T4 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/funiculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of neuraxis. Is part of the white matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127) ('is_a' and 'relationship')]",
+  "description": "A funiculus of neuraxis that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006127#funiculus-of-spinal-cord",
+  "name": "funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006127",
+  "synonym": [
+    "spinal cord funiculus",
+    "white column of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gracileFasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gracile fasciculus and fasciculus of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826) ('is_a' and 'relationship')]",
+  "description": "A gracile fasciculus that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005826#gracile-fasciculus-of-spinal-cord",
+  "name": "gracile fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005826",
+  "synonym": [
+    "fasciculus gracilis (medulla spinalis)",
+    "gracile fascicle of spinal cord",
+    "spinal cord segment of fasciculus gracilis",
+    "spinal cord segment of gracile fasciculus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/grayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315) ('is_a' and 'relationship')]",
+  "description": "The ridge-shaped grey matter of the spinal cord that extends longitudunally through the center of each half of the spinal cord, and are largely or entirely composed of nerve cell bodies and their dendrites and some supportive tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002315#gray-matter-of-spinal-cord",
+  "name": "gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002315",
+  "synonym": [
+    "gray matter of spinal cord",
+    "gray substance of spinal cord",
+    "grey matter of spinal cord",
+    "grey substance of spinal cord",
+    "spinal cord gray matter",
+    "spinal cord grey matter",
+    "spinal cord grey substance",
+    "substantia grisea medullae spinalis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/hindbrainSpinalCordBoundary",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "description": "An anatomical boundary that adjacent to a hindbrain and adjacent to a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005076#hindbrain-spinal-cord-boundary",
+  "name": "hindbrain-spinal cord boundary",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005076",
+  "synonym": [
+    "hindbrain-spinal cord boundary region"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016574) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016574#lamina-iii-of-gray-matter-of-spinal-cord",
+  "name": "lamina III of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016574",
+  "synonym": [
+    "lamina spinale III",
+    "rexed lamina III",
+    "spinal lamina III"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural part of spinal cord gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006118#lamina-i-of-gray-matter-of-spinal-cord",
+  "name": "lamina I of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006118",
+  "synonym": [
+    "lamina i of gray matter of spinal cord",
+    "lamina marginalis",
+    "lamina marginalis",
+    "lamina spinalis i",
+    "layer of Waldeyer",
+    "layer of waldeyer",
+    "rexed lamina I",
+    "rexed lamina i",
+    "rexed layer 1",
+    "spinal lamina I",
+    "spinal lamina i"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016575) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016575#lamina-iv-of-gray-matter-of-spinal-cord",
+  "name": "lamina IV of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016575",
+  "synonym": [
+    "lamina spinale IV",
+    "rexed lamina IV",
+    "spinal lamina IV"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016580) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016580#lamina-ix-of-gray-matter-of-spinal-cord",
+  "name": "lamina IX of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016580",
+  "synonym": [
+    "rexed lamina IX",
+    "spinal lamina IX"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016570#lamina-of-gray-matter-of-spinal-cord",
+  "name": "lamina of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016570",
+  "synonym": [
+    "rexed lamina"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral commissural nucleus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016579) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016579#lamina-viii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VIII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016579",
+  "synonym": [
+    "rexed lamina VIII",
+    "spinal lamina VIII"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016578) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016578#lamina-vii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016578",
+  "synonym": [
+    "rexed lamina VII",
+    "spinal lamina VII"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina VI is a lamina of the spinal cord. It is also known as the base of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016577#lamina-vi-of-gray-matter-of-spinal-cord",
+  "name": "lamina VI of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016577",
+  "synonym": [
+    "rexed lamina VI",
+    "spinal lamina VI"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina V is a lamina of the spinal cord. It is also known as the neck of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016576#lamina-v-of-gray-matter-of-spinal-cord",
+  "name": "lamina V of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016576",
+  "synonym": [
+    "rexed lamina V",
+    "spinal lamina V"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "description": "The lateral mass of fibers on either side of the spinal cord, between the anterolateral and posterolateral sulci. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002179#lateral-funiculus-of-spinal-cord",
+  "name": "lateral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002179",
+  "synonym": [
+    "lateral funiculus",
+    "lateral funiculus of spinal cord",
+    "lateral white column of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "description": "Part of central canal lying within the lumbar spinal cord. It is continuous rostrally with the central canal of the thoracic spinal cord and caudally with the central canal of the sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014543#lumbar-spinal-cord-central-canal",
+  "name": "lumbar division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014543",
+  "synonym": [
+    "lumbar spinal cord central canal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002792)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002792#lumbar-spinal-cord-1",
+  "name": "lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002792",
+  "synonym": [
+    "lumbar segment of spinal cord",
+    "lumbar segments of spinal cord [1-5]",
+    "lumbar spinal cord",
+    "pars lumbalis medullae spinalis",
+    "segmenta lumbalia medullae spinalis [1-5]",
+    "spinal cord lumbar segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005842#lumbar-spinal-cord-dorsal-column-1",
+  "name": "lumbar spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005842",
+  "synonym": [
+    "dorsal funiculus of lumbar segment of spinal cord",
+    "dorsal white column of lumbar segment of spinal cord",
+    "lumbar segment of dorsal funiculus of spinal cord",
+    "lumbar segment of gracile fasciculus of spinal cord",
+    "lumbar spinal cord posterior column"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014638#lumbar-spinal-cord-dorsal-horn-1",
+  "name": "lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014638",
+  "synonym": [
+    "lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and lumbar spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033483)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033483#lumbar-spinal-cord-gray-commissure-1",
+  "name": "lumbar spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033483",
+  "synonym": [
+    "lumbar spinal cord gray commissure",
+    "lumbar spinal cord gray commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029636) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029636#lumbar-spinal-cord-gray-matter-1",
+  "name": "lumbar spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029636",
+  "synonym": [
+    "lumbar spinal cord gray matter",
+    "lumbar spinal cord gray matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005850#lumbar-spinal-cord-lateral-column-1",
+  "name": "lumbar spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005850",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031906) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031906#lumbar-spinal-cord-lateral-horn-1",
+  "name": "lumbar spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031906",
+  "synonym": [
+    "lumbar spinal cord lateral horn",
+    "lumbar spinal cord lateral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005855#lumbar-spinal-cord-ventral-column-1",
+  "name": "lumbar spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005855",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007834#lumbar-spinal-cord-ventral-commissure-1",
+  "name": "lumbar spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007834",
+  "synonym": [
+    "lumbar spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0030276) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0030276#lumbar-spinal-cord-ventral-horn-1",
+  "name": "lumbar spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0030276",
+  "synonym": [
+    "lumbar spinal cord ventral horn",
+    "lumbar spinal cord ventral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026386) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026386#lumbar-spinal-cord-white-matter",
+  "name": "lumbar spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026386",
+  "synonym": [
+    "lumbar spinal cord white matter",
+    "lumbar spinal cord white matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007716)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007716#segment-part-of-lumbar-spinal-cord",
+  "name": "lumbar subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007716",
+  "synonym": [
+    "segment part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumenOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572) ('is_a' and 'relationship')]",
+  "description": "A cerebrospinal fluid-filled space that runs longitudinally through the length of the entire spinal cord. The central canal is contiguous with the ventricular system of the brain. The central canal represents the adult remainder of the neural tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009572#lumen-of-central-canal-of-spinal-cord",
+  "name": "lumen of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009572",
+  "synonym": [
+    "cavity of central canal of spinal cord",
+    "central canal lumen",
+    "spinal cord lumen"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/meninxOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a meninx. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292) ('is_a' and 'relationship')]",
+  "description": "A meninx that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003292#meninx-of-spinal-cord",
+  "name": "meninx of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003292",
+  "synonym": [
+    "meninges of spinal cord",
+    "spinal cord meninges",
+    "spinal cord meninx",
+    "spinal meninx"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ninthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006465)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006465#ninth-thoracic-spinal-cord-segment-1",
+  "name": "ninth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006465",
+  "synonym": [
+    "ninth thoracic spinal cord segment",
+    "t9 segment",
+    "T9 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/roofPlateSpinalCordRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "description": "A tissue that is part of a spinal cord and is part of a roof plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005724#roof-plate-spinal-cord-region",
+  "name": "roof plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005724",
+  "synonym": [
+    "roof plate spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "description": "Part of spinal cord central canal contained in the sacral spinal cord. It is continuous rostrally with the spinal cord central canal of the lumbar cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014547#sacral-division-of-spinal-cord-central-canal",
+  "name": "sacral division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014547",
+  "synonym": [
+    "sacral spinal cord central canal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "description": "A spinal cord segment that adjacent to a sacral region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005843#sacral-spinal-cord-1",
+  "name": "sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005843",
+  "synonym": [
+    "pars sacralis medullae spinalis",
+    "sacral segment of spinal cord",
+    "sacral segments of spinal cord [1-5]",
+    "segmenta sacralia medullae spinalis [1-5]"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005840",
+  "synonym": [
+    "sacral spinal cord posterior column",
+    "sacral subsegment of dorsal funiculus of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033939) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033939#sacral-spinal-cord-dorsal-horn-1",
+  "name": "sacral spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033939",
+  "synonym": [
+    "sacral spinal cord dorsal horn",
+    "sacral spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and sacral spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031111)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031111#sacral-spinal-cord-gray-commissure-1",
+  "name": "sacral spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031111",
+  "synonym": [
+    "sacral spinal cord gray commissure",
+    "sacral spinal cord gray commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029503) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029503#sacral-spinal-cord-gray-matter-1",
+  "name": "sacral spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029503",
+  "synonym": [
+    "sacral spinal cord gray matter",
+    "sacral spinal cord gray matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005848#sacral-spinal-cord-lateral-column-1",
+  "name": "sacral spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005848",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029538) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029538#sacral-spinal-cord-lateral-horn-1",
+  "name": "sacral spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029538",
+  "synonym": [
+    "sacral spinal cord lateral horn",
+    "sacral spinal cord lateral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005853#sacral-spinal-cord-ventral-column-1",
+  "name": "sacral spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005853",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007835#sacral-spinal-cord-ventral-commissure-1",
+  "name": "sacral spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007835",
+  "synonym": [
+    "sacral spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0032748) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0032748#sacral-spinal-cord-ventral-horn-1",
+  "name": "sacral spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0032748",
+  "synonym": [
+    "sacral spinal cord ventral horn",
+    "sacral spinal cord ventral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026246) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026246#sacral-spinal-cord-white-matter-1",
+  "name": "sacral spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026246",
+  "synonym": [
+    "sacral spinal cord white matter",
+    "sacral spinal cord white matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007717) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007717",
+  "synonym": [
+    "segment part of sacral spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006450)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006450#second-lumbar-spinal-cord-segment-1",
+  "name": "second lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006450",
+  "synonym": [
+    "l2 segment",
+    "L2 spinal cord segment",
+    "second lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006461)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006461#second-sacral-spinal-cord-segment-1",
+  "name": "second sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006461",
+  "synonym": [
+    "S2 segment",
+    "S2 spinal cord segment",
+    "second sacral spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006458)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006458#second-thoracic-spinal-cord-segment-1",
+  "name": "second thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006458",
+  "synonym": [
+    "second thoracic spinal cord segment",
+    "t2 segment",
+    "T2 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006455)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006455#seventh-thoracic-spinal-cord-segment-1",
+  "name": "seventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006455",
+  "synonym": [
+    "seventh thoracic spinal cord segment",
+    "t7 segment",
+    "T7 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006454)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006454#sixth-thoracic-spinal-cord-segment-1",
+  "name": "sixth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006454",
+  "synonym": [
+    "sixth thoracic spinal cord segment",
+    "t6 segment",
+    "T6 spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCord.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "description": "Part of the central nervous system located in the vertebral canal continuous with and caudal to the brain; demarcated from brain by plane of foramen magnum. It is composed of an inner core of gray matter in which nerve cells predominate, and an outer layer of white matter in which myelinated nerve fibers predominate, and surrounds the central canal. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002240#spinal-cord-1",
+  "name": "spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002240",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordAlarPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tube alar plate. Is part of the future spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063) ('is_a' and 'relationship')]",
+  "description": "The region of the mantle layer of the neural tube that lies dorsal to the sulcus limitans and contains primarily sensory neurons and interneurons involved in communication of sensory impulses; the alar plate develops into the dorsal horn in the grey matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004063#spinal-cord-alar-plate",
+  "name": "spinal cord alar plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004063",
+  "synonym": [
+    "alar column spinal cord",
+    "spinal cord alar column",
+    "spinal cord alar lamina"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016550) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016550#spinal-cord-column",
+  "name": "spinal cord column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016550",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system commissure and tract of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "description": "The nerve fiber tracts that span the midline of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008882#spinal-cord-commissure",
+  "name": "spinal cord commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008882",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the dorsal funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373) ('is_a' and 'relationship')]",
+  "description": "The wedge-shaped fiber bundle of white matter in the dorsomedial side of the spinal cord that is made up of the fasciculus gracilis and fasciculus cuneatus; it is part of the ascending posterior column-medial lemniscus pathway that is important for well-localized fine touch and conscious proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005373#spinal-cord-dorsal-column",
+  "name": "spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005373",
+  "synonym": [
+    "dorsal column",
+    "dorsal column of spinal cord",
+    "posterior column",
+    "spinal cord posterior column"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordDorsalWhiteCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007840#spinal-cord-dorsal-white-commissure",
+  "name": "spinal cord dorsal white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007840",
+  "synonym": [
+    "commissura alba posterior medullae spinalis",
+    "dorsal white commissure of spinal cord",
+    "posterior white commissure of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an ependyma. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359) ('is_a' and 'relationship')]",
+  "description": "The ependymal cell layer that lines the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005359#spinal-cord-ependyma",
+  "name": "spinal cord ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005359",
+  "synonym": [
+    "ependyma of central canal of spinal cord",
+    "spinal cord ependymal layer"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "description": "The band of grey substance spanning the midline of the spinal cord that surrounds the central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004677#spinal-cord-gray-commissure-1",
+  "name": "spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004677",
+  "synonym": [
+    "area spinalis X",
+    "gray commissure of spinal cord",
+    "lamina X",
+    "lamina X of gray matter of spinal cord",
+    "rexed lamina X",
+    "spinal area X",
+    "spinal cord gray commissure",
+    "spinal cord grey commissure",
+    "spinal lamina X"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the lateral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374) ('is_a' and 'relationship')]",
+  "description": "The region of white matter of the spinal cord that is located between the dorsal and ventral spinal roots. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005374#spinal-cord-lateral-column",
+  "name": "spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005374",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676) ('is_a' and 'relationship')]",
+  "description": "A triangular field that is a lateralward projection of the postero-lateral part of the anterior column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004676#spinal-cord-lateral-horn-1",
+  "name": "spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004676",
+  "synonym": [
+    "columna grisea intermedia medullare spinalis",
+    "intermediate gray column of spinal cord",
+    "lateral gray column of spinal cord",
+    "lateral gray horn",
+    "lateral gray matter of spinal cord",
+    "lateral horn of spinal cord",
+    "spinal cord intermediate horn",
+    "spinal cord lateral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord motor column and spinal cord lateral column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "description": "Column of motor neurons which innervate muscles in the limb; motor neurons in the lateral motor column are further organized into pools, each of which innervates a specific muscle in the limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010405#spinal-cord-lateral-motor-column",
+  "name": "spinal cord lateral motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010405",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordMedialMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord motor column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "description": "The subclasses of motor neurons which project their axons to axial muscles that lie close to the vertebral column; motor neurons in the lateral subdivision of the MMC project their axons to body wall muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004059#spinal-cord-medial-motor-column",
+  "name": "spinal cord medial motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004059",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "description": "The subclasses of motor neurons which are organized into longitudinally oriented columns that occupy distinct and, in some cases, discontinuous domains along the rostrocaudal axis of the spinal cord; motor neurons within a single column send their axons to a common peripheral target. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003990#spinal-cord-motor-column",
+  "name": "spinal cord motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003990",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005844#axial-regional-part-of-spinal-cord",
+  "name": "spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005844",
+  "synonym": [
+    "axial part of spinal cord",
+    "axial regional part of spinal cord",
+    "segment of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the ventral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375) ('is_a' and 'relationship')]",
+  "description": "The area of white matter of the spinal cord located on either side of the ventral (anterior) medial fissure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005375#spinal-cord-ventral-column",
+  "name": "spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005375",
+  "synonym": [
+    "anterior column",
+    "spinal cord anterior column",
+    "ventral column"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "description": "The band of nerve fibers which cross the midline of the spinal cord ventral to the central canal and posterior grey commissure. The anterior (or ventral) white commissure, also known as the alba anterior medullae spinalis, is a bundle of nerve fibers which cross the midline of the spinal cord just anterior to the gray commissure. A N4 fibers and C fibers carrying pain sensation in the spinothalamic tract contribute to this commissure, as do fibers of the anterior corticospinal tract, which carry motor signals from the primary motor cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004170#spinal-cord-ventral-commissure",
+  "name": "spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004170",
+  "synonym": [
+    "anterior white commissure",
+    "anterior white commissure of spinal cord",
+    "spinal cord anterior commissure",
+    "ventral spinal commissure",
+    "ventral white column",
+    "ventral white commissure of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordWhiteCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007838#spinal-cord-white-commissure",
+  "name": "spinal cord white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007838",
+  "synonym": [
+    "white commissure of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central canal of spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "description": "A subdivision of the central canal of the spinal cord along its anterior-posterior axis. This is typically subdivided into cervical, thoracic, lumbar and sacral segments. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014538#regional-part-of-spinal-cord-central-canal",
+  "name": "subdivision of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014538",
+  "synonym": [
+    "regional part of spinal cord central canal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006079) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006079#subdivision-of-spinal-cord-dorsal-column",
+  "name": "subdivision of spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006079",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord lateral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006078) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006078#subdivision-of-spinal-cord-lateral-column",
+  "name": "subdivision of spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006078",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016551) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016551#subdivision-of-spinal-cord-ventral-column",
+  "name": "subdivision of spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016551",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a cervical spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014623#substantia-gelatinosa-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014623",
+  "synonym": [
+    "substantia gelatinosa of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a lumbar spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014633#substantia-gelatinosa-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014633",
+  "synonym": [
+    "substantia gelatinosa of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612) ('is_a' and 'relationship')]",
+  "description": "Substantia gelatinosa of thoracic spinal cord posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014612#substantia-gelatinosa-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014612",
+  "synonym": [
+    "substantia gelatinosa of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tenthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006466)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006466#tenth-thoracic-spinal-cord-segment-1",
+  "name": "tenth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006466",
+  "synonym": [
+    "t10 segment",
+    "T10 spinal cord segment",
+    "tenth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006449)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006449#third-lumbar-spinal-cord-segment-1",
+  "name": "third lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006449",
+  "synonym": [
+    "L3 segment",
+    "L3 spinal cord segment",
+    "third lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006462)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006462#third-sacral-spinal-cord-segment-1",
+  "name": "third sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006462",
+  "synonym": [
+    "S3 segment",
+    "S3 spinal cord segment",
+    "third sacral spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006459)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006459#third-thoracic-spinal-cord-segment-1",
+  "name": "third thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006459",
+  "synonym": [
+    "t3 segment",
+    "T3 spinal cord segment",
+    "third thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "description": "Part of spinal cord central canal contained in the thoracic spinal cord. It is continuous rostrally with the cervical spinal cord central canal and caudally with the lumbar spinal cord central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014541#thoracic-spinal-cord-central-canal",
+  "name": "thoracic division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014541",
+  "synonym": [
+    "thoracic spinal cord central canal"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "description": "The thoracic nerves are the spinal nerves emerging from the thoracic vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003038#thoracic-spinal-cord",
+  "name": "thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003038",
+  "synonym": [
+    "pars thoracica medullae spinalis",
+    "segmenta thoracica medullae spinalis [1-12]",
+    "thoracic region of spinal cord",
+    "thoracic segment of spinal cord",
+    "thoracic segments of spinal cord [1-12]",
+    "thoracic spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005839#thoracic-spinal-cord-dorsal-column-1",
+  "name": "thoracic spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005839",
+  "synonym": [
+    "dorsal funiculus of thoracic segment of spinal cord",
+    "dorsal white column of thoracic segment of spinal cord",
+    "thoracic segment of dorsal funiculus of spinal cord",
+    "thoracic spinal cord posterior column"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014609#thoracic-spinal-cord-dorsal-horn-1",
+  "name": "thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014609",
+  "synonym": [
+    "thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and thoracic spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026293)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026293#thoracic-spinal-cord-gray-commissure-1",
+  "name": "thoracic spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026293",
+  "synonym": [
+    "thoracic spinal cord gray commissure",
+    "thoracic spinal cord gray commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014636#thoracic-spinal-cord-gray-matter-1",
+  "name": "thoracic spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014636",
+  "synonym": [
+    "thoracic spinal cord gray matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005847#thoracic-spinal-cord-lateral-column-1",
+  "name": "thoracic spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005847",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014607#thoracic-spinal-cord-lateral-horn-1",
+  "name": "thoracic spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014607",
+  "synonym": [
+    "thoracic spinal cord lateral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005852#thoracic-spinal-cord-ventral-column-1",
+  "name": "thoracic spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005852",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007837#thoracic-spinal-cord-ventral-commissure-1",
+  "name": "thoracic spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007837",
+  "synonym": [
+    "thoracic spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014610#thoracic-spinal-cord-ventral-horn-1",
+  "name": "thoracic spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014610",
+  "synonym": [
+    "thoracic spinal cord ventral horn"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014637#thoracic-spinal-cord-white-matter-1",
+  "name": "thoracic spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014637",
+  "synonym": [
+    "thoracic spinal cord white matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007715)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007715#segment-part-of-thoracic-spinal-cord",
+  "name": "thoracic subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007715",
+  "synonym": [
+    "segment part of thoracic spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the spinal cord and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007699#tract-of-spinal-cord",
+  "name": "tract of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007699",
+  "synonym": [
+    "spinal cord tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/twelfthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006468)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006468#twelfth-thoracic-spinal-cord-segment-1",
+  "name": "twelfth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006468",
+  "synonym": [
+    "t12 segment",
+    "T12 spinal cord segment",
+    "twelfth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "description": "The white substance of the spinal cord lying on either side between the ventral median fissure and the ventral roots of the spinal nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002180#ventral-funiculus-of-spinal-cord",
+  "name": "ventral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002180",
+  "synonym": [
+    "anterior funiculus",
+    "anterior funiculus of spinal cord",
+    "anterior white column of spinal cord",
+    "funiculus anterior medullae spinalis",
+    "ventral funiculus",
+    "ventral funiculus of spinal cord",
+    "ventral white column of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014630) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014630#spinal-cord-anterior-gray-commissure",
+  "name": "ventral gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014630",
+  "synonym": [
+    "anterior grey commissure of spinal cord",
+    "commissura grisea anterior medullae spinalis",
+    "spinal cord anterior gray commissure",
+    "ventral grey commissure of spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralHornOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257) ('is_a' and 'relationship')]",
+  "description": "The ventral grey column of the spinal cord. The neurons of the ventral region of the mature spinal cord participate in motor output. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002257#spinal-cord-ventral-horn",
+  "name": "ventral horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002257",
+  "synonym": [
+    "anterior gray column of spinal cord",
+    "anterior gray horn of spinal cord",
+    "anterior grey column of spinal cord",
+    "anterior horn",
+    "columna grisea anterior medullae spinalis",
+    "spinal cord anterior horn",
+    "spinal cord ventral horn",
+    "ventral gray column of spinal cord",
+    "ventral gray matter of spinal cord",
+    "ventral grey column of spinal cord",
+    "ventral grey horn",
+    "ventral horn spinal cord",
+    "ventral region of spinal cord",
+    "ventral spinal cord"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralRootOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "description": "The ventral roots contain efferent motor axons. Similar to the dorsal roots, the ventral roots continue out from the spinal column, and meet and mix with their corresponding dorsal nerve root at a point after the ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002260#ventral-root-of-spinal-cord",
+  "name": "ventral root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002260",
+  "synonym": [
+    "anterior spinal root",
+    "ventral spinal root"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318) ('is_a' and 'relationship')]",
+  "description": "The regions of the spinal cord that are largely or entirely composed of myelinated nerve cell axons and contain few or no neural cell bodies or dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002318#white-matter-of-spinal-cord",
+  "name": "white matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002318",
+  "synonym": [
+    "spinal cord white matter",
+    "spinal cord white matter of neuraxis",
+    "spinal cord white substance",
+    "substantia alba medullae spinalis",
+    "white matter of neuraxis of spinal cord",
+    "white substance of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C1SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "description": "The segment of the spinal cord that corresponds to the first cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#first-cervical-spinal-cord-segment",
+  "name": "C1 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006469",
+  "synonym": [
+    "C1 cervical spinal cord",
+    "C1 segment",
+    "C1 spinal cord segment",
+    "first cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C2SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "description": "The segment of the spinal cord that corresponds to the second cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006489#second-cervical-spinal-cord-segment",
+  "name": "C2 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006489",
+  "synonym": [
+    "C2 segment",
+    "C2 spinal cord segment",
+    "second cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C3SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "description": "The segment of the spinal cord that corresponds to the third cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006488#third-cervical-spinal-cord-segment",
+  "name": "C3 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006488",
+  "synonym": [
+    "C3 segment",
+    "C3 spinal cord segment",
+    "third cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C4SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "description": "The segment of the spinal cord that corresponds to the fourth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006490#forth-cervical-spinal-cord-segment",
+  "name": "C4 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006490",
+  "synonym": [
+    "C4 segment",
+    "C4 spinal cord segment",
+    "forth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C5SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "description": "The segment of the spinal cord that corresponds to the fifth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006491#fifth-cervical-spinal-cord-segment",
+  "name": "C5 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006491",
+  "synonym": [
+    "C5 segment",
+    "C5 spinal cord segment",
+    "fifth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C6SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "description": "The segment of the spinal cord that corresponds to the sixth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006492#sixth-cervical-spinal-cord-segment",
+  "name": "C6 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006492",
+  "synonym": [
+    "C6 segment",
+    "C6 spinal cord segment",
+    "sixth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C7SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "description": "The segment of the spinal cord that corresponds to the seventh cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006493#seventh-cervical-spinal-cord-segment",
+  "name": "C7 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006493",
+  "synonym": [
+    "C7 segment",
+    "C7 spinal cord segment",
+    "seventh cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/C8SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006470)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#eighth-cervical-spinal-cord-segment",
+  "name": "C8 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006470",
+  "synonym": [
+    "C8 segment",
+    "C8 spinal cord segment",
+    "eighth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014622) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014622#apex-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "apex of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014622",
+  "synonym": [
+    "apex of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014632) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014632#apex-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "apex of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014632",
+  "synonym": [
+    "apex of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/apexOfSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004678)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004678#apex-of-spinal-cord-dorsal-horn-1",
+  "name": "apex of spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004678",
+  "synonym": [
+    "apex columnae posterioris",
+    "apex cornu posterioris medullae spinalis",
+    "apex of dorsal gray column",
+    "apex of dorsal gray column of spinal cord",
+    "apex of dorsal horn of spinal cord",
+    "apex of posterior horn of spinal cord",
+    "apex of spinal cord dorsal horn",
+    "apex of spinal cord posterior horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014611) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014611#apex-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "apex of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014611",
+  "synonym": [
+    "apex of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/caudalSegmentOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "description": "A spinal cord segment that adjacent to a caudal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005845#caudal-segment-of-spinal-cord",
+  "name": "caudal segment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005845",
+  "synonym": [
+    "coccygeal segment of spinal cord",
+    "coccygeal segments of spinal cord [1-3]",
+    "pars coccygea medullae spinalis",
+    "segmenta coccygea medullae spinalis [1-3]"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralCanalOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the spinal cord and the ventricular system of central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "description": "Spinal cord structure that is part of the ventricular system and is filled with cerebral-spinal fluid and runs the length of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002291#spinal-cord-central-canal",
+  "name": "central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002291",
+  "synonym": [
+    "canalis centralis",
+    "central canal",
+    "central canal of spinal cord",
+    "spinal cord central canal",
+    "ventricle of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "description": "A spinal cord segment that adjacent to a cervical region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002726#cervical-spinal-cord-1",
+  "name": "cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002726",
+  "synonym": [
+    "cervical segment of spinal cord",
+    "cervical segments of spinal cord [1-8]",
+    "cervical spinal cord",
+    "pars cervicalis medullae spinalis",
+    "segmenta cervicalia medullae spinalis [1-8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005841#cervical-spinal-cord-dorsal-column-1",
+  "name": "cervical spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005841",
+  "synonym": [
+    "cervical segment of dorsal funiculus of spinal cord",
+    "cervical spinal cord posterior column",
+    "dorsal funiculus of cervical segment of spinal cord",
+    "dorsal white column of cervical segment of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014620#cervical-spinal-cord-dorsal-horn-1",
+  "name": "cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014620",
+  "synonym": [
+    "cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordGrayCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cervical spinal cord gray matter and dorsal gray commissure of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029626)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029626#cervical-spinal-cord-gray-commissure-1",
+  "name": "cervical spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029626",
+  "synonym": [
+    "cervical spinal cord gray commissure",
+    "cervical spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordGrayMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014613#cervical-spinal-cord-gray-matter-1",
+  "name": "cervical spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014613",
+  "synonym": [
+    "cervical spinal cord gray matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005849#cervical-spinal-cord-lateral-column-1",
+  "name": "cervical spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005849",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordLateralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014619#cervical-spinal-cord-lateral-horn-1",
+  "name": "cervical spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014619",
+  "synonym": [
+    "cervical spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005854#cervical-spinal-cord-ventral-column-1",
+  "name": "cervical spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005854",
+  "synonym": [
+    "cervical spinal cord anterior column"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordVentralCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007836#cervical-spinal-cord-ventral-commissure-1",
+  "name": "cervical spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007836",
+  "synonym": [
+    "cervical spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordVentralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014621#cervical-spinal-cord-ventral-horn-1",
+  "name": "cervical spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014621",
+  "synonym": [
+    "cervical spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSpinalCordWhiteMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014614#cervical-spinal-cord-white-matter-1",
+  "name": "cervical spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014614",
+  "synonym": [
+    "cervical spinal cord white matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cervicalSubsegmentOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007714) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007714#segment-part-of-cervical-spinal-cord",
+  "name": "cervical subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007714",
+  "synonym": [
+    "segment part of cervical spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cuneateFasciculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cuneate fasciculus, fasciculus of spinal cord and tract of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835) ('is_a' and 'relationship')]",
+  "description": "An axon tract in the spinal cord which primarily transmits information from the forelimb and trunk. It is part of the posterior column-medial lemniscus pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005835#cuneate-fasciculus-of-spinal-cord",
+  "name": "cuneate fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005835",
+  "synonym": [
+    "burdach's tract",
+    "cuneate fascicle of spinal cord",
+    "fasciculus cuneatus",
+    "tract of Burdach"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalFuniculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "description": "The white substance of the spinal cord lying on either side between the posterior median sulcus and the dorsal root. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002258#dorsal-funiculus-of-spinal-cord",
+  "name": "dorsal funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002258",
+  "synonym": [
+    "dorsal funiculus",
+    "dorsal funiculus of spinal cord",
+    "dorsal white column of spinal cord",
+    "funiculus dorsalis",
+    "funiculus posterior medullae spinalis",
+    "posterior funiculus",
+    "posterior funiculus of spinal cord",
+    "posterior white column of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631) ('is_a' and 'relationship')]",
+  "description": "The part of the gray commissure in the spinal central gray posterior to the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014631#spinal-cord-posterior-gray-commissure",
+  "name": "dorsal gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014631",
+  "synonym": [
+    "commissura grisea posterior medullae spinalis",
+    "dorsal gray commissure",
+    "dorsal grey commissure of spinal cord",
+    "posterior grey commissure of spinal cord",
+    "spinal cord posterior gray commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalHornOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256) ('is_a' and 'relationship')]",
+  "description": "The pronounced, dorsolaterally oriented ridge of grey matter in each lateral half of the spinal cord. the dorsal (more towards the back) grey matter of the spinal cord. It receives several types of sensory information from the body, including light touch, proprioception, and vibration. This information is sent from receptors of the skin, bones, and joints through sensory neurons whose cell bodies lie in the dorsal root ganglion. The dorsal region of the mature spinal cord contains neurons that process and relay sensory input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002256#spinal-cord-dorsal-horn",
+  "name": "dorsal horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002256",
+  "synonym": [
+    "columna grisea posterior medullae spinalis",
+    "cornu dorsale",
+    "cornu posterius medullae spinalis",
+    "dorsal gray column of spinal cord",
+    "dorsal gray horn",
+    "dorsal gray matter of spinal cord",
+    "dorsal grey column of spinal cord",
+    "dorsal horn spinal cord",
+    "posterior gray column of spinal cord",
+    "posterior gray horn of spinal cord",
+    "posterior grey column of spinal cord",
+    "posterior horn of spinal cord",
+    "spinal cord dorsal horn",
+    "spinal cord posterior horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalRootOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "description": "The dorsal roots contain afferent sensory axons. The dorsal roots of each side continue outwards, along the way forming a dorsal root ganglion (also called a spinal ganglion). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002261#dorsal-root-of-spinal-cord",
+  "name": "dorsal root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002261",
+  "synonym": [
+    "dorsal root",
+    "dorsal root of spinal nerve",
+    "dorsal spinal nerve root",
+    "dorsal spinal root",
+    "posterior root of spinal nerve",
+    "radix dorsalis",
+    "radix posterior (nervus spinalis)",
+    "radix sensoria (nervus spinalis)",
+    "sensory root of spinal nerve"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/eighthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006456)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006456#eighth-thoracic-spinal-cord-segment-1",
+  "name": "eighth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006456",
+  "synonym": [
+    "eighth thoracic spinal cord segment",
+    "t8 segment",
+    "T8 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/eleventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006467)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006467#eleventh-thoracic-spinal-cord-segment-1",
+  "name": "eleventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006467",
+  "synonym": [
+    "eleventh thoracic spinal cord segment",
+    "t11 segment",
+    "T11 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fasciculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve fasciculus and central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837) ('is_a' and 'relationship')]",
+  "description": "A fascicle that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005837#fasciculus-of-spinal-cord",
+  "name": "fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005837",
+  "synonym": [
+    "spinal cord fasciculus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthLumbarSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006447)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006447#fifth-lumbar-spinal-cord-segment-1",
+  "name": "fifth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006447",
+  "synonym": [
+    "fifth lumbar spinal cord segment",
+    "L5 segment",
+    "L5 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthSacralSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006464)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006464#fifth-sacral-spinal-cord-segment-1",
+  "name": "fifth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006464",
+  "synonym": [
+    "fifth sacral spinal cord segment",
+    "S5 segment",
+    "S5 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fifthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006453)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006453#fifth-thoracic-spinal-cord-segment-1",
+  "name": "fifth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006453",
+  "synonym": [
+    "fifth thoracic spinal cord segment",
+    "t5 segment",
+    "T5 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstLumbarSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006448)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006448#first-lumbar-spinal-cord-segment-1",
+  "name": "first lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006448",
+  "synonym": [
+    "first lumbar spinal cord segment",
+    "L1 segment",
+    "L1 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstSacralSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006460)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006460#first-sacral-spinal-cord-segment-1",
+  "name": "first sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006460",
+  "synonym": [
+    "first sacral spinal cord segment",
+    "S1 segment",
+    "S1 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/firstThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006457)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006457#first-thoracic-spinal-cord-segment-1",
+  "name": "first thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006457",
+  "synonym": [
+    "first thoracic spinal cord segment",
+    "t1 segment",
+    "T1 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/floorPlateSpinalCordRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "description": "A multi-tissue structure that is part of a spinal cord and is part of a floor plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005723#floor-plate-spinal-cord-region",
+  "name": "floor plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005723",
+  "synonym": [
+    "floor plate spinal cord",
+    "floorplate spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthLumbarSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006451)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006451#forth-lumbar-spinal-cord-segment",
+  "name": "fourth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006451",
+  "synonym": [
+    "L4 segment",
+    "L4 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthSacralSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006463)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006463#forth-sacral-spinal-cord-segment",
+  "name": "fourth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006463",
+  "synonym": [
+    "S4 segment",
+    "S4 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006452)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006452#forth-thoracic-spinal-cord-segment",
+  "name": "fourth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006452",
+  "synonym": [
+    "T4 segment",
+    "T4 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/funiculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a funiculus of neuraxis. Is part of the white matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127) ('is_a' and 'relationship')]",
+  "description": "A funiculus of neuraxis that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006127#funiculus-of-spinal-cord",
+  "name": "funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006127",
+  "synonym": [
+    "spinal cord funiculus",
+    "white column of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/gracileFasciculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gracile fasciculus and fasciculus of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826) ('is_a' and 'relationship')]",
+  "description": "A gracile fasciculus that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005826#gracile-fasciculus-of-spinal-cord",
+  "name": "gracile fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005826",
+  "synonym": [
+    "fasciculus gracilis (medulla spinalis)",
+    "gracile fascicle of spinal cord",
+    "spinal cord segment of fasciculus gracilis",
+    "spinal cord segment of gracile fasciculus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/grayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315) ('is_a' and 'relationship')]",
+  "description": "The ridge-shaped grey matter of the spinal cord that extends longitudunally through the center of each half of the spinal cord, and are largely or entirely composed of nerve cell bodies and their dendrites and some supportive tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002315#gray-matter-of-spinal-cord",
+  "name": "gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002315",
+  "synonym": [
+    "gray matter of spinal cord",
+    "gray substance of spinal cord",
+    "grey matter of spinal cord",
+    "grey substance of spinal cord",
+    "spinal cord gray matter",
+    "spinal cord grey matter",
+    "spinal cord grey substance",
+    "substantia grisea medullae spinalis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/hindbrainSpinalCordBoundary",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "description": "An anatomical boundary that adjacent to a hindbrain and adjacent to a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005076#hindbrain-spinal-cord-boundary",
+  "name": "hindbrain-spinal cord boundary",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005076",
+  "synonym": [
+    "hindbrain-spinal cord boundary region"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016574) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016574#lamina-iii-of-gray-matter-of-spinal-cord",
+  "name": "lamina III of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016574",
+  "synonym": [
+    "lamina spinale III",
+    "rexed lamina III",
+    "spinal lamina III"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural part of spinal cord gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006118#lamina-i-of-gray-matter-of-spinal-cord",
+  "name": "lamina I of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006118",
+  "synonym": [
+    "lamina i of gray matter of spinal cord",
+    "lamina marginalis",
+    "lamina marginalis",
+    "lamina spinalis i",
+    "layer of Waldeyer",
+    "layer of waldeyer",
+    "rexed lamina I",
+    "rexed lamina i",
+    "rexed layer 1",
+    "spinal lamina I",
+    "spinal lamina i"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016575) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016575#lamina-iv-of-gray-matter-of-spinal-cord",
+  "name": "lamina IV of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016575",
+  "synonym": [
+    "lamina spinale IV",
+    "rexed lamina IV",
+    "spinal lamina IV"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016580) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016580#lamina-ix-of-gray-matter-of-spinal-cord",
+  "name": "lamina IX of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016580",
+  "synonym": [
+    "rexed lamina IX",
+    "spinal lamina IX"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016570#lamina-of-gray-matter-of-spinal-cord",
+  "name": "lamina of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016570",
+  "synonym": [
+    "rexed lamina"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral commissural nucleus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016579) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016579#lamina-viii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VIII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016579",
+  "synonym": [
+    "rexed lamina VIII",
+    "spinal lamina VIII"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016578) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016578#lamina-vii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016578",
+  "synonym": [
+    "rexed lamina VII",
+    "spinal lamina VII"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina VI is a lamina of the spinal cord. It is also known as the base of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016577#lamina-vi-of-gray-matter-of-spinal-cord",
+  "name": "lamina VI of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016577",
+  "synonym": [
+    "rexed lamina VI",
+    "spinal lamina VI"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina V is a lamina of the spinal cord. It is also known as the neck of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016576#lamina-v-of-gray-matter-of-spinal-cord",
+  "name": "lamina V of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016576",
+  "synonym": [
+    "rexed lamina V",
+    "spinal lamina V"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralFuniculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "description": "The lateral mass of fibers on either side of the spinal cord, between the anterolateral and posterolateral sulci. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002179#lateral-funiculus-of-spinal-cord",
+  "name": "lateral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002179",
+  "synonym": [
+    "lateral funiculus",
+    "lateral funiculus of spinal cord",
+    "lateral white column of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "description": "Part of central canal lying within the lumbar spinal cord. It is continuous rostrally with the central canal of the thoracic spinal cord and caudally with the central canal of the sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014543#lumbar-spinal-cord-central-canal",
+  "name": "lumbar division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014543",
+  "synonym": [
+    "lumbar spinal cord central canal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002792)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002792#lumbar-spinal-cord-1",
+  "name": "lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002792",
+  "synonym": [
+    "lumbar segment of spinal cord",
+    "lumbar segments of spinal cord [1-5]",
+    "lumbar spinal cord",
+    "pars lumbalis medullae spinalis",
+    "segmenta lumbalia medullae spinalis [1-5]",
+    "spinal cord lumbar segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005842#lumbar-spinal-cord-dorsal-column-1",
+  "name": "lumbar spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005842",
+  "synonym": [
+    "dorsal funiculus of lumbar segment of spinal cord",
+    "dorsal white column of lumbar segment of spinal cord",
+    "lumbar segment of dorsal funiculus of spinal cord",
+    "lumbar segment of gracile fasciculus of spinal cord",
+    "lumbar spinal cord posterior column"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014638#lumbar-spinal-cord-dorsal-horn-1",
+  "name": "lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014638",
+  "synonym": [
+    "lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordGrayCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and lumbar spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033483)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033483#lumbar-spinal-cord-gray-commissure-1",
+  "name": "lumbar spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033483",
+  "synonym": [
+    "lumbar spinal cord gray commissure",
+    "lumbar spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordGrayMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029636) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029636#lumbar-spinal-cord-gray-matter-1",
+  "name": "lumbar spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029636",
+  "synonym": [
+    "lumbar spinal cord gray matter",
+    "lumbar spinal cord gray matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005850#lumbar-spinal-cord-lateral-column-1",
+  "name": "lumbar spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005850",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordLateralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031906) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031906#lumbar-spinal-cord-lateral-horn-1",
+  "name": "lumbar spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031906",
+  "synonym": [
+    "lumbar spinal cord lateral horn",
+    "lumbar spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005855#lumbar-spinal-cord-ventral-column-1",
+  "name": "lumbar spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005855",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordVentralCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007834#lumbar-spinal-cord-ventral-commissure-1",
+  "name": "lumbar spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007834",
+  "synonym": [
+    "lumbar spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordVentralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0030276) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0030276#lumbar-spinal-cord-ventral-horn-1",
+  "name": "lumbar spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0030276",
+  "synonym": [
+    "lumbar spinal cord ventral horn",
+    "lumbar spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSpinalCordWhiteMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026386) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026386#lumbar-spinal-cord-white-matter",
+  "name": "lumbar spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026386",
+  "synonym": [
+    "lumbar spinal cord white matter",
+    "lumbar spinal cord white matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumbarSubsegmentOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007716)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007716#segment-part-of-lumbar-spinal-cord",
+  "name": "lumbar subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007716",
+  "synonym": [
+    "segment part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lumenOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572) ('is_a' and 'relationship')]",
+  "description": "A cerebrospinal fluid-filled space that runs longitudinally through the length of the entire spinal cord. The central canal is contiguous with the ventricular system of the brain. The central canal represents the adult remainder of the neural tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009572#lumen-of-central-canal-of-spinal-cord",
+  "name": "lumen of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009572",
+  "synonym": [
+    "cavity of central canal of spinal cord",
+    "central canal lumen",
+    "spinal cord lumen"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/meninxOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a meninx. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292) ('is_a' and 'relationship')]",
+  "description": "A meninx that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003292#meninx-of-spinal-cord",
+  "name": "meninx of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003292",
+  "synonym": [
+    "meninges of spinal cord",
+    "spinal cord meninges",
+    "spinal cord meninx",
+    "spinal meninx"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ninthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006465)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006465#ninth-thoracic-spinal-cord-segment-1",
+  "name": "ninth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006465",
+  "synonym": [
+    "ninth thoracic spinal cord segment",
+    "t9 segment",
+    "T9 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/roofPlateSpinalCordRegion",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "description": "A tissue that is part of a spinal cord and is part of a roof plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005724#roof-plate-spinal-cord-region",
+  "name": "roof plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005724",
+  "synonym": [
+    "roof plate spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "description": "Part of spinal cord central canal contained in the sacral spinal cord. It is continuous rostrally with the spinal cord central canal of the lumbar cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014547#sacral-division-of-spinal-cord-central-canal",
+  "name": "sacral division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014547",
+  "synonym": [
+    "sacral spinal cord central canal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "description": "A spinal cord segment that adjacent to a sacral region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005843#sacral-spinal-cord-1",
+  "name": "sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005843",
+  "synonym": [
+    "pars sacralis medullae spinalis",
+    "sacral segment of spinal cord",
+    "sacral segments of spinal cord [1-5]",
+    "segmenta sacralia medullae spinalis [1-5]"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005840",
+  "synonym": [
+    "sacral spinal cord posterior column",
+    "sacral subsegment of dorsal funiculus of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033939) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033939#sacral-spinal-cord-dorsal-horn-1",
+  "name": "sacral spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033939",
+  "synonym": [
+    "sacral spinal cord dorsal horn",
+    "sacral spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordGrayCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and sacral spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031111)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031111#sacral-spinal-cord-gray-commissure-1",
+  "name": "sacral spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031111",
+  "synonym": [
+    "sacral spinal cord gray commissure",
+    "sacral spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordGrayMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029503) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029503#sacral-spinal-cord-gray-matter-1",
+  "name": "sacral spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029503",
+  "synonym": [
+    "sacral spinal cord gray matter",
+    "sacral spinal cord gray matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005848#sacral-spinal-cord-lateral-column-1",
+  "name": "sacral spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005848",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordLateralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029538) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029538#sacral-spinal-cord-lateral-horn-1",
+  "name": "sacral spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029538",
+  "synonym": [
+    "sacral spinal cord lateral horn",
+    "sacral spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005853#sacral-spinal-cord-ventral-column-1",
+  "name": "sacral spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005853",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordVentralCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007835#sacral-spinal-cord-ventral-commissure-1",
+  "name": "sacral spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007835",
+  "synonym": [
+    "sacral spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordVentralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0032748) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0032748#sacral-spinal-cord-ventral-horn-1",
+  "name": "sacral spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0032748",
+  "synonym": [
+    "sacral spinal cord ventral horn",
+    "sacral spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSpinalCordWhiteMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026246) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026246#sacral-spinal-cord-white-matter-1",
+  "name": "sacral spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026246",
+  "synonym": [
+    "sacral spinal cord white matter",
+    "sacral spinal cord white matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sacralSubsegmentOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007717) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007717",
+  "synonym": [
+    "segment part of sacral spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondLumbarSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006450)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006450#second-lumbar-spinal-cord-segment-1",
+  "name": "second lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006450",
+  "synonym": [
+    "l2 segment",
+    "L2 spinal cord segment",
+    "second lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondSacralSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006461)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006461#second-sacral-spinal-cord-segment-1",
+  "name": "second sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006461",
+  "synonym": [
+    "S2 segment",
+    "S2 spinal cord segment",
+    "second sacral spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006458)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006458#second-thoracic-spinal-cord-segment-1",
+  "name": "second thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006458",
+  "synonym": [
+    "second thoracic spinal cord segment",
+    "t2 segment",
+    "T2 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/seventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006455)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006455#seventh-thoracic-spinal-cord-segment-1",
+  "name": "seventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006455",
+  "synonym": [
+    "seventh thoracic spinal cord segment",
+    "t7 segment",
+    "T7 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/sixthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006454)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006454#sixth-thoracic-spinal-cord-segment-1",
+  "name": "sixth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006454",
+  "synonym": [
+    "sixth thoracic spinal cord segment",
+    "t6 segment",
+    "T6 spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCord.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "description": "Part of the central nervous system located in the vertebral canal continuous with and caudal to the brain; demarcated from brain by plane of foramen magnum. It is composed of an inner core of gray matter in which nerve cells predominate, and an outer layer of white matter in which myelinated nerve fibers predominate, and surrounds the central canal. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002240#spinal-cord-1",
+  "name": "spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002240",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordAlarPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural tube alar plate. Is part of the future spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063) ('is_a' and 'relationship')]",
+  "description": "The region of the mantle layer of the neural tube that lies dorsal to the sulcus limitans and contains primarily sensory neurons and interneurons involved in communication of sensory impulses; the alar plate develops into the dorsal horn in the grey matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004063#spinal-cord-alar-plate",
+  "name": "spinal cord alar plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004063",
+  "synonym": [
+    "alar column spinal cord",
+    "spinal cord alar column",
+    "spinal cord alar lamina"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016550) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016550#spinal-cord-column",
+  "name": "spinal cord column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016550",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nervous system commissure and tract of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "description": "The nerve fiber tracts that span the midline of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008882#spinal-cord-commissure",
+  "name": "spinal cord commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008882",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the dorsal funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373) ('is_a' and 'relationship')]",
+  "description": "The wedge-shaped fiber bundle of white matter in the dorsomedial side of the spinal cord that is made up of the fasciculus gracilis and fasciculus cuneatus; it is part of the ascending posterior column-medial lemniscus pathway that is important for well-localized fine touch and conscious proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005373#spinal-cord-dorsal-column",
+  "name": "spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005373",
+  "synonym": [
+    "dorsal column",
+    "dorsal column of spinal cord",
+    "posterior column",
+    "spinal cord posterior column"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordDorsalWhiteCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007840#spinal-cord-dorsal-white-commissure",
+  "name": "spinal cord dorsal white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007840",
+  "synonym": [
+    "commissura alba posterior medullae spinalis",
+    "dorsal white commissure of spinal cord",
+    "posterior white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordEpendyma",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an ependyma. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359) ('is_a' and 'relationship')]",
+  "description": "The ependymal cell layer that lines the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005359#spinal-cord-ependyma",
+  "name": "spinal cord ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005359",
+  "synonym": [
+    "ependyma of central canal of spinal cord",
+    "spinal cord ependymal layer"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordGrayCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "description": "The band of grey substance spanning the midline of the spinal cord that surrounds the central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004677#spinal-cord-gray-commissure-1",
+  "name": "spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004677",
+  "synonym": [
+    "area spinalis X",
+    "gray commissure of spinal cord",
+    "lamina X",
+    "lamina X of gray matter of spinal cord",
+    "rexed lamina X",
+    "spinal area X",
+    "spinal cord gray commissure",
+    "spinal cord grey commissure",
+    "spinal lamina X"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the lateral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374) ('is_a' and 'relationship')]",
+  "description": "The region of white matter of the spinal cord that is located between the dorsal and ventral spinal roots. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005374#spinal-cord-lateral-column",
+  "name": "spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005374",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordLateralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676) ('is_a' and 'relationship')]",
+  "description": "A triangular field that is a lateralward projection of the postero-lateral part of the anterior column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004676#spinal-cord-lateral-horn-1",
+  "name": "spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004676",
+  "synonym": [
+    "columna grisea intermedia medullare spinalis",
+    "intermediate gray column of spinal cord",
+    "lateral gray column of spinal cord",
+    "lateral gray horn",
+    "lateral gray matter of spinal cord",
+    "lateral horn of spinal cord",
+    "spinal cord intermediate horn",
+    "spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordLateralMotorColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord motor column and spinal cord lateral column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "description": "Column of motor neurons which innervate muscles in the limb; motor neurons in the lateral motor column are further organized into pools, each of which innervates a specific muscle in the limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010405#spinal-cord-lateral-motor-column",
+  "name": "spinal cord lateral motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010405",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordMedialMotorColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord motor column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "description": "The subclasses of motor neurons which project their axons to axial muscles that lie close to the vertebral column; motor neurons in the lateral subdivision of the MMC project their axons to body wall muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004059#spinal-cord-medial-motor-column",
+  "name": "spinal cord medial motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004059",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordMotorColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "description": "The subclasses of motor neurons which are organized into longitudinally oriented columns that occupy distinct and, in some cases, discontinuous domains along the rostrocaudal axis of the spinal cord; motor neurons within a single column send their axons to a common peripheral target. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003990#spinal-cord-motor-column",
+  "name": "spinal cord motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003990",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005844#axial-regional-part-of-spinal-cord",
+  "name": "spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005844",
+  "synonym": [
+    "axial part of spinal cord",
+    "axial regional part of spinal cord",
+    "segment of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the ventral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375) ('is_a' and 'relationship')]",
+  "description": "The area of white matter of the spinal cord located on either side of the ventral (anterior) medial fissure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005375#spinal-cord-ventral-column",
+  "name": "spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005375",
+  "synonym": [
+    "anterior column",
+    "spinal cord anterior column",
+    "ventral column"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordVentralCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "description": "The band of nerve fibers which cross the midline of the spinal cord ventral to the central canal and posterior grey commissure. The anterior (or ventral) white commissure, also known as the alba anterior medullae spinalis, is a bundle of nerve fibers which cross the midline of the spinal cord just anterior to the gray commissure. A N4 fibers and C fibers carrying pain sensation in the spinothalamic tract contribute to this commissure, as do fibers of the anterior corticospinal tract, which carry motor signals from the primary motor cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004170#spinal-cord-ventral-commissure",
+  "name": "spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004170",
+  "synonym": [
+    "anterior white commissure",
+    "anterior white commissure of spinal cord",
+    "spinal cord anterior commissure",
+    "ventral spinal commissure",
+    "ventral white column",
+    "ventral white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalCordWhiteCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007838#spinal-cord-white-commissure",
+  "name": "spinal cord white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007838",
+  "synonym": [
+    "white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subdivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the central canal of spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "description": "A subdivision of the central canal of the spinal cord along its anterior-posterior axis. This is typically subdivided into cervical, thoracic, lumbar and sacral segments. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014538#regional-part-of-spinal-cord-central-canal",
+  "name": "subdivision of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014538",
+  "synonym": [
+    "regional part of spinal cord central canal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006079) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006079#subdivision-of-spinal-cord-dorsal-column",
+  "name": "subdivision of spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006079",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subdivisionOfSpinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord lateral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006078) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006078#subdivision-of-spinal-cord-lateral-column",
+  "name": "subdivision of spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006078",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/subdivisionOfSpinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016551) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016551#subdivision-of-spinal-cord-ventral-column",
+  "name": "subdivision of spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016551",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a cervical spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014623#substantia-gelatinosa-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014623",
+  "synonym": [
+    "substantia gelatinosa of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a lumbar spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014633#substantia-gelatinosa-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014633",
+  "synonym": [
+    "substantia gelatinosa of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612) ('is_a' and 'relationship')]",
+  "description": "Substantia gelatinosa of thoracic spinal cord posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014612#substantia-gelatinosa-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014612",
+  "synonym": [
+    "substantia gelatinosa of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tenthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006466)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006466#tenth-thoracic-spinal-cord-segment-1",
+  "name": "tenth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006466",
+  "synonym": [
+    "t10 segment",
+    "T10 spinal cord segment",
+    "tenth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdLumbarSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006449)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006449#third-lumbar-spinal-cord-segment-1",
+  "name": "third lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006449",
+  "synonym": [
+    "L3 segment",
+    "L3 spinal cord segment",
+    "third lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdSacralSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006462)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006462#third-sacral-spinal-cord-segment-1",
+  "name": "third sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006462",
+  "synonym": [
+    "S3 segment",
+    "S3 spinal cord segment",
+    "third sacral spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006459)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006459#third-thoracic-spinal-cord-segment-1",
+  "name": "third thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006459",
+  "synonym": [
+    "t3 segment",
+    "T3 spinal cord segment",
+    "third thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "description": "Part of spinal cord central canal contained in the thoracic spinal cord. It is continuous rostrally with the cervical spinal cord central canal and caudally with the lumbar spinal cord central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014541#thoracic-spinal-cord-central-canal",
+  "name": "thoracic division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014541",
+  "synonym": [
+    "thoracic spinal cord central canal"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "description": "The thoracic nerves are the spinal nerves emerging from the thoracic vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003038#thoracic-spinal-cord",
+  "name": "thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003038",
+  "synonym": [
+    "pars thoracica medullae spinalis",
+    "segmenta thoracica medullae spinalis [1-12]",
+    "thoracic region of spinal cord",
+    "thoracic segment of spinal cord",
+    "thoracic segments of spinal cord [1-12]",
+    "thoracic spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordDorsalColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005839#thoracic-spinal-cord-dorsal-column-1",
+  "name": "thoracic spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005839",
+  "synonym": [
+    "dorsal funiculus of thoracic segment of spinal cord",
+    "dorsal white column of thoracic segment of spinal cord",
+    "thoracic segment of dorsal funiculus of spinal cord",
+    "thoracic spinal cord posterior column"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014609#thoracic-spinal-cord-dorsal-horn-1",
+  "name": "thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014609",
+  "synonym": [
+    "thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordGrayCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and thoracic spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026293)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026293#thoracic-spinal-cord-gray-commissure-1",
+  "name": "thoracic spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026293",
+  "synonym": [
+    "thoracic spinal cord gray commissure",
+    "thoracic spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordGrayMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014636#thoracic-spinal-cord-gray-matter-1",
+  "name": "thoracic spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014636",
+  "synonym": [
+    "thoracic spinal cord gray matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordLateralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005847#thoracic-spinal-cord-lateral-column-1",
+  "name": "thoracic spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005847",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordLateralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014607#thoracic-spinal-cord-lateral-horn-1",
+  "name": "thoracic spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014607",
+  "synonym": [
+    "thoracic spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordVentralColumn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005852#thoracic-spinal-cord-ventral-column-1",
+  "name": "thoracic spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005852",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordVentralCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007837#thoracic-spinal-cord-ventral-commissure-1",
+  "name": "thoracic spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007837",
+  "synonym": [
+    "thoracic spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordVentralHorn",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014610#thoracic-spinal-cord-ventral-horn-1",
+  "name": "thoracic spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014610",
+  "synonym": [
+    "thoracic spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSpinalCordWhiteMatter",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014637#thoracic-spinal-cord-white-matter-1",
+  "name": "thoracic spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014637",
+  "synonym": [
+    "thoracic spinal cord white matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thoracicSubsegmentOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007715)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007715#segment-part-of-thoracic-spinal-cord",
+  "name": "thoracic subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007715",
+  "synonym": [
+    "segment part of thoracic spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tractOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the spinal cord and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007699#tract-of-spinal-cord",
+  "name": "tract of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007699",
+  "synonym": [
+    "spinal cord tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/twelfthThoracicSpinalCordSegment",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006468)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006468#twelfth-thoracic-spinal-cord-segment-1",
+  "name": "twelfth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006468",
+  "synonym": [
+    "t12 segment",
+    "T12 spinal cord segment",
+    "twelfth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralFuniculusOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "description": "The white substance of the spinal cord lying on either side between the ventral median fissure and the ventral roots of the spinal nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002180#ventral-funiculus-of-spinal-cord",
+  "name": "ventral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002180",
+  "synonym": [
+    "anterior funiculus",
+    "anterior funiculus of spinal cord",
+    "anterior white column of spinal cord",
+    "funiculus anterior medullae spinalis",
+    "ventral funiculus",
+    "ventral funiculus of spinal cord",
+    "ventral white column of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014630) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014630#spinal-cord-anterior-gray-commissure",
+  "name": "ventral gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014630",
+  "synonym": [
+    "anterior grey commissure of spinal cord",
+    "commissura grisea anterior medullae spinalis",
+    "spinal cord anterior gray commissure",
+    "ventral grey commissure of spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralHornOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257) ('is_a' and 'relationship')]",
+  "description": "The ventral grey column of the spinal cord. The neurons of the ventral region of the mature spinal cord participate in motor output. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002257#spinal-cord-ventral-horn",
+  "name": "ventral horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002257",
+  "synonym": [
+    "anterior gray column of spinal cord",
+    "anterior gray horn of spinal cord",
+    "anterior grey column of spinal cord",
+    "anterior horn",
+    "columna grisea anterior medullae spinalis",
+    "spinal cord anterior horn",
+    "spinal cord ventral horn",
+    "ventral gray column of spinal cord",
+    "ventral gray matter of spinal cord",
+    "ventral grey column of spinal cord",
+    "ventral grey horn",
+    "ventral horn spinal cord",
+    "ventral region of spinal cord",
+    "ventral spinal cord"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralRootOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "description": "The ventral roots contain efferent motor axons. Similar to the dorsal roots, the ventral roots continue out from the spinal column, and meet and mix with their corresponding dorsal nerve root at a point after the ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002260#ventral-root-of-spinal-cord",
+  "name": "ventral root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002260",
+  "synonym": [
+    "anterior spinal root",
+    "ventral spinal root"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfSpinalCord",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318) ('is_a' and 'relationship')]",
+  "description": "The regions of the spinal cord that are largely or entirely composed of myelinated nerve cell axons and contain few or no neural cell bodies or dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002318#white-matter-of-spinal-cord",
+  "name": "white matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002318",
+  "synonym": [
+    "spinal cord white matter",
+    "spinal cord white matter of neuraxis",
+    "spinal cord white substance",
+    "substantia alba medullae spinalis",
+    "white matter of neuraxis of spinal cord",
+    "white substance of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C1SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C1SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "description": "The segment of the spinal cord that corresponds to the first cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006469)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#first-cervical-spinal-cord-segment",
+  "name": "C1 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006469",
+  "synonym": [
+    "C1 cervical spinal cord",
+    "C1 segment",
+    "C1 spinal cord segment",
+    "first cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C2SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C2SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "description": "The segment of the spinal cord that corresponds to the second cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006489)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006489#second-cervical-spinal-cord-segment",
+  "name": "C2 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006489",
+  "synonym": [
+    "C2 segment",
+    "C2 spinal cord segment",
+    "second cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C3SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C3SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "description": "The segment of the spinal cord that corresponds to the third cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006488)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006488#third-cervical-spinal-cord-segment",
+  "name": "C3 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006488",
+  "synonym": [
+    "C3 segment",
+    "C3 spinal cord segment",
+    "third cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C4SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C4SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "description": "The segment of the spinal cord that corresponds to the fourth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006490)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006490#forth-cervical-spinal-cord-segment",
+  "name": "C4 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006490",
+  "synonym": [
+    "C4 segment",
+    "C4 spinal cord segment",
+    "forth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C5SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C5SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "description": "The segment of the spinal cord that corresponds to the fifth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006491)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006491#fifth-cervical-spinal-cord-segment",
+  "name": "C5 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006491",
+  "synonym": [
+    "C5 segment",
+    "C5 spinal cord segment",
+    "fifth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C6SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C6SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "description": "The segment of the spinal cord that corresponds to the sixth cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006492)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006492#sixth-cervical-spinal-cord-segment",
+  "name": "C6 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006492",
+  "synonym": [
+    "C6 segment",
+    "C6 spinal cord segment",
+    "sixth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C7SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C7SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "description": "The segment of the spinal cord that corresponds to the seventh cervical vertebra in most mammals. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006493)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006493#seventh-cervical-spinal-cord-segment",
+  "name": "C7 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006493",
+  "synonym": [
+    "C7 segment",
+    "C7 spinal cord segment",
+    "seventh cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/C8SegmentOfCervicalSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/C8SegmentOfCervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006470)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006469#eighth-cervical-spinal-cord-segment",
+  "name": "C8 segment of cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006470",
+  "synonym": [
+    "C8 segment",
+    "C8 spinal cord segment",
+    "eighth cervical spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014622) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014622#apex-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "apex of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014622",
+  "synonym": [
+    "apex of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014632) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014632#apex-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "apex of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014632",
+  "synonym": [
+    "apex of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/apexOfSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004678)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004678#apex-of-spinal-cord-dorsal-horn-1",
+  "name": "apex of spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004678",
+  "synonym": [
+    "apex columnae posterioris",
+    "apex cornu posterioris medullae spinalis",
+    "apex of dorsal gray column",
+    "apex of dorsal gray column of spinal cord",
+    "apex of dorsal horn of spinal cord",
+    "apex of posterior horn of spinal cord",
+    "apex of spinal cord dorsal horn",
+    "apex of spinal cord posterior horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/apexOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014611) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014611#apex-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "apex of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014611",
+  "synonym": [
+    "apex of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/caudalSegmentOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudalSegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "description": "A spinal cord segment that adjacent to a caudal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005845)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005845#caudal-segment-of-spinal-cord",
+  "name": "caudal segment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005845",
+  "synonym": [
+    "coccygeal segment of spinal cord",
+    "coccygeal segments of spinal cord [1-3]",
+    "pars coccygea medullae spinalis",
+    "segmenta coccygea medullae spinalis [1-3]"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralCanalOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord and the ventricular system of central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "description": "Spinal cord structure that is part of the ventricular system and is filled with cerebral-spinal fluid and runs the length of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002291)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002291#spinal-cord-central-canal",
+  "name": "central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002291",
+  "synonym": [
+    "canalis centralis",
+    "central canal",
+    "central canal of spinal cord",
+    "spinal cord central canal",
+    "ventricle of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "description": "A spinal cord segment that adjacent to a cervical region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002726)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002726#cervical-spinal-cord-1",
+  "name": "cervical spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002726",
+  "synonym": [
+    "cervical segment of spinal cord",
+    "cervical segments of spinal cord [1-8]",
+    "cervical spinal cord",
+    "pars cervicalis medullae spinalis",
+    "segmenta cervicalia medullae spinalis [1-8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005841)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005841#cervical-spinal-cord-dorsal-column-1",
+  "name": "cervical spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005841",
+  "synonym": [
+    "cervical segment of dorsal funiculus of spinal cord",
+    "cervical spinal cord posterior column",
+    "dorsal funiculus of cervical segment of spinal cord",
+    "dorsal white column of cervical segment of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014620)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014620#cervical-spinal-cord-dorsal-horn-1",
+  "name": "cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014620",
+  "synonym": [
+    "cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cervical spinal cord gray matter and dorsal gray commissure of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029626)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029626#cervical-spinal-cord-gray-commissure-1",
+  "name": "cervical spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029626",
+  "synonym": [
+    "cervical spinal cord gray commissure",
+    "cervical spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014613)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014613#cervical-spinal-cord-gray-matter-1",
+  "name": "cervical spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014613",
+  "synonym": [
+    "cervical spinal cord gray matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005849)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005849#cervical-spinal-cord-lateral-column-1",
+  "name": "cervical spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005849",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014619)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014619#cervical-spinal-cord-lateral-horn-1",
+  "name": "cervical spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014619",
+  "synonym": [
+    "cervical spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralColumn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005854)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005854#cervical-spinal-cord-ventral-column-1",
+  "name": "cervical spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005854",
+  "synonym": [
+    "cervical spinal cord anterior column"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007836)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007836#cervical-spinal-cord-ventral-commissure-1",
+  "name": "cervical spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007836",
+  "synonym": [
+    "cervical spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014621)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014621#cervical-spinal-cord-ventral-horn-1",
+  "name": "cervical spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014621",
+  "synonym": [
+    "cervical spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a cervical spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014614)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014614#cervical-spinal-cord-white-matter-1",
+  "name": "cervical spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014614",
+  "synonym": [
+    "cervical spinal cord white matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cervicalSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cervicalSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the cervical spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007714) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007714#segment-part-of-cervical-spinal-cord",
+  "name": "cervical subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007714",
+  "synonym": [
+    "segment part of cervical spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cuneateFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cuneateFasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cuneate fasciculus, fasciculus of spinal cord and tract of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835) ('is_a' and 'relationship')]",
+  "description": "An axon tract in the spinal cord which primarily transmits information from the forelimb and trunk. It is part of the posterior column-medial lemniscus pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005835#cuneate-fasciculus-of-spinal-cord",
+  "name": "cuneate fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005835",
+  "synonym": [
+    "burdach's tract",
+    "cuneate fascicle of spinal cord",
+    "fasciculus cuneatus",
+    "tract of Burdach"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "description": "The white substance of the spinal cord lying on either side between the posterior median sulcus and the dorsal root. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002258)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002258#dorsal-funiculus-of-spinal-cord",
+  "name": "dorsal funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002258",
+  "synonym": [
+    "dorsal funiculus",
+    "dorsal funiculus of spinal cord",
+    "dorsal white column of spinal cord",
+    "funiculus dorsalis",
+    "funiculus posterior medullae spinalis",
+    "posterior funiculus",
+    "posterior funiculus of spinal cord",
+    "posterior white column of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631) ('is_a' and 'relationship')]",
+  "description": "The part of the gray commissure in the spinal central gray posterior to the central canal of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014631)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014631#spinal-cord-posterior-gray-commissure",
+  "name": "dorsal gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014631",
+  "synonym": [
+    "commissura grisea posterior medullae spinalis",
+    "dorsal gray commissure",
+    "dorsal grey commissure of spinal cord",
+    "posterior grey commissure of spinal cord",
+    "spinal cord posterior gray commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalHornOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256) ('is_a' and 'relationship')]",
+  "description": "The pronounced, dorsolaterally oriented ridge of grey matter in each lateral half of the spinal cord. the dorsal (more towards the back) grey matter of the spinal cord. It receives several types of sensory information from the body, including light touch, proprioception, and vibration. This information is sent from receptors of the skin, bones, and joints through sensory neurons whose cell bodies lie in the dorsal root ganglion. The dorsal region of the mature spinal cord contains neurons that process and relay sensory input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002256)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002256#spinal-cord-dorsal-horn",
+  "name": "dorsal horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002256",
+  "synonym": [
+    "columna grisea posterior medullae spinalis",
+    "cornu dorsale",
+    "cornu posterius medullae spinalis",
+    "dorsal gray column of spinal cord",
+    "dorsal gray horn",
+    "dorsal gray matter of spinal cord",
+    "dorsal grey column of spinal cord",
+    "dorsal horn spinal cord",
+    "posterior gray column of spinal cord",
+    "posterior gray horn of spinal cord",
+    "posterior grey column of spinal cord",
+    "posterior horn of spinal cord",
+    "spinal cord dorsal horn",
+    "spinal cord posterior horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalRootOfSpinalCord.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalRootOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "description": "The dorsal roots contain afferent sensory axons. The dorsal roots of each side continue outwards, along the way forming a dorsal root ganglion (also called a spinal ganglion). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002261)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002261#dorsal-root-of-spinal-cord",
+  "name": "dorsal root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002261",
+  "synonym": [
+    "dorsal root",
+    "dorsal root of spinal nerve",
+    "dorsal spinal nerve root",
+    "dorsal spinal root",
+    "posterior root of spinal nerve",
+    "radix dorsalis",
+    "radix posterior (nervus spinalis)",
+    "radix sensoria (nervus spinalis)",
+    "sensory root of spinal nerve"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/eighthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eighthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006456)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006456#eighth-thoracic-spinal-cord-segment-1",
+  "name": "eighth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006456",
+  "synonym": [
+    "eighth thoracic spinal cord segment",
+    "t8 segment",
+    "T8 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/eleventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/eleventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006467)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006467#eleventh-thoracic-spinal-cord-segment-1",
+  "name": "eleventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006467",
+  "synonym": [
+    "eleventh thoracic spinal cord segment",
+    "t11 segment",
+    "T11 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fasciculusOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve fasciculus and central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837) ('is_a' and 'relationship')]",
+  "description": "A fascicle that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005837#fasciculus-of-spinal-cord",
+  "name": "fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005837",
+  "synonym": [
+    "spinal cord fasciculus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006447)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006447#fifth-lumbar-spinal-cord-segment-1",
+  "name": "fifth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006447",
+  "synonym": [
+    "fifth lumbar spinal cord segment",
+    "L5 segment",
+    "L5 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006464)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006464#fifth-sacral-spinal-cord-segment-1",
+  "name": "fifth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006464",
+  "synonym": [
+    "fifth sacral spinal cord segment",
+    "S5 segment",
+    "S5 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fifthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fifthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006453)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006453#fifth-thoracic-spinal-cord-segment-1",
+  "name": "fifth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006453",
+  "synonym": [
+    "fifth thoracic spinal cord segment",
+    "t5 segment",
+    "T5 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006448)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006448#first-lumbar-spinal-cord-segment-1",
+  "name": "first lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006448",
+  "synonym": [
+    "first lumbar spinal cord segment",
+    "L1 segment",
+    "L1 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006460)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006460#first-sacral-spinal-cord-segment-1",
+  "name": "first sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006460",
+  "synonym": [
+    "first sacral spinal cord segment",
+    "S1 segment",
+    "S1 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/firstThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/firstThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006457)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006457#first-thoracic-spinal-cord-segment-1",
+  "name": "first thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006457",
+  "synonym": [
+    "first thoracic spinal cord segment",
+    "t1 segment",
+    "T1 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/floorPlateSpinalCordRegion.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/floorPlateSpinalCordRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "description": "A multi-tissue structure that is part of a spinal cord and is part of a floor plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005723)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005723#floor-plate-spinal-cord-region",
+  "name": "floor plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005723",
+  "synonym": [
+    "floor plate spinal cord",
+    "floorplate spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006451)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006451#forth-lumbar-spinal-cord-segment",
+  "name": "fourth lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006451",
+  "synonym": [
+    "L4 segment",
+    "L4 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthSacralSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006463)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006463#forth-sacral-spinal-cord-segment",
+  "name": "fourth sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006463",
+  "synonym": [
+    "S4 segment",
+    "S4 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006452)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006452#forth-thoracic-spinal-cord-segment",
+  "name": "fourth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006452",
+  "synonym": [
+    "T4 segment",
+    "T4 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/funiculusOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/funiculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of neuraxis. Is part of the white matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127) ('is_a' and 'relationship')]",
+  "description": "A funiculus of neuraxis that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006127)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006127#funiculus-of-spinal-cord",
+  "name": "funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006127",
+  "synonym": [
+    "spinal cord funiculus",
+    "white column of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/gracileFasciculusOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/gracileFasciculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gracile fasciculus and fasciculus of spinal cord. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826) ('is_a' and 'relationship')]",
+  "description": "A gracile fasciculus that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005826)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005826#gracile-fasciculus-of-spinal-cord",
+  "name": "gracile fasciculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005826",
+  "synonym": [
+    "fasciculus gracilis (medulla spinalis)",
+    "gracile fascicle of spinal cord",
+    "spinal cord segment of fasciculus gracilis",
+    "spinal cord segment of gracile fasciculus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/grayMatterOfSpinalCord.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/grayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315) ('is_a' and 'relationship')]",
+  "description": "The ridge-shaped grey matter of the spinal cord that extends longitudunally through the center of each half of the spinal cord, and are largely or entirely composed of nerve cell bodies and their dendrites and some supportive tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002315)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002315#gray-matter-of-spinal-cord",
+  "name": "gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002315",
+  "synonym": [
+    "gray matter of spinal cord",
+    "gray substance of spinal cord",
+    "grey matter of spinal cord",
+    "grey substance of spinal cord",
+    "spinal cord gray matter",
+    "spinal cord grey matter",
+    "spinal cord grey substance",
+    "substantia grisea medullae spinalis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/hindbrainSpinalCordBoundary.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/hindbrainSpinalCordBoundary",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "description": "An anatomical boundary that adjacent to a hindbrain and adjacent to a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005076)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005076#hindbrain-spinal-cord-boundary",
+  "name": "hindbrain-spinal cord boundary",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005076",
+  "synonym": [
+    "hindbrain-spinal cord boundary region"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016574) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016574#lamina-iii-of-gray-matter-of-spinal-cord",
+  "name": "lamina III of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016574",
+  "synonym": [
+    "lamina spinale III",
+    "rexed lamina III",
+    "spinal lamina III"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118) ('is_a' and 'relationship')]",
+  "description": "Cytoarchitectural part of spinal cord gray matter. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006118)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006118#lamina-i-of-gray-matter-of-spinal-cord",
+  "name": "lamina I of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006118",
+  "synonym": [
+    "lamina i of gray matter of spinal cord",
+    "lamina marginalis",
+    "lamina marginalis",
+    "lamina spinalis i",
+    "layer of Waldeyer",
+    "layer of waldeyer",
+    "rexed lamina I",
+    "rexed lamina i",
+    "rexed layer 1",
+    "spinal lamina I",
+    "spinal lamina i"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016575) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016575#lamina-iv-of-gray-matter-of-spinal-cord",
+  "name": "lamina IV of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016575",
+  "synonym": [
+    "lamina spinale IV",
+    "rexed lamina IV",
+    "spinal lamina IV"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaIXOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016580) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016580#lamina-ix-of-gray-matter-of-spinal-cord",
+  "name": "lamina IX of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016580",
+  "synonym": [
+    "rexed lamina IX",
+    "spinal lamina IX"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016570#lamina-of-gray-matter-of-spinal-cord",
+  "name": "lamina of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016570",
+  "synonym": [
+    "rexed lamina"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral commissural nucleus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016579) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016579#lamina-viii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VIII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016579",
+  "synonym": [
+    "rexed lamina VIII",
+    "spinal lamina VIII"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the ventral horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016578) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016578#lamina-vii-of-gray-matter-of-spinal-cord",
+  "name": "lamina VII of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016578",
+  "synonym": [
+    "rexed lamina VII",
+    "spinal lamina VII"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVIOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the dorsal horn of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina VI is a lamina of the spinal cord. It is also known as the base of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016577)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016577#lamina-vi-of-gray-matter-of-spinal-cord",
+  "name": "lamina VI of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016577",
+  "synonym": [
+    "rexed lamina VI",
+    "spinal lamina VI"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/laminaVOfGrayMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. Is part of the nucleus proprius of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576) ('is_a' and 'relationship')]",
+  "description": "Spinal lamina V is a lamina of the spinal cord. It is also known as the neck of the posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016576#lamina-v-of-gray-matter-of-spinal-cord",
+  "name": "lamina V of gray matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016576",
+  "synonym": [
+    "rexed lamina V",
+    "spinal lamina V"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "description": "The lateral mass of fibers on either side of the spinal cord, between the anterolateral and posterolateral sulci. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002179)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002179#lateral-funiculus-of-spinal-cord",
+  "name": "lateral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002179",
+  "synonym": [
+    "lateral funiculus",
+    "lateral funiculus of spinal cord",
+    "lateral white column of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "description": "Part of central canal lying within the lumbar spinal cord. It is continuous rostrally with the central canal of the thoracic spinal cord and caudally with the central canal of the sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014543)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014543#lumbar-spinal-cord-central-canal",
+  "name": "lumbar division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014543",
+  "synonym": [
+    "lumbar spinal cord central canal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002792)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002792#lumbar-spinal-cord-1",
+  "name": "lumbar spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002792",
+  "synonym": [
+    "lumbar segment of spinal cord",
+    "lumbar segments of spinal cord [1-5]",
+    "lumbar spinal cord",
+    "pars lumbalis medullae spinalis",
+    "segmenta lumbalia medullae spinalis [1-5]",
+    "spinal cord lumbar segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005842)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005842#lumbar-spinal-cord-dorsal-column-1",
+  "name": "lumbar spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005842",
+  "synonym": [
+    "dorsal funiculus of lumbar segment of spinal cord",
+    "dorsal white column of lumbar segment of spinal cord",
+    "lumbar segment of dorsal funiculus of spinal cord",
+    "lumbar segment of gracile fasciculus of spinal cord",
+    "lumbar spinal cord posterior column"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014638#lumbar-spinal-cord-dorsal-horn-1",
+  "name": "lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014638",
+  "synonym": [
+    "lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and lumbar spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033483)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033483#lumbar-spinal-cord-gray-commissure-1",
+  "name": "lumbar spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033483",
+  "synonym": [
+    "lumbar spinal cord gray commissure",
+    "lumbar spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029636) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029636#lumbar-spinal-cord-gray-matter-1",
+  "name": "lumbar spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029636",
+  "synonym": [
+    "lumbar spinal cord gray matter",
+    "lumbar spinal cord gray matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005850)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005850#lumbar-spinal-cord-lateral-column-1",
+  "name": "lumbar spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005850",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031906) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031906#lumbar-spinal-cord-lateral-horn-1",
+  "name": "lumbar spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031906",
+  "synonym": [
+    "lumbar spinal cord lateral horn",
+    "lumbar spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005855)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005855#lumbar-spinal-cord-ventral-column-1",
+  "name": "lumbar spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005855",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a lumbar spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007834)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007834#lumbar-spinal-cord-ventral-commissure-1",
+  "name": "lumbar spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007834",
+  "synonym": [
+    "lumbar spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the lumbar spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0030276) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0030276#lumbar-spinal-cord-ventral-horn-1",
+  "name": "lumbar spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0030276",
+  "synonym": [
+    "lumbar spinal cord ventral horn",
+    "lumbar spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the lumbar spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026386) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026386#lumbar-spinal-cord-white-matter",
+  "name": "lumbar spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026386",
+  "synonym": [
+    "lumbar spinal cord white matter",
+    "lumbar spinal cord white matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumbarSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumbarSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007716)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007716#segment-part-of-lumbar-spinal-cord",
+  "name": "lumbar subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007716",
+  "synonym": [
+    "segment part of lumbar spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lumenOfCentralCanalOfSpinalCord.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lumenOfCentralCanalOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572) ('is_a' and 'relationship')]",
+  "description": "A cerebrospinal fluid-filled space that runs longitudinally through the length of the entire spinal cord. The central canal is contiguous with the ventricular system of the brain. The central canal represents the adult remainder of the neural tube. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009572#lumen-of-central-canal-of-spinal-cord",
+  "name": "lumen of central canal of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009572",
+  "synonym": [
+    "cavity of central canal of spinal cord",
+    "central canal lumen",
+    "spinal cord lumen"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/meninxOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/meninxOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a meninx. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292) ('is_a' and 'relationship')]",
+  "description": "A meninx that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003292)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003292#meninx-of-spinal-cord",
+  "name": "meninx of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003292",
+  "synonym": [
+    "meninges of spinal cord",
+    "spinal cord meninges",
+    "spinal cord meninx",
+    "spinal meninx"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ninthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ninthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006465)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006465#ninth-thoracic-spinal-cord-segment-1",
+  "name": "ninth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006465",
+  "synonym": [
+    "ninth thoracic spinal cord segment",
+    "t9 segment",
+    "T9 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/roofPlateSpinalCordRegion.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/roofPlateSpinalCordRegion",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "description": "A tissue that is part of a spinal cord and is part of a roof plate. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005724)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005724#roof-plate-spinal-cord-region",
+  "name": "roof plate spinal cord region",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005724",
+  "synonym": [
+    "roof plate spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "description": "Part of spinal cord central canal contained in the sacral spinal cord. It is continuous rostrally with the spinal cord central canal of the lumbar cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014547)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014547#sacral-division-of-spinal-cord-central-canal",
+  "name": "sacral division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014547",
+  "synonym": [
+    "sacral spinal cord central canal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "description": "A spinal cord segment that adjacent to a sacral region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005843)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005843#sacral-spinal-cord-1",
+  "name": "sacral spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005843",
+  "synonym": [
+    "pars sacralis medullae spinalis",
+    "sacral segment of spinal cord",
+    "sacral segments of spinal cord [1-5]",
+    "segmenta sacralia medullae spinalis [1-5]"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005840)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005840",
+  "synonym": [
+    "sacral spinal cord posterior column",
+    "sacral subsegment of dorsal funiculus of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0033939) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0033939#sacral-spinal-cord-dorsal-horn-1",
+  "name": "sacral spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0033939",
+  "synonym": [
+    "sacral spinal cord dorsal horn",
+    "sacral spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and sacral spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0031111)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0031111#sacral-spinal-cord-gray-commissure-1",
+  "name": "sacral spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0031111",
+  "synonym": [
+    "sacral spinal cord gray commissure",
+    "sacral spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordGrayMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029503) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029503#sacral-spinal-cord-gray-matter-1",
+  "name": "sacral spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029503",
+  "synonym": [
+    "sacral spinal cord gray matter",
+    "sacral spinal cord gray matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005848)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005848#sacral-spinal-cord-lateral-column-1",
+  "name": "sacral spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005848",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordLateralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0029538) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0029538#sacral-spinal-cord-lateral-horn-1",
+  "name": "sacral spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0029538",
+  "synonym": [
+    "sacral spinal cord lateral horn",
+    "sacral spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005853)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005853#sacral-spinal-cord-ventral-column-1",
+  "name": "sacral spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005853",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a sacral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007835)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007835#sacral-spinal-cord-ventral-commissure-1",
+  "name": "sacral spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007835",
+  "synonym": [
+    "sacral spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordVentralHorn.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the sacral spinal cord gray matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0032748) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0032748#sacral-spinal-cord-ventral-horn-1",
+  "name": "sacral spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0032748",
+  "synonym": [
+    "sacral spinal cord ventral horn",
+    "sacral spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026246) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026246#sacral-spinal-cord-white-matter-1",
+  "name": "sacral spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026246",
+  "synonym": [
+    "sacral spinal cord white matter",
+    "sacral spinal cord white matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sacralSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sacralSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. Is part of the sacral spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007717) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005840#sacral-spinal-cord-dorsal-column-1",
+  "name": "sacral subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007717",
+  "synonym": [
+    "segment part of sacral spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006450)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006450#second-lumbar-spinal-cord-segment-1",
+  "name": "second lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006450",
+  "synonym": [
+    "l2 segment",
+    "L2 spinal cord segment",
+    "second lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006461)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006461#second-sacral-spinal-cord-segment-1",
+  "name": "second sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006461",
+  "synonym": [
+    "S2 segment",
+    "S2 spinal cord segment",
+    "second sacral spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006458)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006458#second-thoracic-spinal-cord-segment-1",
+  "name": "second thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006458",
+  "synonym": [
+    "second thoracic spinal cord segment",
+    "t2 segment",
+    "T2 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/seventhThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/seventhThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006455)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006455#seventh-thoracic-spinal-cord-segment-1",
+  "name": "seventh thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006455",
+  "synonym": [
+    "seventh thoracic spinal cord segment",
+    "t7 segment",
+    "T7 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/sixthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/sixthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006454)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006454#sixth-thoracic-spinal-cord-segment-1",
+  "name": "sixth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006454",
+  "synonym": [
+    "sixth thoracic spinal cord segment",
+    "t6 segment",
+    "T6 spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCord.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central nervous system. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "description": "Part of the central nervous system located in the vertebral canal continuous with and caudal to the brain; demarcated from brain by plane of foramen magnum. It is composed of an inner core of gray matter in which nerve cells predominate, and an outer layer of white matter in which myelinated nerve fibers predominate, and surrounds the central canal. (CUMBO) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002240)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002240#spinal-cord-1",
+  "name": "spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002240",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordAlarPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordAlarPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural tube alar plate. Is part of the future spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063) ('is_a' and 'relationship')]",
+  "description": "The region of the mantle layer of the neural tube that lies dorsal to the sulcus limitans and contains primarily sensory neurons and interneurons involved in communication of sensory impulses; the alar plate develops into the dorsal horn in the grey matter of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004063)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004063#spinal-cord-alar-plate",
+  "name": "spinal cord alar plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004063",
+  "synonym": [
+    "alar column spinal cord",
+    "spinal cord alar column",
+    "spinal cord alar lamina"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016550) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016550#spinal-cord-column",
+  "name": "spinal cord column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016550",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordCommissure.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nervous system commissure and tract of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "description": "The nerve fiber tracts that span the midline of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0008882)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0008882#spinal-cord-commissure",
+  "name": "spinal cord commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0008882",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the dorsal funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373) ('is_a' and 'relationship')]",
+  "description": "The wedge-shaped fiber bundle of white matter in the dorsomedial side of the spinal cord that is made up of the fasciculus gracilis and fasciculus cuneatus; it is part of the ascending posterior column-medial lemniscus pathway that is important for well-localized fine touch and conscious proprioception. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005373)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005373#spinal-cord-dorsal-column",
+  "name": "spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005373",
+  "synonym": [
+    "dorsal column",
+    "dorsal column of spinal cord",
+    "posterior column",
+    "spinal cord posterior column"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordDorsalWhiteCommissure.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordDorsalWhiteCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007840)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007840#spinal-cord-dorsal-white-commissure",
+  "name": "spinal cord dorsal white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007840",
+  "synonym": [
+    "commissura alba posterior medullae spinalis",
+    "dorsal white commissure of spinal cord",
+    "posterior white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an ependyma. Is part of the central canal of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359) ('is_a' and 'relationship')]",
+  "description": "The ependymal cell layer that lines the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005359)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005359#spinal-cord-ependyma",
+  "name": "spinal cord ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005359",
+  "synonym": [
+    "ependyma of central canal of spinal cord",
+    "spinal cord ependymal layer"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordGrayCommissure.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lamina of gray matter of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "description": "The band of grey substance spanning the midline of the spinal cord that surrounds the central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004677)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004677#spinal-cord-gray-commissure-1",
+  "name": "spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004677",
+  "synonym": [
+    "area spinalis X",
+    "gray commissure of spinal cord",
+    "lamina X",
+    "lamina X of gray matter of spinal cord",
+    "rexed lamina X",
+    "spinal area X",
+    "spinal cord gray commissure",
+    "spinal cord grey commissure",
+    "spinal lamina X"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the lateral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374) ('is_a' and 'relationship')]",
+  "description": "The region of white matter of the spinal cord that is located between the dorsal and ventral spinal roots. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005374)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005374#spinal-cord-lateral-column",
+  "name": "spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005374",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralHorn.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676) ('is_a' and 'relationship')]",
+  "description": "A triangular field that is a lateralward projection of the postero-lateral part of the anterior column. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004676)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004676#spinal-cord-lateral-horn-1",
+  "name": "spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004676",
+  "synonym": [
+    "columna grisea intermedia medullare spinalis",
+    "intermediate gray column of spinal cord",
+    "lateral gray column of spinal cord",
+    "lateral gray horn",
+    "lateral gray matter of spinal cord",
+    "lateral horn of spinal cord",
+    "spinal cord intermediate horn",
+    "spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordLateralMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordLateralMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord motor column and spinal cord lateral column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "description": "Column of motor neurons which innervate muscles in the limb; motor neurons in the lateral motor column are further organized into pools, each of which innervates a specific muscle in the limb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0010405)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0010405#spinal-cord-lateral-motor-column",
+  "name": "spinal cord lateral motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0010405",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordMedialMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordMedialMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord motor column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "description": "The subclasses of motor neurons which project their axons to axial muscles that lie close to the vertebral column; motor neurons in the lateral subdivision of the MMC project their axons to body wall muscles. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004059)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004059#spinal-cord-medial-motor-column",
+  "name": "spinal cord medial motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004059",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordMotorColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordMotorColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "description": "The subclasses of motor neurons which are organized into longitudinally oriented columns that occupy distinct and, in some cases, discontinuous domains along the rostrocaudal axis of the spinal cord; motor neurons within a single column send their axons to a common peripheral target. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003990)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003990#spinal-cord-motor-column",
+  "name": "spinal cord motor column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003990",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005844)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005844#axial-regional-part-of-spinal-cord",
+  "name": "spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005844",
+  "synonym": [
+    "axial part of spinal cord",
+    "axial regional part of spinal cord",
+    "segment of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordVentralColumn.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the ventral funiculus of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375) ('is_a' and 'relationship')]",
+  "description": "The area of white matter of the spinal cord located on either side of the ventral (anterior) medial fissure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005375)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005375#spinal-cord-ventral-column",
+  "name": "spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005375",
+  "synonym": [
+    "anterior column",
+    "spinal cord anterior column",
+    "ventral column"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordVentralCommissure.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord white commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "description": "The band of nerve fibers which cross the midline of the spinal cord ventral to the central canal and posterior grey commissure. The anterior (or ventral) white commissure, also known as the alba anterior medullae spinalis, is a bundle of nerve fibers which cross the midline of the spinal cord just anterior to the gray commissure. A N4 fibers and C fibers carrying pain sensation in the spinothalamic tract contribute to this commissure, as do fibers of the anterior corticospinal tract, which carry motor signals from the primary motor cortex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004170)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004170#spinal-cord-ventral-commissure",
+  "name": "spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004170",
+  "synonym": [
+    "anterior white commissure",
+    "anterior white commissure of spinal cord",
+    "spinal cord anterior commissure",
+    "ventral spinal commissure",
+    "ventral white column",
+    "ventral white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalCordWhiteCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalCordWhiteCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord commissure. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007838)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007838#spinal-cord-white-commissure",
+  "name": "spinal cord white commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007838",
+  "synonym": [
+    "white commissure of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the central canal of spinal cord. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "description": "A subdivision of the central canal of the spinal cord along its anterior-posterior axis. This is typically subdivided into cervical, thoracic, lumbar and sacral segments. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014538)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014538#regional-part-of-spinal-cord-central-canal",
+  "name": "subdivision of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014538",
+  "synonym": [
+    "regional part of spinal cord central canal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord dorsal column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006079) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006079#subdivision-of-spinal-cord-dorsal-column",
+  "name": "subdivision of spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006079",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord lateral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006078) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006078#subdivision-of-spinal-cord-lateral-column",
+  "name": "subdivision of spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006078",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/subdivisionOfSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/subdivisionOfSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the spinal cord ventral column. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016551) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016551#subdivision-of-spinal-cord-ventral-column",
+  "name": "subdivision of spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016551",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfCervicalSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the cervical spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a cervical spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014623)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014623#substantia-gelatinosa-of-cervical-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of cervical spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014623",
+  "synonym": [
+    "substantia gelatinosa of cervical spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfLumbarSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the lumbar spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633) ('is_a' and 'relationship')]",
+  "description": "A substantia gelatinosa that is part of a lumbar spinal cord dorsal horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014633)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014633#substantia-gelatinosa-of-lumbar-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of lumbar spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014633",
+  "synonym": [
+    "substantia gelatinosa of lumbar spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/substantiaGelatinosaOfThoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a substantia gelatinosa. Is part of the thoracic spinal cord dorsal horn. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612) ('is_a' and 'relationship')]",
+  "description": "Substantia gelatinosa of thoracic spinal cord posterior horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014612)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014612#substantia-gelatinosa-of-thoracic-spinal-cord-dorsal-horn-1",
+  "name": "substantia gelatinosa of thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014612",
+  "synonym": [
+    "substantia gelatinosa of thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tenthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tenthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006466)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006466#tenth-thoracic-spinal-cord-segment-1",
+  "name": "tenth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006466",
+  "synonym": [
+    "t10 segment",
+    "T10 spinal cord segment",
+    "tenth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdLumbarSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdLumbarSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lumbar subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006449)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006449#third-lumbar-spinal-cord-segment-1",
+  "name": "third lumbar spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006449",
+  "synonym": [
+    "L3 segment",
+    "L3 spinal cord segment",
+    "third lumbar spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdSacralSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdSacralSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sacral subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006462)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006462#third-sacral-spinal-cord-segment-1",
+  "name": "third sacral spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006462",
+  "synonym": [
+    "S3 segment",
+    "S3 spinal cord segment",
+    "third sacral spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006459)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006459#third-thoracic-spinal-cord-segment-1",
+  "name": "third thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006459",
+  "synonym": [
+    "t3 segment",
+    "T3 spinal cord segment",
+    "third thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicDivisionOfSpinalCordCentralCanal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord central canal. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "description": "Part of spinal cord central canal contained in the thoracic spinal cord. It is continuous rostrally with the cervical spinal cord central canal and caudally with the lumbar spinal cord central canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014541)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014541#thoracic-spinal-cord-central-canal",
+  "name": "thoracic division of spinal cord central canal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014541",
+  "synonym": [
+    "thoracic spinal cord central canal"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord segment. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "description": "The thoracic nerves are the spinal nerves emerging from the thoracic vertebrae. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003038)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003038#thoracic-spinal-cord",
+  "name": "thoracic spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003038",
+  "synonym": [
+    "pars thoracica medullae spinalis",
+    "segmenta thoracica medullae spinalis [1-12]",
+    "thoracic region of spinal cord",
+    "thoracic segment of spinal cord",
+    "thoracic segments of spinal cord [1-12]",
+    "thoracic spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalColumn.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordDorsalColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord dorsal column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord dorsal column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005839)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005839#thoracic-spinal-cord-dorsal-column-1",
+  "name": "thoracic spinal cord dorsal column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005839",
+  "synonym": [
+    "dorsal funiculus of thoracic segment of spinal cord",
+    "dorsal white column of thoracic segment of spinal cord",
+    "thoracic segment of dorsal funiculus of spinal cord",
+    "thoracic spinal cord posterior column"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordDorsalHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordDorsalHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609) ('is_a' and 'relationship')]",
+  "description": "A dorsal horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014609)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014609#thoracic-spinal-cord-dorsal-horn-1",
+  "name": "thoracic spinal cord dorsal horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014609",
+  "synonym": [
+    "thoracic spinal cord dorsal horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayCommissure.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordGrayCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dorsal gray commissure of spinal cord and thoracic spinal cord gray matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026293)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026293#thoracic-spinal-cord-gray-commissure-1",
+  "name": "thoracic spinal cord gray commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026293",
+  "synonym": [
+    "thoracic spinal cord gray commissure",
+    "thoracic spinal cord gray commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordGrayMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordGrayMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636) ('is_a' and 'relationship')]",
+  "description": "A gray matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014636)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014636#thoracic-spinal-cord-gray-matter-1",
+  "name": "thoracic spinal cord gray matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014636",
+  "synonym": [
+    "thoracic spinal cord gray matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordLateralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord lateral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord lateral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005847)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005847#thoracic-spinal-cord-lateral-column-1",
+  "name": "thoracic spinal cord lateral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005847",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordLateralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordLateralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord lateral horn. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607) ('is_a' and 'relationship')]",
+  "description": "A spinal cord lateral horn that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014607)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014607#thoracic-spinal-cord-lateral-horn-1",
+  "name": "thoracic spinal cord lateral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014607",
+  "synonym": [
+    "thoracic spinal cord lateral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralColumn.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralColumn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subdivision of spinal cord ventral column. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852) ('is_a' and 'relationship')]",
+  "description": "A subdivision of spinal cord ventral column that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005852)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005852#thoracic-spinal-cord-ventral-column-1",
+  "name": "thoracic spinal cord ventral column",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005852",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord ventral commissure. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837) ('is_a' and 'relationship')]",
+  "description": "A spinal cord ventral commissure that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007837)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007837#thoracic-spinal-cord-ventral-commissure-1",
+  "name": "thoracic spinal cord ventral commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007837",
+  "synonym": [
+    "thoracic spinal cord anterior commissure"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordVentralHorn.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordVentralHorn",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ventral horn of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610) ('is_a' and 'relationship')]",
+  "description": "A ventral horn of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014610)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014610#thoracic-spinal-cord-ventral-horn-1",
+  "name": "thoracic spinal cord ventral horn",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014610",
+  "synonym": [
+    "thoracic spinal cord ventral horn"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSpinalCordWhiteMatter.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSpinalCordWhiteMatter",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of spinal cord. Is part of the thoracic spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637) ('is_a' and 'relationship')]",
+  "description": "A white matter of spinal cord that is part of a thoracic spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014637)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014637#thoracic-spinal-cord-white-matter-1",
+  "name": "thoracic spinal cord white matter",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014637",
+  "synonym": [
+    "thoracic spinal cord white matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thoracicSubsegmentOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thoracicSubsegmentOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007715)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007715#segment-part-of-thoracic-spinal-cord",
+  "name": "thoracic subsegment of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007715",
+  "synonym": [
+    "segment part of thoracic spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tractOfSpinalCord.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the spinal cord and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007699)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007699#tract-of-spinal-cord",
+  "name": "tract of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007699",
+  "synonym": [
+    "spinal cord tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/twelfthThoracicSpinalCordSegment.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/twelfthThoracicSpinalCordSegment",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a thoracic subsegment of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006468)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006468#twelfth-thoracic-spinal-cord-segment-1",
+  "name": "twelfth thoracic spinal cord segment",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006468",
+  "synonym": [
+    "t12 segment",
+    "T12 spinal cord segment",
+    "twelfth thoracic spinal cord segment"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralFuniculusOfSpinalCord.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralFuniculusOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a funiculus of spinal cord. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "description": "The white substance of the spinal cord lying on either side between the ventral median fissure and the ventral roots of the spinal nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002180)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002180#ventral-funiculus-of-spinal-cord",
+  "name": "ventral funiculus of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002180",
+  "synonym": [
+    "anterior funiculus",
+    "anterior funiculus of spinal cord",
+    "anterior white column of spinal cord",
+    "funiculus anterior medullae spinalis",
+    "ventral funiculus",
+    "ventral funiculus of spinal cord",
+    "ventral white column of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralGrayCommissureOfSpinalCord.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralGrayCommissureOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a gray matter of spinal cord. Is part of the spinal cord gray commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014630) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014630#spinal-cord-anterior-gray-commissure",
+  "name": "ventral gray commissure of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014630",
+  "synonym": [
+    "anterior grey commissure of spinal cord",
+    "commissura grisea anterior medullae spinalis",
+    "spinal cord anterior gray commissure",
+    "ventral grey commissure of spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralHornOfSpinalCord.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralHornOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal cord column. Is part of the gray matter of spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257) ('is_a' and 'relationship')]",
+  "description": "The ventral grey column of the spinal cord. The neurons of the ventral region of the mature spinal cord participate in motor output. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002257)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002257#spinal-cord-ventral-horn",
+  "name": "ventral horn of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002257",
+  "synonym": [
+    "anterior gray column of spinal cord",
+    "anterior gray horn of spinal cord",
+    "anterior grey column of spinal cord",
+    "anterior horn",
+    "columna grisea anterior medullae spinalis",
+    "spinal cord anterior horn",
+    "spinal cord ventral horn",
+    "ventral gray column of spinal cord",
+    "ventral gray matter of spinal cord",
+    "ventral grey column of spinal cord",
+    "ventral grey horn",
+    "ventral horn spinal cord",
+    "ventral region of spinal cord",
+    "ventral spinal cord"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralRootOfSpinalCord.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralRootOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a spinal nerve root. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "description": "The ventral roots contain efferent motor axons. Similar to the dorsal roots, the ventral roots continue out from the spinal column, and meet and mix with their corresponding dorsal nerve root at a point after the ganglion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002260)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002260#ventral-root-of-spinal-cord",
+  "name": "ventral root of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002260",
+  "synonym": [
+    "anterior spinal root",
+    "ventral spinal root"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfSpinalCord.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfSpinalCord",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. Is part of the spinal cord. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318) ('is_a' and 'relationship')]",
+  "description": "The regions of the spinal cord that are largely or entirely composed of myelinated nerve cell axons and contain few or no neural cell bodies or dendrites. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002318)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002318#white-matter-of-spinal-cord",
+  "name": "white matter of spinal cord",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002318",
+  "synonym": [
+    "spinal cord white matter",
+    "spinal cord white matter of neuraxis",
+    "spinal cord white substance",
+    "substantia alba medullae spinalis",
+    "white matter of neuraxis of spinal cord",
+    "white substance of spinal cord"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'spinal cord' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.