### PR TITLE
UBERON terms with 'lobe' in name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cephalopodOpticLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Cephalopod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963) .",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796) ('is_a' and 'relationship')]",
+  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0725883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006796#cephalopod-optic-lobe",
   "name": "cephalopod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006796",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/electrosensoryLateralLineLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "description": "Anatomical structure located in the hindbrain that receives primary electroreceptor input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002105#electrosensory-lateral-line-lobe",
+  "name": "electrosensory lateral line lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002105",
+  "synonym": [
+    "ELL"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/facialLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/facialLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/facialLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000512)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000512#facial-lobe",
+  "name": "facial lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000512",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -4,20 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/flocculonodularLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Flocculonodular lobe' is a cerebellum lobe. It is part of the vestibulocerebellum.",
-  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [WP,unvetted].",
+  "definition": "Is a cerebellum lobe. Is part of the vestibulocerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012) ('is_a' and 'relationship')]",
+  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104286",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003012#flocculonodular-lobe-1",
   "name": "flocculonodular lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
-    "Archaeocerebellum",
-    "archicerebellum",
     "cerebellum flocculonodular lobe",
     "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
-    "posterior lobe-2 of cerebellum",
-    "vestibulocerebellum"
+    "posterior lobe-2 of cerebellum"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
     "cerebellum flocculonodular lobe",
-    "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
     "posterior lobe-2 of cerebellum"

