### PR TITLE
UBERON terms with 'olfactory' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryOlfactoryBulb",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069) ('is_a' and 'relationship')]",
+  "description": "The forebrain region that coordinates sensory signaling arising from the vomeronasal organ; it is located on the dorsal-posterior portion of the main olfactory bulb, and the axons that leave the accessory olfactory bulb project to targets in the amygdala and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004069#accessory-olfactory-bulb",
+  "name": "accessory olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004069",
+  "synonym": [
+    "accessory (vomeronasal) bulb",
+    "olfactory bulb accessory nucleus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Islands of Calleja of olfactory tubercle' is a regional part of brain. It is part of the island of Calleja and olfactory tubercle.",
-  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells",
+  "definition": "Is a regional part of brain. Is part of the island of Calleja and the olfactory tubercle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867) ('is_a' and 'relationship')]",
+  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105732",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023867#islands-of-calleja-of-olfactory-tubercle-1",
   "name": "islands of Calleja of olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023867",
   "synonym": [
-    "Islets of Calleja",
     "islands of calleja of olfactory tubercle"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralOlfactoryStria",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone).",
-  "description": "'Lateral olfactory stria' is an olfactory tract linking bulb to ipsilateral dorsal telencephalon.",
+  "definition": "Is an olfactory tract linking bulb to ipsilateral dorsal telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
+  "description": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106082",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001888#lateral-olfactory-stria-1",
   "name": "lateral olfactory stria",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001888",
-  "synonym": null
+  "synonym": [
+    "tractus olfactorius lateralis"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mainOlfactoryBulb",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951) ('is_a' and 'relationship')]",
+  "description": "The main olfactory bulb has a multi-layered cellular architecture. In order from surface to the center the layers are: Glomerular layer, External plexiform layer, Mitral cell layer, Internal plexiform layer, Granule cell layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009951#main-olfactory-bulb",
+  "name": "main olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009951",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialOlfactoryStria",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a stria of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "description": "The medial olfactory stria turns medialward behind the parolfactory area and ends in the subcallosal gyrus; in some cases a small intermediate stria is seen running backward to the anterior perforated substance. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034734#medial-olfactory-stria",
+  "name": "medial olfactory stria",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034734",
+  "synonym": [
+    "stria olfactoria medialis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryBulb.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryBulb.jsonld
@@ -4,18 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulb",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory bulb' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "Structure of the vertebrate telencephalon involved in olfaction.",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264) ('is_a' and 'relationship')]",
+  "description": "A bulbous anterior projection of the olfactory lobe that is the place of termination of the olfactory nerves and is especially well developed in lower vertebrates (as fishes). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107921",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002264#olfactory-bulb-1",
   "name": "olfactory bulb",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002264",
   "synonym": [
-    "bulbus olfactorius",
-    "bulbus olfactorius (Morgagni)",
-    "main olfactory bulb",
-    "Olb",
-    "olfactory lobe",
-    "olfactory lobe (Barr & Kiernan)"
+    "bulbus olfactorius"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulbSubependymalZone",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "description": "The region of mitotically active layer of cells surrounding the lateral brain ventricles that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells, that produce neurons that migrate to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005380#olfactory-bulb-subependymal-zone",
+  "name": "olfactory bulb subependymal zone",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005380",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory epithelium. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997) ('is_a' and 'relationship')]",
+  "description": "A sensory epithelium inside the nasal cavity that is responsible for detecting odors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001997#olfactory-epithelium-1",
+  "name": "olfactory epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001997",
+  "synonym": [
+    "main olfactory epithelium",
+    "nasal cavity olfactory epithelium",
+    "olfactory membrane",
+    "olfactory sensory epithelium",
+    "sensory olfactory epithelium"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryGlomerulus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural glomerulus. Is part of the olfactory bulb glomerular layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387) ('is_a' and 'relationship')]",
+  "description": "One of the small globular masses of dense neuropil in the olfactory bulb, containing the first synapse in the olfactory pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005387#olfactory-glomerulus",
+  "name": "olfactory glomerulus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005387",
+  "synonym": [
+    "glomerulus of olfactory bulb",
+    "olfactory bulb glomerulus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "description": "The lobe at the anterior part of each cerebral hemisphere, responsible for olfactory functions. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005366#olfactory-lobe",
+  "name": "olfactory lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005366",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryPathway.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryPathway.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryPathway",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the limbic system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201) ('is_a' and 'relationship')]",
+  "description": "Set of nerve fibers conducting impulses from olfactory receptors to the cerebral cortex. It includes the olfactory nerve; olfactory bulb; olfactory tract, olfactory tubercle, anterior perforated substance, and olfactory cortex. The term rhinencephalon is restricted to structures in the CNS receiving fibers from the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013201#olfactory-pathway",
+  "name": "olfactory pathway",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013201",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryTract.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory tract' is a tract of brain. It is part of the white matter of telencephalon.",
-  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain.",
+  "definition": "Is a tract of brain. Is part of the white matter of telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265) ('is_a' and 'relationship')]",
+  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724772",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002265#olfactory-tract-1",
   "name": "olfactory tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002265",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034730)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034730#olfactory-tract-linking-bulb-to-ipsilateral-dorsal-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral dorsal telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034730",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000238)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000238#olfactory-tract-linking-bulb-to-ipsilateral-ventral-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral ventral telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000238",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTrigone",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory trigone' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia)",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922) ('is_a' and 'relationship')]",
+  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107973",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002922#olfactory-trigone-1",
   "name": "olfactory trigone",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002922",
   "synonym": [
-    "olt",
     "trigonum olfactorium"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTubercle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory tubercle' is a telencephalic nucleus. It is part of the olfactory cortex.",
-  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region.  It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character.  According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis.   (Maryann Martone)",
+  "definition": "Is a telencephalic nucleus. Is part of the olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883) ('is_a' and 'relationship')]",
+  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region. It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character. According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001883#olfactory-tubercle-1",
   "name": "olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001883",
   "synonym": [
-    "anterior perforated space",
-    "anterior perforated substance",
     "tuberculum olfactorium"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/accessoryOlfactoryBulb",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069) ('is_a' and 'relationship')]",
+  "description": "The forebrain region that coordinates sensory signaling arising from the vomeronasal organ; it is located on the dorsal-posterior portion of the main olfactory bulb, and the axons that leave the accessory olfactory bulb project to targets in the amygdala and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004069#accessory-olfactory-bulb",
+  "name": "accessory olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004069",
+  "synonym": [
+    "accessory (vomeronasal) bulb",
+    "olfactory bulb accessory nucleus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Islands of Calleja of olfactory tubercle' is a regional part of brain. It is part of the island of Calleja and olfactory tubercle.",
-  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells",
+  "definition": "Is a regional part of brain. Is part of the island of Calleja and the olfactory tubercle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867) ('is_a' and 'relationship')]",
+  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105732",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023867#islands-of-calleja-of-olfactory-tubercle-1",
   "name": "islands of Calleja of olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023867",
   "synonym": [
-    "Islets of Calleja",
     "islands of calleja of olfactory tubercle"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralOlfactoryStria",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone).",
-  "description": "'Lateral olfactory stria' is an olfactory tract linking bulb to ipsilateral dorsal telencephalon.",
+  "definition": "Is an olfactory tract linking bulb to ipsilateral dorsal telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
+  "description": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106082",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001888#lateral-olfactory-stria-1",
   "name": "lateral olfactory stria",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001888",
-  "synonym": null
+  "synonym": [
+    "tractus olfactorius lateralis"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mainOlfactoryBulb",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951) ('is_a' and 'relationship')]",
+  "description": "The main olfactory bulb has a multi-layered cellular architecture. In order from surface to the center the layers are: Glomerular layer, External plexiform layer, Mitral cell layer, Internal plexiform layer, Granule cell layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009951#main-olfactory-bulb",
+  "name": "main olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009951",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/medialOlfactoryStria",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a stria of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "description": "The medial olfactory stria turns medialward behind the parolfactory area and ends in the subcallosal gyrus; in some cases a small intermediate stria is seen running backward to the anterior perforated substance. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034734#medial-olfactory-stria",
+  "name": "medial olfactory stria",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034734",
+  "synonym": [
+    "stria olfactoria medialis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulb.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulb.jsonld
@@ -4,18 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryBulb",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Olfactory bulb' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "Structure of the vertebrate telencephalon involved in olfaction.",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264) ('is_a' and 'relationship')]",
+  "description": "A bulbous anterior projection of the olfactory lobe that is the place of termination of the olfactory nerves and is especially well developed in lower vertebrates (as fishes). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107921",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002264#olfactory-bulb-1",
   "name": "olfactory bulb",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002264",
   "synonym": [
-    "bulbus olfactorius",
-    "bulbus olfactorius (Morgagni)",
-    "main olfactory bulb",
-    "Olb",
-    "olfactory lobe",
-    "olfactory lobe (Barr & Kiernan)"
+    "bulbus olfactorius"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryBulbSubependymalZone",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "description": "The region of mitotically active layer of cells surrounding the lateral brain ventricles that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells, that produce neurons that migrate to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005380#olfactory-bulb-subependymal-zone",
+  "name": "olfactory bulb subependymal zone",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005380",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryEpithelium",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a sensory epithelium. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997) ('is_a' and 'relationship')]",
+  "description": "A sensory epithelium inside the nasal cavity that is responsible for detecting odors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001997#olfactory-epithelium-1",
+  "name": "olfactory epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001997",
+  "synonym": [
+    "main olfactory epithelium",
+    "nasal cavity olfactory epithelium",
+    "olfactory membrane",
+    "olfactory sensory epithelium",
+    "sensory olfactory epithelium"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryGlomerulus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural glomerulus. Is part of the olfactory bulb glomerular layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387) ('is_a' and 'relationship')]",
+  "description": "One of the small globular masses of dense neuropil in the olfactory bulb, containing the first synapse in the olfactory pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005387#olfactory-glomerulus",
+  "name": "olfactory glomerulus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005387",
+  "synonym": [
+    "glomerulus of olfactory bulb",
+    "olfactory bulb glomerulus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "description": "The lobe at the anterior part of each cerebral hemisphere, responsible for olfactory functions. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005366#olfactory-lobe",
+  "name": "olfactory lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005366",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryPathway.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryPathway.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryPathway",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the limbic system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201) ('is_a' and 'relationship')]",
+  "description": "Set of nerve fibers conducting impulses from olfactory receptors to the cerebral cortex. It includes the olfactory nerve; olfactory bulb; olfactory tract, olfactory tubercle, anterior perforated substance, and olfactory cortex. The term rhinencephalon is restricted to structures in the CNS receiving fibers from the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013201#olfactory-pathway",
+  "name": "olfactory pathway",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013201",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryTract.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Olfactory tract' is a tract of brain. It is part of the white matter of telencephalon.",
-  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain.",
+  "definition": "Is a tract of brain. Is part of the white matter of telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265) ('is_a' and 'relationship')]",
+  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724772",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002265#olfactory-tract-1",
   "name": "olfactory tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002265",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034730)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034730#olfactory-tract-linking-bulb-to-ipsilateral-dorsal-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral dorsal telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034730",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000238)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000238#olfactory-tract-linking-bulb-to-ipsilateral-ventral-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral ventral telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000238",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryTrigone",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Olfactory trigone' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia)",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922) ('is_a' and 'relationship')]",
+  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107973",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002922#olfactory-trigone-1",
   "name": "olfactory trigone",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002922",
   "synonym": [
-    "olt",
     "trigonum olfactorium"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/olfactoryTubercle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Olfactory tubercle' is a telencephalic nucleus. It is part of the olfactory cortex.",
-  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region.  It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character.  According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis.   (Maryann Martone)",
+  "definition": "Is a telencephalic nucleus. Is part of the olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883) ('is_a' and 'relationship')]",
+  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region. It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character. According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001883#olfactory-tubercle-1",
   "name": "olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001883",
   "synonym": [
-    "anterior perforated space",
-    "anterior perforated substance",
     "tuberculum olfactorium"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/accessoryOlfactoryBulb.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryOlfactoryBulb",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069) ('is_a' and 'relationship')]",
+  "description": "The forebrain region that coordinates sensory signaling arising from the vomeronasal organ; it is located on the dorsal-posterior portion of the main olfactory bulb, and the axons that leave the accessory olfactory bulb project to targets in the amygdala and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004069)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004069#accessory-olfactory-bulb",
+  "name": "accessory olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004069",
+  "synonym": [
+    "accessory (vomeronasal) bulb",
+    "olfactory bulb accessory nucleus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/islandsOfCallejaOfOlfactoryTubercle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Islands of Calleja of olfactory tubercle' is a regional part of brain. It is part of the island of Calleja and olfactory tubercle.",
-  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells",
+  "definition": "Is a regional part of brain. Is part of the island of Calleja and the olfactory tubercle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867) ('is_a' and 'relationship')]",
+  "description": "Part of olfactory tubercle defined by dense aggregations of granule cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023867)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105732",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023867#islands-of-calleja-of-olfactory-tubercle-1",
   "name": "islands of Calleja of olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023867",
   "synonym": [
-    "Islets of Calleja",
     "islands of calleja of olfactory tubercle"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralOlfactoryStria.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralOlfactoryStria",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone).",
-  "description": "'Lateral olfactory stria' is an olfactory tract linking bulb to ipsilateral dorsal telencephalon.",
+  "definition": "Is an olfactory tract linking bulb to ipsilateral dorsal telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
+  "description": "White matter tract that contains projections from the olfactory bulb to the olfactory cortex (Maryann Martone). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001888)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106082",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001888#lateral-olfactory-stria-1",
   "name": "lateral olfactory stria",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001888",
-  "synonym": null
+  "synonym": [
+    "tractus olfactorius lateralis"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mainOlfactoryBulb.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mainOlfactoryBulb",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the olfactory bulb. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951) ('is_a' and 'relationship')]",
+  "description": "The main olfactory bulb has a multi-layered cellular architecture. In order from surface to the center the layers are: Glomerular layer, External plexiform layer, Mitral cell layer, Internal plexiform layer, Granule cell layer. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009951)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009951#main-olfactory-bulb",
+  "name": "main olfactory bulb",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009951",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/medialOlfactoryStria.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialOlfactoryStria",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a stria of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "description": "The medial olfactory stria turns medialward behind the parolfactory area and ends in the subcallosal gyrus; in some cases a small intermediate stria is seen running backward to the anterior perforated substance. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034734)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034734#medial-olfactory-stria",
+  "name": "medial olfactory stria",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034734",
+  "synonym": [
+    "stria olfactoria medialis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulb.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulb.jsonld
@@ -4,18 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulb",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory bulb' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "Structure of the vertebrate telencephalon involved in olfaction.",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264) ('is_a' and 'relationship')]",
+  "description": "A bulbous anterior projection of the olfactory lobe that is the place of termination of the olfactory nerves and is especially well developed in lower vertebrates (as fishes). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002264)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107921",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002264#olfactory-bulb-1",
   "name": "olfactory bulb",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002264",
   "synonym": [
-    "bulbus olfactorius",
-    "bulbus olfactorius (Morgagni)",
-    "main olfactory bulb",
-    "Olb",
-    "olfactory lobe",
-    "olfactory lobe (Barr & Kiernan)"
+    "bulbus olfactorius"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryBulbSubependymalZone.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryBulbSubependymalZone",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory bulb layer. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "description": "The region of mitotically active layer of cells surrounding the lateral brain ventricles that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells, that produce neurons that migrate to the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005380)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005380#olfactory-bulb-subependymal-zone",
+  "name": "olfactory bulb subependymal zone",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005380",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryEpithelium.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a sensory epithelium. Is part of the somatic nervous system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997) ('is_a' and 'relationship')]",
+  "description": "A sensory epithelium inside the nasal cavity that is responsible for detecting odors. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001997)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001997#olfactory-epithelium-1",
+  "name": "olfactory epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001997",
+  "synonym": [
+    "main olfactory epithelium",
+    "nasal cavity olfactory epithelium",
+    "olfactory membrane",
+    "olfactory sensory epithelium",
+    "sensory olfactory epithelium"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryGlomerulus.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryGlomerulus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural glomerulus. Is part of the olfactory bulb glomerular layer. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387) ('is_a' and 'relationship')]",
+  "description": "One of the small globular masses of dense neuropil in the olfactory bulb, containing the first synapse in the olfactory pathway. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005387)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005387#olfactory-glomerulus",
+  "name": "olfactory glomerulus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005387",
+  "synonym": [
+    "glomerulus of olfactory bulb",
+    "olfactory bulb glomerulus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "description": "The lobe at the anterior part of each cerebral hemisphere, responsible for olfactory functions. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005366)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005366#olfactory-lobe",
+  "name": "olfactory lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005366",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryPathway.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryPathway.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryPathway",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the limbic system. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201) ('is_a' and 'relationship')]",
+  "description": "Set of nerve fibers conducting impulses from olfactory receptors to the cerebral cortex. It includes the olfactory nerve; olfactory bulb; olfactory tract, olfactory tubercle, anterior perforated substance, and olfactory cortex. The term rhinencephalon is restricted to structures in the CNS receiving fibers from the olfactory bulb. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013201)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013201#olfactory-pathway",
+  "name": "olfactory pathway",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013201",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryTract.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory tract' is a tract of brain. It is part of the white matter of telencephalon.",
-  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain.",
+  "definition": "Is a tract of brain. Is part of the white matter of telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265) ('is_a' and 'relationship')]",
+  "description": "White matter tract that contains projections from the olfactory bulb to other parts of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002265)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724772",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002265#olfactory-tract-1",
   "name": "olfactory tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002265",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralDorsalTelencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034730)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034730#olfactory-tract-linking-bulb-to-ipsilateral-dorsal-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral dorsal telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034730",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTractLinkingBulbToIpsilateralVentralTelencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an olfactory tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000238)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000238#olfactory-tract-linking-bulb-to-ipsilateral-ventral-telencephalon",
+  "name": "olfactory tract linking bulb to ipsilateral ventral telencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000238",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryTrigone.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTrigone",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory trigone' is a regional part of brain. It is part of the olfactory lobe.",
-  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia)",
+  "definition": "Is a regional part of brain. Is part of the olfactory lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922) ('is_a' and 'relationship')]",
+  "description": "A small triangular area in front of the anterior perforated substance. Its apex, directed forward, occupies the posterior part of the olfactory sulcus, and is brought into view by throwing back the olfactory tract (adapted from Wikipedia) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107973",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002922#olfactory-trigone-1",
   "name": "olfactory trigone",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002922",
   "synonym": [
-    "olt",
     "trigonum olfactorium"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/olfactoryTubercle.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryTubercle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Olfactory tubercle' is a telencephalic nucleus. It is part of the olfactory cortex.",
-  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region.  It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character.  According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis.   (Maryann Martone)",
+  "definition": "Is a telencephalic nucleus. Is part of the olfactory cortex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883) ('is_a' and 'relationship')]",
+  "description": "Region in the ventral telencephalon, prominent in rodents, but present in all mammals, consisting of a laminated cortical part and the cap/hilus region. It is traditionally viewed as part of the olfactory cortex but recognized by some as having a striatal character. According to many authors, the structure of the OT transitions from cortical like to striatal like along the lateral medial axis. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001883)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001883#olfactory-tubercle-1",
   "name": "olfactory tubercle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001883",
   "synonym": [
-    "anterior perforated space",
-    "anterior perforated substance",
     "tuberculum olfactorium"
   ]
 }
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'olfactory' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.