### PR TITLE
UBERON terms with 'cell group' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A10DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036005)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036005#a10-dopaminergic-cell-group",
+  "name": "A10 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036005",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A11DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036006)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036006#a11-dopaminergic-cell-group",
+  "name": "A11 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036006",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A12DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036009)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036009#a12-dopaminergic-cell-group",
+  "name": "A12 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036009",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A13DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. Is part of the zona incerta. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007) ('is_a' and 'relationship')]",
+  "description": "A group of cells that fluoresce for dopamine and are distributed in clusters that, in the primate, are ventral and medial to the mammillothalamic tract of the hypothalamus; a few extend into the reuniens nucleus of the thalamus (Felten-1983). In the mouse A13 is located ventral to the mammillothalamic tract of the thalamus in the zona incerta (adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036007#a13-dopaminergic-cell-group",
+  "name": "A13 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036007",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A14DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036001)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036001#a14-dopaminergic-cell-group",
+  "name": "A14 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036001",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A15DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036002)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036002#a15-dopaminergic-cell-group",
+  "name": "A15 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036002",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A16DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036008)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036008#a16-dopaminergic-cell-group",
+  "name": "A16 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036008",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A17DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036004)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036004#a17-dopaminergic-cell-group",
+  "name": "A17 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036004",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A8DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036000)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036000#a8-dopaminergic-cell-group",
+  "name": "A8 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036000",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A9DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036003)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036003#a9-dopaminergic-cell-group",
+  "name": "A9 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036003",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/AaqDopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036010)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036010#aaq-dopaminergic-cell-group",
+  "name": "Aaq dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036010",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dopaminergicCellGroups",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "description": "Collections of neurons in the central nervous system that have been demonstrated by histochemical fluorescence to contain the neurotransmitter dopamine ( Fuxe-1970 ) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035999#dopaminergic-cell-groups",
+  "name": "dopaminergic cell groups",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035999",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicDopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036011)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036011#telencephalic-dopaminergic-cell-group",
+  "name": "telencephalic dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036011",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A10DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036005)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036005#a10-dopaminergic-cell-group",
+  "name": "A10 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036005",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A11DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036006)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036006#a11-dopaminergic-cell-group",
+  "name": "A11 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036006",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A12DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036009)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036009#a12-dopaminergic-cell-group",
+  "name": "A12 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036009",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A13DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. Is part of the zona incerta. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007) ('is_a' and 'relationship')]",
+  "description": "A group of cells that fluoresce for dopamine and are distributed in clusters that, in the primate, are ventral and medial to the mammillothalamic tract of the hypothalamus; a few extend into the reuniens nucleus of the thalamus (Felten-1983). In the mouse A13 is located ventral to the mammillothalamic tract of the thalamus in the zona incerta (adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036007#a13-dopaminergic-cell-group",
+  "name": "A13 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036007",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A14DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036001)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036001#a14-dopaminergic-cell-group",
+  "name": "A14 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036001",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A15DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036002)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036002#a15-dopaminergic-cell-group",
+  "name": "A15 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036002",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A16DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036008)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036008#a16-dopaminergic-cell-group",
+  "name": "A16 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036008",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A17DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036004)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036004#a17-dopaminergic-cell-group",
+  "name": "A17 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036004",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A8DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036000)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036000#a8-dopaminergic-cell-group",
+  "name": "A8 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036000",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/A9DopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036003)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036003#a9-dopaminergic-cell-group",
+  "name": "A9 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036003",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/AaqDopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036010)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036010#aaq-dopaminergic-cell-group",
+  "name": "Aaq dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036010",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dopaminergicCellGroups",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "description": "Collections of neurons in the central nervous system that have been demonstrated by histochemical fluorescence to contain the neurotransmitter dopamine ( Fuxe-1970 ) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035999#dopaminergic-cell-groups",
+  "name": "dopaminergic cell groups",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035999",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telencephalicDopaminergicCellGroup",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036011)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036011#telencephalic-dopaminergic-cell-group",
+  "name": "telencephalic dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036011",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A10DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A10DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036005)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036005#a10-dopaminergic-cell-group",
+  "name": "A10 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036005",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A11DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A11DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036006)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036006#a11-dopaminergic-cell-group",
+  "name": "A11 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036006",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A12DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A12DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036009)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036009#a12-dopaminergic-cell-group",
+  "name": "A12 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036009",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A13DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A13DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. Is part of the zona incerta. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007) ('is_a' and 'relationship')]",
+  "description": "A group of cells that fluoresce for dopamine and are distributed in clusters that, in the primate, are ventral and medial to the mammillothalamic tract of the hypothalamus; a few extend into the reuniens nucleus of the thalamus (Felten-1983). In the mouse A13 is located ventral to the mammillothalamic tract of the thalamus in the zona incerta (adapted from Brain Info) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036007#a13-dopaminergic-cell-group",
+  "name": "A13 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036007",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A14DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A14DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036001)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036001#a14-dopaminergic-cell-group",
+  "name": "A14 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036001",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A15DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A15DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036002)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036002#a15-dopaminergic-cell-group",
+  "name": "A15 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036002",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A16DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A16DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036008)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036008#a16-dopaminergic-cell-group",
+  "name": "A16 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036008",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A17DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A17DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036004)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036004#a17-dopaminergic-cell-group",
+  "name": "A17 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036004",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A8DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A8DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036000)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036000#a8-dopaminergic-cell-group",
+  "name": "A8 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036000",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/A9DopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/A9DopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036003)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036003#a9-dopaminergic-cell-group",
+  "name": "A9 dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036003",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/AaqDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/AaqDopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036010)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036010#aaq-dopaminergic-cell-group",
+  "name": "Aaq dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036010",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dopaminergicCellGroups.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dopaminergicCellGroups",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "description": "Collections of neurons in the central nervous system that have been demonstrated by histochemical fluorescence to contain the neurotransmitter dopamine ( Fuxe-1970 ) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035999)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035999#dopaminergic-cell-groups",
+  "name": "dopaminergic cell groups",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035999",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telencephalicDopaminergicCellGroup.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicDopaminergicCellGroup",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a dopaminergic cell groups. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0036011)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0036011#telencephalic-dopaminergic-cell-group",
+  "name": "telencephalic dopaminergic cell group",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0036011",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'cell group' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.