--- a/instances/latest/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/flocculonodularLobeHemispherePortion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Flocculonodular lobe, hemisphere portion' is a regional part of cerebellar cortex. It is part of the cerebellar hemisphere and flocculonodular lobe.",
+  "definition": "Is a regional part of cerebellar cortex. Is part of the cerebellar hemisphere and the flocculonodular lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0027331) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104947",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0027331#flocculonodular-lobe-hemisphere-portion",
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
-  "synonym": null
+  "synonym": [
+    "hemispheric part of the flocculonodular lobe of the cerebellum",
+    "hemispheric part of the flocculonodular lobe of the cerebellum"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -11,7 +11,6 @@
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
   "synonym": [
-    "hemispheric part of the flocculonodular lobe of the cerebellum",
     "hemispheric part of the flocculonodular lobe of the cerebellum"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/frontalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/frontalLobe.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/frontalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Frontal lobe' is a lobe of cerebral hemisphere.",
-  "description": "The anterior part of the cerebral hemisphere. (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
+  "description": "Frontal lobe is the anterior-most of five lobes of the cerebral hemisphere. It is bounded by the central sulcus on its posterior border and by the longitudinal cerebral fissure on its medial border. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104451",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016525#frontal-lobe-1",
   "name": "frontal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016525",
   "synonym": [
-    "frontal cortex",
-    "frontal region",
     "lobi frontales",
-    "lobus frontalis",
-    "regio frontalis"
+    "lobus frontalis"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000517) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000517#glossopharyngeal-lobe",
+  "name": "glossopharyngeal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000517",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the dorsal zone of median tuberal portion of hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000165) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000165#inferior-lobe",
+  "name": "inferior lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000165",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002811#left-frontal-lobe-1",
+  "name": "left frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002811",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002804#left-limbic-lobe-1",
+  "name": "left limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002804",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002806#left-occipital-lobe-1",
+  "name": "left occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002806",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftParietalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the left hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002802#left-parietal-lobe-1",
+  "name": "left parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002802",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002808#left-temporal-lobe-1",
+  "name": "left temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002808",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/limbicLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/limbicLobe.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limbicLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem.",
-  "description": "'Limbic lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
+  "description": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106264",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002600#limbic-lobe-1",
   "name": "limbic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002600",
-  "synonym": null
+  "synonym": [
+    "fornicate gyrus",
+    "grande lobe limbique of Broca",
+    "limbic lobe (carpenter)"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
@@ -4,22 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lobeOfCerebralHemisphere",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lobe of cerebral hemisphere' is part of the cerebral hemisphere.",
-  "description": "Divisions of the cerebral cortex from gross anatomical observation based on the locations of major sulci and fissures in gyrencephalic animals, including both the gray matter and underlying white matter. From 4-6 lobes have been defined.",
+  "definition": "Is part of the cerebral hemisphere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
+  "description": "Subdivision of telencephalon which is one of a number of subdivisions of each hemisphere separated by both real landmarks (sulci and fissures) and arbitrary boundaries. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106316",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016526#lobe-of-cerebral-cortex",
   "name": "lobe of cerebral hemisphere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016526",
   "synonym": [
-    "cerebral cortical segment",
     "cerebral hemisphere lobe",
     "cerebral lobe",
-    "cerebral lobes",
     "lobe of cerebral cortex",
     "lobe parts of cerebral cortex",
-    "lobes of the brain",
-    "lobi cerebri",
-    "regional organ part of cerebral cortex",
-    "segment of cerebral cortex"
+    "lobi cerebri"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialCaudalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the vestibulolateralis lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000388) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000388#medial-caudal-lobe",
+  "name": "medial caudal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000388",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
@@ -4,23 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralLobeOfNeurohypophysis",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [WP,unvetted].",
-  "description": "'Neural lobe of neurohypophysis' is a regional part of brain. It is part of the neurohypophysis.",
+  "definition": "Is a regional part of brain. Is part of the neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217) ('is_a' and 'relationship')]",
+  "description": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108544",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003217#pars-nervosa-of-hypophysis",
   "name": "neural lobe of neurohypophysis",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003217",
   "synonym": [
-    "caudal lobe",
-    "eminentia medialis (Shantha)",
-    "eminentia mediana",
-    "eminentia postinfundibularis",
-    "lobe caudalis cerebelli",
     "lobus nervosus (Neurohypophysis)",
-    "medial eminence",
-    "middle lobe",
-    "neural component of pituitary",
-    "pars nervosa",
     "pars nervosa (hypophysis)",
     "pars nervosa (neurohypophysis)",
     "pars nervosa neurohypophysis",
@@ -31,12 +22,8 @@
     "pars nervosa pituitary gland",
     "pars posterior",
     "pars posterior of hypophysis",
-    "pituitary gland",
-    "PNHP",
-    "posterior lobe",
     "posterior lobe of neurohypophysis",
-    "posterior lobe of pituitary",
-    "posterior lobe-3",
-    "posterior pituitary"
+    "posterior lobe-3"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/occipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/occipitalLobe.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Occipital lobe' is a lobe of cerebral hemisphere.",
-  "description": "Posterior part of the cerebral hemisphere (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
+  "description": "Posterior part of the cerebral hemisphere (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002021#occipital-lobe-1",
   "name": "occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002021",
   "synonym": [
-    "lobus occipitalis",
     "regio occipitalis"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/parietalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/parietalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Upper central part of the cerebral hemisphere. (MSH).",
-  "description": "'Parietal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
+  "description": "Upper central part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108534",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001872#parietal-lobe-1",
   "name": "parietal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001872",
-  "synonym": null
+  "synonym": [
+    "regio parietalis"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002810#right-frontal-lobe-1",
+  "name": "right frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002810",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002805#right-limbic-lobe-1",
+  "name": "right limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002805",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002807#right-occipital-lobe-1",
+  "name": "right occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002807",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightParietalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the right hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002803#right-parietal-lobe-1",
+  "name": "right parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002803",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002809#right-temporal-lobe-1",
+  "name": "right temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002809",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
-  "synonym": [
-    "superficial feature part of occipital lobe",
-    "superficial feature part of occipital lobe"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -4,13 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superficialFeaturePartOfOccipitalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Superficial feature part of occipital lobe' is a regional part of brain. It is part of the occipital lobe.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023462) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111268",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
   "synonym": [
+    "superficial feature part of occipital lobe",
     "superficial feature part of occipital lobe"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/temporalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/temporalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/temporalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Lower lateral part of the cerebral hemisphere. (MSH).",
-  "description": "'Temporal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
+  "description": "Lower lateral part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111590",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001871#temporal-lobe-1",
   "name": "temporal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001871",
-  "synonym": null
+  "synonym": [
+    "lobus temporalis"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/vagalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vagalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000297)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000297#vagal-lobe",
+  "name": "vagal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000297",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulolateralisLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000307) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000307#vestibulolateralis-lobe",
+  "name": "vestibulolateralis lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000307",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfCerebralLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter. Is part of the lobe of cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016527) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016527#white-matter-of-cerebral-lobe",
+  "name": "white matter of cerebral lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016527",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a frontal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016528#white-matter-of-frontal-lobe",
+  "name": "white matter of frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016528",
+  "synonym": [
+    "frontal lobe white matter"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the limbic lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a limbic lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016536#white-matter-of-limbic-lobe",
+  "name": "white matter of limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016536",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016535#white-matter-of-occipital-lobe",
+  "name": "white matter of occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016535",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the parietal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a parietal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016531#white-matter-of-parietal-lobe",
+  "name": "white matter of parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016531",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the temporal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016534#white-matter-of-temporal-lobe",
+  "name": "white matter of temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016534",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cephalopodOpticLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Cephalopod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963) .",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796) ('is_a' and 'relationship')]",
+  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0725883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006796#cephalopod-optic-lobe",
   "name": "cephalopod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006796",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/electrosensoryLateralLineLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "description": "Anatomical structure located in the hindbrain that receives primary electroreceptor input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002105#electrosensory-lateral-line-lobe",
+  "name": "electrosensory lateral line lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002105",
+  "synonym": [
+    "ELL"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/facialLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/facialLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/facialLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000512)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000512#facial-lobe",
+  "name": "facial lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000512",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -4,20 +4,18 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/flocculonodularLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Flocculonodular lobe' is a cerebellum lobe. It is part of the vestibulocerebellum.",
-  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [WP,unvetted].",
+  "definition": "Is a cerebellum lobe. Is part of the vestibulocerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012) ('is_a' and 'relationship')]",
+  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104286",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003012#flocculonodular-lobe-1",
   "name": "flocculonodular lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
-    "Archaeocerebellum",
-    "archicerebellum",
     "cerebellum flocculonodular lobe",
     "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
-    "posterior lobe-2 of cerebellum",
-    "vestibulocerebellum"
+    "posterior lobe-2 of cerebellum"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
     "cerebellum flocculonodular lobe",
-    "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
     "posterior lobe-2 of cerebellum"

--- a/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -11,7 +11,6 @@
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
   "synonym": [
-    "hemispheric part of the flocculonodular lobe of the cerebellum",
     "hemispheric part of the flocculonodular lobe of the cerebellum"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/flocculonodularLobeHemispherePortion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Flocculonodular lobe, hemisphere portion' is a regional part of cerebellar cortex. It is part of the cerebellar hemisphere and flocculonodular lobe.",
+  "definition": "Is a regional part of cerebellar cortex. Is part of the cerebellar hemisphere and the flocculonodular lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0027331) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104947",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0027331#flocculonodular-lobe-hemisphere-portion",
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
-  "synonym": null
+  "synonym": [
+    "hemispheric part of the flocculonodular lobe of the cerebellum",
+    "hemispheric part of the flocculonodular lobe of the cerebellum"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/frontalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/frontalLobe.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/frontalLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Frontal lobe' is a lobe of cerebral hemisphere.",
-  "description": "The anterior part of the cerebral hemisphere. (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
+  "description": "Frontal lobe is the anterior-most of five lobes of the cerebral hemisphere. It is bounded by the central sulcus on its posterior border and by the longitudinal cerebral fissure on its medial border. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104451",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016525#frontal-lobe-1",
   "name": "frontal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016525",
   "synonym": [
-    "frontal cortex",
-    "frontal region",
     "lobi frontales",
-    "lobus frontalis",
-    "regio frontalis"
+    "lobus frontalis"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/glossopharyngealLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000517) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000517#glossopharyngeal-lobe",
+  "name": "glossopharyngeal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000517",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the dorsal zone of median tuberal portion of hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000165) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000165#inferior-lobe",
+  "name": "inferior lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000165",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftFrontalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002811#left-frontal-lobe-1",
+  "name": "left frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002811",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftLimbicLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002804#left-limbic-lobe-1",
+  "name": "left limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002804",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftOccipitalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002806#left-occipital-lobe-1",
+  "name": "left occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002806",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftParietalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftParietalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the left hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002802#left-parietal-lobe-1",
+  "name": "left parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002802",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftTemporalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002808#left-temporal-lobe-1",
+  "name": "left temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002808",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/limbicLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/limbicLobe.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/limbicLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem.",
-  "description": "'Limbic lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
+  "description": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106264",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002600#limbic-lobe-1",
   "name": "limbic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002600",
-  "synonym": null
+  "synonym": [
+    "fornicate gyrus",
+    "grande lobe limbique of Broca",
+    "limbic lobe (carpenter)"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
@@ -4,22 +4,18 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lobeOfCerebralHemisphere",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Lobe of cerebral hemisphere' is part of the cerebral hemisphere.",
-  "description": "Divisions of the cerebral cortex from gross anatomical observation based on the locations of major sulci and fissures in gyrencephalic animals, including both the gray matter and underlying white matter. From 4-6 lobes have been defined.",
+  "definition": "Is part of the cerebral hemisphere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
+  "description": "Subdivision of telencephalon which is one of a number of subdivisions of each hemisphere separated by both real landmarks (sulci and fissures) and arbitrary boundaries. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106316",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016526#lobe-of-cerebral-cortex",
   "name": "lobe of cerebral hemisphere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016526",
   "synonym": [
-    "cerebral cortical segment",
     "cerebral hemisphere lobe",
     "cerebral lobe",
-    "cerebral lobes",
     "lobe of cerebral cortex",
     "lobe parts of cerebral cortex",
-    "lobes of the brain",
-    "lobi cerebri",
-    "regional organ part of cerebral cortex",
-    "segment of cerebral cortex"
+    "lobi cerebri"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/medialCaudalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the vestibulolateralis lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000388) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000388#medial-caudal-lobe",
+  "name": "medial caudal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000388",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
@@ -4,23 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/neuralLobeOfNeurohypophysis",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [WP,unvetted].",
-  "description": "'Neural lobe of neurohypophysis' is a regional part of brain. It is part of the neurohypophysis.",
+  "definition": "Is a regional part of brain. Is part of the neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217) ('is_a' and 'relationship')]",
+  "description": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108544",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003217#pars-nervosa-of-hypophysis",
   "name": "neural lobe of neurohypophysis",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003217",
   "synonym": [
-    "caudal lobe",
-    "eminentia medialis (Shantha)",
-    "eminentia mediana",
-    "eminentia postinfundibularis",
-    "lobe caudalis cerebelli",
     "lobus nervosus (Neurohypophysis)",
-    "medial eminence",
-    "middle lobe",
-    "neural component of pituitary",
-    "pars nervosa",
     "pars nervosa (hypophysis)",
     "pars nervosa (neurohypophysis)",
     "pars nervosa neurohypophysis",
@@ -31,12 +22,8 @@
     "pars nervosa pituitary gland",
     "pars posterior",
     "pars posterior of hypophysis",
-    "pituitary gland",
-    "PNHP",
-    "posterior lobe",
     "posterior lobe of neurohypophysis",
-    "posterior lobe of pituitary",
-    "posterior lobe-3",
-    "posterior pituitary"
+    "posterior lobe-3"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/occipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/occipitalLobe.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/occipitalLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Occipital lobe' is a lobe of cerebral hemisphere.",
-  "description": "Posterior part of the cerebral hemisphere (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
+  "description": "Posterior part of the cerebral hemisphere (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002021#occipital-lobe-1",
   "name": "occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002021",
   "synonym": [
-    "lobus occipitalis",
     "regio occipitalis"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/parietalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/parietalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parietalLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "Upper central part of the cerebral hemisphere. (MSH).",
-  "description": "'Parietal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
+  "description": "Upper central part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108534",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001872#parietal-lobe-1",
   "name": "parietal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001872",
-  "synonym": null
+  "synonym": [
+    "regio parietalis"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightFrontalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002810#right-frontal-lobe-1",
+  "name": "right frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002810",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightLimbicLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002805#right-limbic-lobe-1",
+  "name": "right limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002805",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightOccipitalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002807#right-occipital-lobe-1",
+  "name": "right occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002807",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightParietalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightParietalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the right hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002803#right-parietal-lobe-1",
+  "name": "right parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002803",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightTemporalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002809#right-temporal-lobe-1",
+  "name": "right temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002809",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
-  "synonym": [
-    "superficial feature part of occipital lobe",
-    "superficial feature part of occipital lobe"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -4,13 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superficialFeaturePartOfOccipitalLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Superficial feature part of occipital lobe' is a regional part of brain. It is part of the occipital lobe.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023462) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111268",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
   "synonym": [
+    "superficial feature part of occipital lobe",
     "superficial feature part of occipital lobe"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/temporalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/temporalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/temporalLobe",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "Lower lateral part of the cerebral hemisphere. (MSH).",
-  "description": "'Temporal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
+  "description": "Lower lateral part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111590",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001871#temporal-lobe-1",
   "name": "temporal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001871",
-  "synonym": null
+  "synonym": [
+    "lobus temporalis"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vagalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vagalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vagalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000297)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000297#vagal-lobe",
+  "name": "vagal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000297",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibulolateralisLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000307) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000307#vestibulolateralis-lobe",
+  "name": "vestibulolateralis lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000307",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfCerebralLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter. Is part of the lobe of cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016527) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016527#white-matter-of-cerebral-lobe",
+  "name": "white matter of cerebral lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016527",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfFrontalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a frontal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016528#white-matter-of-frontal-lobe",
+  "name": "white matter of frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016528",
+  "synonym": [
+    "frontal lobe white matter"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfLimbicLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the limbic lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a limbic lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016536#white-matter-of-limbic-lobe",
+  "name": "white matter of limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016536",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfOccipitalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016535#white-matter-of-occipital-lobe",
+  "name": "white matter of occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016535",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfParietalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the parietal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a parietal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016531#white-matter-of-parietal-lobe",
+  "name": "white matter of parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016531",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/whiteMatterOfTemporalLobe",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the temporal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016534#white-matter-of-temporal-lobe",
+  "name": "white matter of temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016534",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/cephalopodOpticLobe.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cephalopodOpticLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Cephalopod optic lobe' is a visual processing part of nervous system. It is part of the brain.",
-  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963) .",
+  "definition": "Is a visual processing part of nervous system. Is part of the brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796) ('is_a' and 'relationship')]",
+  "description": "Large lobes of the brain associated with the eyes. In octopods and some squids the optic lobes may be separated from the rest of the brain by an optic stalk of varying length. In Octopus the optic lobes contain 92 million cells compared with only 42 million in the main central mass of the brain (J. Young, 1963). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006796)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0725883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006796#cephalopod-optic-lobe",
   "name": "cephalopod optic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006796",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/electrosensoryLateralLineLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/electrosensoryLateralLineLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a hindbrain nucleus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "description": "Anatomical structure located in the hindbrain that receives primary electroreceptor input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002105)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002105#electrosensory-lateral-line-lobe",
+  "name": "electrosensory lateral line lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002105",
+  "synonym": [
+    "ELL"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/facialLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/facialLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/facialLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000512)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000512#facial-lobe",
+  "name": "facial lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000512",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -4,20 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/flocculonodularLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Flocculonodular lobe' is a cerebellum lobe. It is part of the vestibulocerebellum.",
-  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [WP,unvetted].",
+  "definition": "Is a cerebellum lobe. Is part of the vestibulocerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012) ('is_a' and 'relationship')]",
+  "description": "The flocculonodular lobe is a lobe of the cerebellum consisting of the nodule and the flocculus. It is closely associated with the vestibulocerebellum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003012)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104286",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003012#flocculonodular-lobe-1",
   "name": "flocculonodular lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
-    "Archaeocerebellum",
-    "archicerebellum",
     "cerebellum flocculonodular lobe",
     "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
-    "posterior lobe-2 of cerebellum",
-    "vestibulocerebellum"
+    "posterior lobe-2 of cerebellum"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobe.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003012",
   "synonym": [
     "cerebellum flocculonodular lobe",
-    "flocculonodular lobe",
     "flocculonodular lobe of cerebellum",
     "lobus flocculonodularis",
     "posterior lobe-2 of cerebellum"

--- a/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/flocculonodularLobeHemispherePortion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Flocculonodular lobe, hemisphere portion' is a regional part of cerebellar cortex. It is part of the cerebellar hemisphere and flocculonodular lobe.",
+  "definition": "Is a regional part of cerebellar cortex. Is part of the cerebellar hemisphere and the flocculonodular lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0027331) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104947",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0027331#flocculonodular-lobe-hemisphere-portion",
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
-  "synonym": null
+  "synonym": [
+    "hemispheric part of the flocculonodular lobe of the cerebellum",
+    "hemispheric part of the flocculonodular lobe of the cerebellum"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/flocculonodularLobeHemispherePortion.jsonld
@@ -11,7 +11,6 @@
   "name": "flocculonodular lobe, hemisphere portion",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0027331",
   "synonym": [
-    "hemispheric part of the flocculonodular lobe of the cerebellum",
     "hemispheric part of the flocculonodular lobe of the cerebellum"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/frontalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/frontalLobe.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/frontalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Frontal lobe' is a lobe of cerebral hemisphere.",
-  "description": "The anterior part of the cerebral hemisphere. (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
+  "description": "Frontal lobe is the anterior-most of five lobes of the cerebral hemisphere. It is bounded by the central sulcus on its posterior border and by the longitudinal cerebral fissure on its medial border. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016525)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104451",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016525#frontal-lobe-1",
   "name": "frontal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016525",
   "synonym": [
-    "frontal cortex",
-    "frontal region",
     "lobi frontales",
-    "lobus frontalis",
-    "regio frontalis"
+    "lobus frontalis"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/glossopharyngealLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/glossopharyngealLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000517) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000517#glossopharyngeal-lobe",
+  "name": "glossopharyngeal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000517",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the dorsal zone of median tuberal portion of hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000165) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000165#inferior-lobe",
+  "name": "inferior lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000165",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002811)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002811#left-frontal-lobe-1",
+  "name": "left frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002811",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002804)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002804#left-limbic-lobe-1",
+  "name": "left limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002804",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002806)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002806#left-occipital-lobe-1",
+  "name": "left occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002806",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftParietalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the left hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002802)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002802#left-parietal-lobe-1",
+  "name": "left parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002802",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a left cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002808)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002808#left-temporal-lobe-1",
+  "name": "left temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002808",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/limbicLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/limbicLobe.jsonld
@@ -4,11 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/limbicLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem.",
-  "description": "'Limbic lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
+  "description": "Part of cerebral hemisphere located on the medial surface, forming a ring around the brain stem. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002600)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106264",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002600#limbic-lobe-1",
   "name": "limbic lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002600",
-  "synonym": null
+  "synonym": [
+    "fornicate gyrus",
+    "grande lobe limbique of Broca",
+    "limbic lobe (carpenter)"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lobeOfCerebralHemisphere.jsonld
@@ -4,22 +4,18 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lobeOfCerebralHemisphere",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lobe of cerebral hemisphere' is part of the cerebral hemisphere.",
-  "description": "Divisions of the cerebral cortex from gross anatomical observation based on the locations of major sulci and fissures in gyrencephalic animals, including both the gray matter and underlying white matter. From 4-6 lobes have been defined.",
+  "definition": "Is part of the cerebral hemisphere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
+  "description": "Subdivision of telencephalon which is one of a number of subdivisions of each hemisphere separated by both real landmarks (sulci and fissures) and arbitrary boundaries. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016526)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106316",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016526#lobe-of-cerebral-cortex",
   "name": "lobe of cerebral hemisphere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016526",
   "synonym": [
-    "cerebral cortical segment",
     "cerebral hemisphere lobe",
     "cerebral lobe",
-    "cerebral lobes",
     "lobe of cerebral cortex",
     "lobe parts of cerebral cortex",
-    "lobes of the brain",
-    "lobi cerebri",
-    "regional organ part of cerebral cortex",
-    "segment of cerebral cortex"
+    "lobi cerebri"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/medialCaudalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialCaudalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the vestibulolateralis lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000388) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000388#medial-caudal-lobe",
+  "name": "medial caudal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000388",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/neuralLobeOfNeurohypophysis.jsonld
@@ -4,23 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/neuralLobeOfNeurohypophysis",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [WP,unvetted].",
-  "description": "'Neural lobe of neurohypophysis' is a regional part of brain. It is part of the neurohypophysis.",
+  "definition": "Is a regional part of brain. Is part of the neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217) ('is_a' and 'relationship')]",
+  "description": "The posterior pituitary (or neurohypophysis) comprises the posterior lobe of the pituitary gland and is part of the endocrine system. Despite its name, the posterior pituitary gland is not a gland, per se; rather, it is largely a collection of axonal projections from the hypothalamus that terminate behind the anterior pituitary gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003217)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108544",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003217#pars-nervosa-of-hypophysis",
   "name": "neural lobe of neurohypophysis",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003217",
   "synonym": [
-    "caudal lobe",
-    "eminentia medialis (Shantha)",
-    "eminentia mediana",
-    "eminentia postinfundibularis",
-    "lobe caudalis cerebelli",
     "lobus nervosus (Neurohypophysis)",
-    "medial eminence",
-    "middle lobe",
-    "neural component of pituitary",
-    "pars nervosa",
     "pars nervosa (hypophysis)",
     "pars nervosa (neurohypophysis)",
     "pars nervosa neurohypophysis",
@@ -31,12 +22,8 @@
     "pars nervosa pituitary gland",
     "pars posterior",
     "pars posterior of hypophysis",
-    "pituitary gland",
-    "PNHP",
-    "posterior lobe",
     "posterior lobe of neurohypophysis",
-    "posterior lobe of pituitary",
-    "posterior lobe-3",
-    "posterior pituitary"
+    "posterior lobe-3"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/occipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/occipitalLobe.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Occipital lobe' is a lobe of cerebral hemisphere.",
-  "description": "Posterior part of the cerebral hemisphere (MSH)",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
+  "description": "Posterior part of the cerebral hemisphere (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002021)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0107883",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002021#occipital-lobe-1",
   "name": "occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002021",
   "synonym": [
-    "lobus occipitalis",
     "regio occipitalis"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/parietalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/parietalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Upper central part of the cerebral hemisphere. (MSH).",
-  "description": "'Parietal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
+  "description": "Upper central part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001872)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108534",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001872#parietal-lobe-1",
   "name": "parietal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001872",
-  "synonym": null
+  "synonym": [
+    "regio parietalis"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightFrontalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a frontal cortex. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810) ('is_a' and 'relationship')]",
+  "description": "A frontal cortex that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002810)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002810#right-frontal-lobe-1",
+  "name": "right frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002810",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a limbic lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805) ('is_a' and 'relationship')]",
+  "description": "A limbic lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002805)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002805#right-limbic-lobe-1",
+  "name": "right limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002805",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an occipital lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807) ('is_a' and 'relationship')]",
+  "description": "An occipital lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002807)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002807#right-occipital-lobe-1",
+  "name": "right occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002807",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightParietalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a parietal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803) ('is_a' and 'relationship')]",
+  "description": "Parietal lobe of the right hemisphere of the brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002803)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002803#right-parietal-lobe-1",
+  "name": "right parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002803",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a temporal lobe. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809) ('is_a' and 'relationship')]",
+  "description": "A temporal lobe that is part of a right cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002809)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002809#right-temporal-lobe-1",
+  "name": "right temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002809",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
-  "synonym": [
-    "superficial feature part of occipital lobe",
-    "superficial feature part of occipital lobe"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/superficialFeaturePartOfOccipitalLobe.jsonld
@@ -4,13 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superficialFeaturePartOfOccipitalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Superficial feature part of occipital lobe' is a regional part of brain. It is part of the occipital lobe.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023462) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111268",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023462#superficial-feature-part-of-occipital-lobe-1",
   "name": "superficial feature part of occipital lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023462",
   "synonym": [
+    "superficial feature part of occipital lobe",
     "superficial feature part of occipital lobe"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/temporalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/temporalLobe.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/temporalLobe",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "Lower lateral part of the cerebral hemisphere. (MSH).",
-  "description": "'Temporal lobe' is a lobe of cerebral hemisphere.",
+  "definition": "Is a lobe of cerebral hemisphere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
+  "description": "Lower lateral part of the cerebral hemisphere. (MSH) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001871)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111590",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001871#temporal-lobe-1",
   "name": "temporal lobe",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001871",
-  "synonym": null
+  "synonym": [
+    "lobus temporalis"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vagalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vagalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vagalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nucleus of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000297)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000297#vagal-lobe",
+  "name": "vagal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000297",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibulolateralisLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulolateralisLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the cerebellum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000307) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000307#vestibulolateralis-lobe",
+  "name": "vestibulolateralis lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000307",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfCerebralLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfCerebralLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter. Is part of the lobe of cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016527) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016527#white-matter-of-cerebral-lobe",
+  "name": "white matter of cerebral lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016527",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfFrontalLobe.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfFrontalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the frontal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a frontal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016528)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016528#white-matter-of-frontal-lobe",
+  "name": "white matter of frontal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016528",
+  "synonym": [
+    "frontal lobe white matter"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfLimbicLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfLimbicLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the limbic lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a limbic lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016536)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016536#white-matter-of-limbic-lobe",
+  "name": "white matter of limbic lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016536",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfOccipitalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfOccipitalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016535)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016535#white-matter-of-occipital-lobe",
+  "name": "white matter of occipital lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016535",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfParietalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfParietalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the parietal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a parietal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016531)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016531#white-matter-of-parietal-lobe",
+  "name": "white matter of parietal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016531",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/whiteMatterOfTemporalLobe.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/whiteMatterOfTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of cerebral lobe. Is part of the temporal lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534) ('is_a' and 'relationship')]",
+  "description": "A white matter of cerebral lobe that is part of a temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0016534)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0016534#white-matter-of-temporal-lobe",
+  "name": "white matter of temporal lobe",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0016534",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'lobe' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.