### PR TITLE
UBERON terms with 'ventricle' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
-    "anterior horn of lateral ventricle",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",

--- a/instances/latest/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorHornOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Anterior horn of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
+  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100702",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002651#anterior-horn-of-lateral-ventricle-1",
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
     "anterior horn of lateral ventricle",
-    "cornu anterius",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",
     "cornu frontale ventriculi lateralis",
     "frontal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu anterius"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/bodyOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Body of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
+  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101374",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002655#body-of-lateral-ventricle-1",
   "name": "body of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002655",
   "synonym": [
     "central part of lateral ventricle",
-    "corpus",
     "corpus ventriculi lateralis",
     "lateral ventricular body",
-    "pars centralis",
     "pars centralis (ventriculi lateralis)",
     "pars centralis ventriculi lateralis",
-    "ventriculus lateralis"
+    "ventriculus lateralis, corpus",
+    "ventriculus lateralis, pars centralis"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/brainVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/brainVentricle.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Brain ventricle' is a brain ventricle/choroid plexus and ventricle of nervous system. It is part of the ventricular system of brain.",
-  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid.",
+  "definition": "Is a brain ventricle/choroid plexus and ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086) ('is_a' and 'relationship')]",
+  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730602",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004086#cerebral-ventricular-cavity",
   "name": "brain ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004086",
-  "synonym": null
+  "synonym": [
+    "cerebral ventricle",
+    "region of ventricular system of brain"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
@@ -2,13 +2,14 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentriclechoroidPlexus",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentricleChoroidPlexus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Brain ventricle/choroid plexus' is part of the brain.",
-  "description": "The brain ventricles or their associated choroid plexuses.",
+  "definition": "Is part of the brain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
+  "description": "The brain ventricles or their associated choroid plexuses. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730467",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003947#brain-ventricle-choroid-plexus",
   "name": "brain ventricle/choroid plexus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003947",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/calcarAvisOfTheLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalic ventricle and the hippocampal formation. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970) ('is_a' and 'relationship')]",
+  "description": "On the medial wall of the posterior cornu of the lateral ventricle is a longitudinal eminence, the calcar avis (hippocampus minor), which is an involution of the ventricular wall produced by the calcarine fissure. It is sometimes visible on ultrasonogram. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035970#calcar-avis-of-the-lateral-ventricle",
+  "name": "calcar avis of the lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035970",
+  "synonym": [
+    "hippocampus minor"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of fourth ventricle' is a choroid plexus and cerebellum vasculature. It is part of the fourth ventricle.",
-  "description": "Choroid plexus of the fourth ventricle",
+  "definition": "Is a choroid plexus and cerebellum vasculature. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290) ('is_a' and 'relationship')]",
+  "description": "Choroid plexus of the fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102143",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002290#choroid-plexus-of-fourth-ventricle",
   "name": "choroid plexus of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002290",
   "synonym": [
-    "4th ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of fourth ventricle",
     "chorioid plexus of fourth ventricle",
     "choroid plexus fourth ventricle",
@@ -19,3 +18,4 @@
     "fourth ventricle choroid plexus"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of lateral ventricle' is a choroid plexus. It is part of the telencephalic ventricle.",
-  "description": "Part of choroid plexus contained in the lateral ventricle",
+  "definition": "Is a choroid plexus. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102144",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002307#choroid-plexus-of-lateral-ventricle",
   "name": "choroid plexus of lateral ventricle",
@@ -18,3 +18,4 @@
     "lateral ventricle choroid plexus"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfTectalVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus that is part of a cerebral aqueduct. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007299#choroid-plexus-of-tectal-ventricle",
+  "name": "choroid plexus of tectal ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007299",
+  "synonym": [
+    "choroid plexus tectal ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfThirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of third ventricle' is a choroid plexus. It is part of the third ventricle.",
-  "description": "Part of choroid plexus contained in the third ventricle",
+  "definition": "Is a choroid plexus. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102145",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002288#choroid-plexus-of-third-ventricle",
   "name": "choroid plexus of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002288",
   "synonym": [
-    "3rd ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of third ventricle",
     "chorioid plexus of third ventricle",
     "choroid plexus third ventricle",
@@ -20,3 +19,4 @@
     "third ventricle choroid plexus"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricle.jsonld
@@ -4,22 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle' is a brain ventricle. It is part of the hindbrain.",
-  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures.",
+  "definition": "Is a brain ventricle. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104381",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002422#fourth-ventricle",
   "name": "fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002422",
   "synonym": [
-    "4th ventricle",
-    "fourth ventricle proper",
-    "hindbrain ventricle",
-    "IVth ventricle",
-    "rhombencephalic ventricle",
-    "rhombencephalic vesicle",
-    "ventricle IV",
-    "ventricle of hindbrain",
-    "ventricle of rhombencephalon",
-    "ventriculus quartus"
+    "ventricle IV"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleAperture",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle aperture' is part of the fourth ventricle.",
-  "description": "One of:  the 4th ventricle median or lateral apertures.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
+  "description": "One of: the 4th ventricle median or lateral apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735066",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004668#fourth-ventricle-aperture",
   "name": "fourth ventricle aperture",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004668",
-  "synonym": null
+  "synonym": [
+    "aperture of 4th ventricle",
+    "aperture of fourth ventricle"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
@@ -4,11 +4,28 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus epithelium' is a choroid plexus epithelium. It is part of the choroid plexus of fourth ventricle.",
-  "description": null,
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728876",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004276#fourth-ventricle-choroid-plexus-epithelium",
   "name": "fourth ventricle choroid plexus epithelium",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004276",
-  "synonym": null
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of fourth ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of fourth ventricle",
+    "choroid plexus epithelial tissue of fourth ventricle",
+    "choroid plexus epithelium of fourth ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelial tissue of choroid plexus of fourth ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelium of choroid plexus of fourth ventricle",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "fourth ventricle choroid plexus epithelial tissue",
+    "fourth ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelial tissue of choroid plexus",
+    "fourth ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelium of choroid plexus"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleChoroidPlexusStroma",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus stroma' is a choroid plexus stroma. It is part of the choroid plexus of fourth ventricle.",
-  "description": "A choroid plexus stroma that is part of a fourth ventricle.",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726195",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006340#fourth-ventricle-choroid-plexus-stroma",
   "name": "fourth ventricle choroid plexus stroma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006340",
   "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleEpendyma",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle ependyma' is a brain ependyma. It is part of the fourth ventricle.",
-  "description": null,
+  "definition": "Is a brain ependyma. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729148",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004644#fourth-ventricle-ependyma",
   "name": "fourth ventricle ependyma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004644",
-  "synonym": null
+  "synonym": [
+    "ependyma of fourth ventricle"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleLateralAperture",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "description": "One of the two lateral openings of the fourth ventricle into the subarachnoid space at the cerebellopontine angle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003992#fourth-ventricle-lateral-aperture",
+  "name": "fourth ventricle lateral aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003992",
+  "synonym": [
+    "apertura lateralis",
+    "foramen of key and retzius",
+    "foramen of Key-Retzius",
+    "foramen of Luschka",
+    "foramen of Retzius",
+    "lateral aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -14,7 +14,6 @@
     "apertura mediana",
     "foramen of Magendie",
     "foramen of Majendie",
-    "fourth ventricle median aperture",
     "median aperture of fourth ventricle"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleMedianAperture",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "description": "The large midline opening of the posterior inferior part of the roof of the fourth ventricle that connects the fourth ventricle to the posterior cerebromedullary cistern and the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003991#fourth-ventricle-median-aperture",
+  "name": "fourth ventricle median aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003991",
+  "synonym": [
+    "apertura mediana",
+    "foramen of Magendie",
+    "foramen of Majendie",
+    "fourth ventricle median aperture",
+    "median aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -4,22 +4,22 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorHornOfTheLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Inferior horn of the lateral ventricle' is part of the telencephalic ventricle.",
-  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe.",
+  "definition": "Is part of the telencephalic ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
+  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105444",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006091#inferior-horn-of-the-lateral-ventricle-1",
   "name": "inferior horn of the lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006091",
   "synonym": [
-    "cornu inferius",
     "cornu inferius (ventriculi lateralis)",
     "cornu inferius ventriculi lateralis",
-    "cornu temporale",
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
     "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu inferius",
+    "ventriculus lateralis, cornu temporale"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -16,7 +16,6 @@
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
-    "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
     "ventriculus lateralis, cornu inferius",
     "ventriculus lateralis, cornu temporale"

--- a/instances/latest/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/infundibularRecessOf3rdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the third ventricle and the future neurohypophysis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "description": "A funnel-shaped diverticulum that extends downward from the anterior aspect of the floor of the third ventricle into the infundibulum of the hypophysis; the embryonic structure gives rise the neural component of the pituitary (pas nervosa). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006250#infundibular-recess-of-3rd-ventricle",
+  "name": "infundibular recess of 3rd ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006250",
+  "synonym": [
+    "infundibular recess",
+    "infundibular recess of third ventricle",
+    "recessus infundibularis",
+    "recessus infundibuli"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralEminenceOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lateral eminence of fourth ventricle' is part of the fourth ventricle.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034672)]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0734681",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": null
+  "synonym": [
+    "lateral eminence of fourth ventricle"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": [
-    "lateral eminence of fourth ventricle"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralRecessOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lateral recess of fourth ventricle' is an anatomical entity. It is part of the fourth ventricle.",
-  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space.",
+  "definition": "Is an anatomical entity. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656) ('is_a' and 'relationship')]",
+  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736090",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007656#lateral-recess-of-fourth-ventricle",
   "name": "lateral recess of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007656",
-  "synonym": null
+  "synonym": [
+    "recessus lateralis (ventriculi quarti)"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004274#lateral-ventricle-choroid-plexus-epithelium",
+  "name": "lateral ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004274",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of lateral ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of lateral ventricle",
+    "choroid plexus epithelial tissue of lateral ventricle",
+    "choroid plexus epithelium of lateral ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelial tissue of choroid plexus of lateral ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelium of choroid plexus of lateral ventricle",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "lateral ventricle choroid plexus epithelial tissue",
+    "lateral ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelial tissue of choroid plexus",
+    "lateral ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006338#lateral-ventricle-choroid-plexus-stroma",
+  "name": "lateral ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006338",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004643#lateral-ventricle-ependyma",
+  "name": "lateral ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004643",
+  "synonym": [
+    "ependyma of lateral ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the left side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013161#left-lateral-ventricle",
+  "name": "left lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013161",
+  "synonym": [
+    "left telencephalic ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/opticRecessOfThirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Optic recess of third ventricle' is an anatomical entity. It is part of the third ventricle.",
-  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287) ('is_a' and 'relationship')]",
+  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108073",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002287#optic-recess-of-third-ventricle-1",
   "name": "optic recess of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002287",
   "synonym": [
     "optic recess",
-    "optic recesses",
     "preoptic recess",
-    "recessus opticus",
-    "recessus praeopticus",
     "recessus supraopticus",
     "supraoptic recess"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pinealRecessOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283) ('is_a' and 'relationship')]",
+  "description": "The diverticulum of the thin roof of the dorsocaudal third ventricle that projects into the stalk of the pineal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022283#pineal-recess-of-third-ventricle",
+  "name": "pineal recess of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022283",
+  "synonym": [
+    "pineal recess",
+    "pineal recess of 3V",
+    "recessus pinealis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -17,7 +17,6 @@
     "cornu posterius ventriculi lateralis",
     "occipital horn",
     "occipital horn of lateral ventricle",
-    "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
     "ventriculus lateralis, cornu occipitale",

--- a/instances/latest/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorHornLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior horn lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe.",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
+  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109097",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004672#posterior-horn-lateral-ventricle-1",
   "name": "posterior horn lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004672",
   "synonym": [
-    "cornu occipitale",
     "cornu occipitale (ventriculi lateralis)",
     "cornu occipitale ventriculi lateralis",
-    "cornu posterius",
     "cornu posterius (ventriculi lateralis)",
     "cornu posterius ventriculi lateralis",
     "occipital horn",
@@ -22,6 +20,8 @@
     "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu occipitale",
+    "ventriculus lateralis, cornu posterius"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the right side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013162#right-lateral-ventricle",
+  "name": "right lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013162",
+  "synonym": [
+    "right telencephalic ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -4,11 +4,19 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tela choroidea of fourth ventricle' is a tela choroidea. It is part of the fourth ventricle.",
-  "description": "Tela chorioidea that lines the fourth ventricle[ZFA]. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout:  The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla[WP].",
+  "definition": "Is a tela choroidea. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the fourth ventricle. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout: The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727490",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005287#tela-choroidea-of-fourth-ventricle",
   "name": "tela choroidea of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005287",
-  "synonym": null
+  "synonym": [
+    "choroid membrane",
+    "choroid membrane of fourth ventricle",
+    "tela chorioidea fourth ventricle",
+    "tela choroidea fourth ventricle",
+    "tela choroidea of fourth ventricle",
+    "tela choroidea ventriculi quarti"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -15,7 +15,6 @@
     "choroid membrane of fourth ventricle",
     "tela chorioidea fourth ventricle",
     "tela choroidea fourth ventricle",
-    "tela choroidea of fourth ventricle",
     "tela choroidea ventriculi quarti"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfTelencephalicVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the telencephalic ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005289#tela-choroidea-of-telencephalic-ventricle",
+  "name": "tela choroidea of telencephalic ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005289",
+  "synonym": [
+    "tela chorioidea of lateral ventricle",
+    "tela chorioidea of telencephalic ventricle",
+    "tela chorioidea telencephalic ventricle",
+    "tela choroidea (ventriculi lateralis)",
+    "tela choroidea of lateral ventricle",
+    "tela choroidea telencephalic ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the third ventricle. The part of the choroid plexus in relation to the body of the ventricle forms the vascular fringed margin of a triangular process of pia mater, named the tela chorioidea of the third ventricle, and projects from under cover of the lateral edge of the fornix. Blood is supplied by branches from the superior cerebellar artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005288#tela-choroidea-of-third-ventricle",
+  "name": "tela choroidea of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005288",
+  "synonym": [
+    "choroid membrane of third ventricle",
+    "tela chorioidea of third ventricle",
+    "tela chorioidea third ventricle",
+    "tela choroidea third ventricle",
+    "tela choroidea ventriculi tertii"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
     "lateral ventricle",
-    "telencephalic ventricle",
     "telencephalon lateral ventricle"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -4,22 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Telencephalic ventricle' is a brain ventricle. It is part of the telencephalon.",
-  "description": "Part of the ventricular system of the brain in each of the cerebral hemispheres. The lateral ventricle in each hemisphere is separated from the other by the septum and each communicates with the THIRD VENTRICLE by the foramen of Monro, In species, particularly those with well developed cortex, the lateral ventrical may be subdivided into anterior, posterior and temporal horns and a body",
+  "definition": "Is a brain ventricle. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285) ('is_a' and 'relationship')]",
+  "description": "A brain ventricle that is part of a telencephalon. In mammals and species with an evaginated telencephalon, this is one of a pair of lateral structures, one in each hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106125",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002285#lateral-ventricle",
   "name": "telencephalic ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
-    "forebrain ventricle",
     "lateral ventricle",
-    "lateral ventricle of brain",
-    "lateral ventricles",
-    "LV",
-    "tectal ventricle",
     "telencephalic ventricle",
-    "telencephalic ventricles",
-    "telencephalic vesicle",
     "telencephalon lateral ventricle"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdVentricle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdVentricle.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Third ventricle' is a brain ventricle. It is part of the diencephalon.",
-  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon;  it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone.  It is bounded anteriorly by the lamina terminalis;  much of the medial surface is formed by the thalamus and hypothalamus;  part of the hypothalamus forms its floor (Nolte, the Human Brain, 6th ed., 2009, pg 101).",
+  "definition": "Is a brain ventricle. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon; it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111707",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002286#third-ventricle-1",
   "name": "third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002286",
   "synonym": [
     "3rd ventricle",
-    "3V",
-    "diencephalic ventricle",
-    "diencephalic vesicle",
-    "ventriculus diencephali",
-    "ventriculus tertius cerebri"
+    "ventriculus diencephali"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004275#third-ventricle-choroid-plexus-epithelium",
+  "name": "third ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004275",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of third ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of third ventricle",
+    "choroid plexus epithelial tissue of third ventricle",
+    "choroid plexus epithelium of third ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelial tissue of choroid plexus of third ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelium of choroid plexus of third ventricle",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "third ventricle choroid plexus epithelial tissue",
+    "third ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelial tissue of choroid plexus",
+    "third ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006339#third-ventricle-choroid-plexus-stroma",
+  "name": "third ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006339",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004642#third-ventricle-ependyma",
+  "name": "third ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004642",
+  "synonym": [
+    "3rd ventricle ependyma",
+    "ependyma of third ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
-    "anterior horn of lateral ventricle",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",

--- a/instances/v3.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/anteriorHornOfLateralVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Anterior horn of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
+  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100702",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002651#anterior-horn-of-lateral-ventricle-1",
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
     "anterior horn of lateral ventricle",
-    "cornu anterius",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",
     "cornu frontale ventriculi lateralis",
     "frontal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu anterius"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/bodyOfLateralVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Body of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
+  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101374",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002655#body-of-lateral-ventricle-1",
   "name": "body of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002655",
   "synonym": [
     "central part of lateral ventricle",
-    "corpus",
     "corpus ventriculi lateralis",
     "lateral ventricular body",
-    "pars centralis",
     "pars centralis (ventriculi lateralis)",
     "pars centralis ventriculi lateralis",
-    "ventriculus lateralis"
+    "ventriculus lateralis, corpus",
+    "ventriculus lateralis, pars centralis"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/brainVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/brainVentricle.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/brainVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Brain ventricle' is a brain ventricle/choroid plexus and ventricle of nervous system. It is part of the ventricular system of brain.",
-  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid.",
+  "definition": "Is a brain ventricle/choroid plexus and ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086) ('is_a' and 'relationship')]",
+  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730602",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004086#cerebral-ventricular-cavity",
   "name": "brain ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004086",
-  "synonym": null
+  "synonym": [
+    "cerebral ventricle",
+    "region of ventricular system of brain"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
@@ -2,13 +2,14 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/brainVentriclechoroidPlexus",
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/brainVentricleChoroidPlexus",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Brain ventricle/choroid plexus' is part of the brain.",
-  "description": "The brain ventricles or their associated choroid plexuses.",
+  "definition": "Is part of the brain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
+  "description": "The brain ventricles or their associated choroid plexuses. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730467",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003947#brain-ventricle-choroid-plexus",
   "name": "brain ventricle/choroid plexus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003947",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/calcarAvisOfTheLateralVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalic ventricle and the hippocampal formation. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970) ('is_a' and 'relationship')]",
+  "description": "On the medial wall of the posterior cornu of the lateral ventricle is a longitudinal eminence, the calcar avis (hippocampus minor), which is an involution of the ventricular wall produced by the calcarine fissure. It is sometimes visible on ultrasonogram. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035970#calcar-avis-of-the-lateral-ventricle",
+  "name": "calcar avis of the lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035970",
+  "synonym": [
+    "hippocampus minor"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/choroidPlexusOfFourthVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Choroid plexus of fourth ventricle' is a choroid plexus and cerebellum vasculature. It is part of the fourth ventricle.",
-  "description": "Choroid plexus of the fourth ventricle",
+  "definition": "Is a choroid plexus and cerebellum vasculature. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290) ('is_a' and 'relationship')]",
+  "description": "Choroid plexus of the fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102143",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002290#choroid-plexus-of-fourth-ventricle",
   "name": "choroid plexus of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002290",
   "synonym": [
-    "4th ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of fourth ventricle",
     "chorioid plexus of fourth ventricle",
     "choroid plexus fourth ventricle",
@@ -19,3 +18,4 @@
     "fourth ventricle choroid plexus"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/choroidPlexusOfLateralVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Choroid plexus of lateral ventricle' is a choroid plexus. It is part of the telencephalic ventricle.",
-  "description": "Part of choroid plexus contained in the lateral ventricle",
+  "definition": "Is a choroid plexus. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102144",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002307#choroid-plexus-of-lateral-ventricle",
   "name": "choroid plexus of lateral ventricle",
@@ -18,3 +18,4 @@
     "lateral ventricle choroid plexus"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/choroidPlexusOfTectalVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a choroid plexus. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus that is part of a cerebral aqueduct. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007299#choroid-plexus-of-tectal-ventricle",
+  "name": "choroid plexus of tectal ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007299",
+  "synonym": [
+    "choroid plexus tectal ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/choroidPlexusOfThirdVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Choroid plexus of third ventricle' is a choroid plexus. It is part of the third ventricle.",
-  "description": "Part of choroid plexus contained in the third ventricle",
+  "definition": "Is a choroid plexus. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102145",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002288#choroid-plexus-of-third-ventricle",
   "name": "choroid plexus of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002288",
   "synonym": [
-    "3rd ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of third ventricle",
     "chorioid plexus of third ventricle",
     "choroid plexus third ventricle",
@@ -20,3 +19,4 @@
     "third ventricle choroid plexus"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricle.jsonld
@@ -4,22 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Fourth ventricle' is a brain ventricle. It is part of the hindbrain.",
-  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures.",
+  "definition": "Is a brain ventricle. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104381",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002422#fourth-ventricle",
   "name": "fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002422",
   "synonym": [
-    "4th ventricle",
-    "fourth ventricle proper",
-    "hindbrain ventricle",
-    "IVth ventricle",
-    "rhombencephalic ventricle",
-    "rhombencephalic vesicle",
-    "ventricle IV",
-    "ventricle of hindbrain",
-    "ventricle of rhombencephalon",
-    "ventriculus quartus"
+    "ventricle IV"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleAperture",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Fourth ventricle aperture' is part of the fourth ventricle.",
-  "description": "One of:  the 4th ventricle median or lateral apertures.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
+  "description": "One of: the 4th ventricle median or lateral apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735066",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004668#fourth-ventricle-aperture",
   "name": "fourth ventricle aperture",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004668",
-  "synonym": null
+  "synonym": [
+    "aperture of 4th ventricle",
+    "aperture of fourth ventricle"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
@@ -4,11 +4,28 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus epithelium' is a choroid plexus epithelium. It is part of the choroid plexus of fourth ventricle.",
-  "description": null,
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728876",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004276#fourth-ventricle-choroid-plexus-epithelium",
   "name": "fourth ventricle choroid plexus epithelium",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004276",
-  "synonym": null
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of fourth ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of fourth ventricle",
+    "choroid plexus epithelial tissue of fourth ventricle",
+    "choroid plexus epithelium of fourth ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelial tissue of choroid plexus of fourth ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelium of choroid plexus of fourth ventricle",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "fourth ventricle choroid plexus epithelial tissue",
+    "fourth ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelial tissue of choroid plexus",
+    "fourth ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelium of choroid plexus"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleChoroidPlexusStroma",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus stroma' is a choroid plexus stroma. It is part of the choroid plexus of fourth ventricle.",
-  "description": "A choroid plexus stroma that is part of a fourth ventricle.",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726195",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006340#fourth-ventricle-choroid-plexus-stroma",
   "name": "fourth ventricle choroid plexus stroma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006340",
   "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleEpendyma",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Fourth ventricle ependyma' is a brain ependyma. It is part of the fourth ventricle.",
-  "description": null,
+  "definition": "Is a brain ependyma. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729148",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004644#fourth-ventricle-ependyma",
   "name": "fourth ventricle ependyma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004644",
-  "synonym": null
+  "synonym": [
+    "ependyma of fourth ventricle"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleLateralAperture",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "description": "One of the two lateral openings of the fourth ventricle into the subarachnoid space at the cerebellopontine angle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003992#fourth-ventricle-lateral-aperture",
+  "name": "fourth ventricle lateral aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003992",
+  "synonym": [
+    "apertura lateralis",
+    "foramen of key and retzius",
+    "foramen of Key-Retzius",
+    "foramen of Luschka",
+    "foramen of Retzius",
+    "lateral aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -14,7 +14,6 @@
     "apertura mediana",
     "foramen of Magendie",
     "foramen of Majendie",
-    "fourth ventricle median aperture",
     "median aperture of fourth ventricle"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/fourthVentricleMedianAperture",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "description": "The large midline opening of the posterior inferior part of the roof of the fourth ventricle that connects the fourth ventricle to the posterior cerebromedullary cistern and the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003991#fourth-ventricle-median-aperture",
+  "name": "fourth ventricle median aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003991",
+  "synonym": [
+    "apertura mediana",
+    "foramen of Magendie",
+    "foramen of Majendie",
+    "fourth ventricle median aperture",
+    "median aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -16,7 +16,6 @@
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
-    "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
     "ventriculus lateralis, cornu inferius",
     "ventriculus lateralis, cornu temporale"

--- a/instances/v3.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -4,22 +4,22 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/inferiorHornOfTheLateralVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Inferior horn of the lateral ventricle' is part of the telencephalic ventricle.",
-  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe.",
+  "definition": "Is part of the telencephalic ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
+  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105444",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006091#inferior-horn-of-the-lateral-ventricle-1",
   "name": "inferior horn of the lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006091",
   "synonym": [
-    "cornu inferius",
     "cornu inferius (ventriculi lateralis)",
     "cornu inferius ventriculi lateralis",
-    "cornu temporale",
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
     "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu inferius",
+    "ventriculus lateralis, cornu temporale"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/infundibularRecessOf3rdVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the third ventricle and the future neurohypophysis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "description": "A funnel-shaped diverticulum that extends downward from the anterior aspect of the floor of the third ventricle into the infundibulum of the hypophysis; the embryonic structure gives rise the neural component of the pituitary (pas nervosa). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006250#infundibular-recess-of-3rd-ventricle",
+  "name": "infundibular recess of 3rd ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006250",
+  "synonym": [
+    "infundibular recess",
+    "infundibular recess of third ventricle",
+    "recessus infundibularis",
+    "recessus infundibuli"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralEminenceOfFourthVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Lateral eminence of fourth ventricle' is part of the fourth ventricle.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034672)]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0734681",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": null
+  "synonym": [
+    "lateral eminence of fourth ventricle"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": [
-    "lateral eminence of fourth ventricle"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralRecessOfFourthVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Lateral recess of fourth ventricle' is an anatomical entity. It is part of the fourth ventricle.",
-  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space.",
+  "definition": "Is an anatomical entity. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656) ('is_a' and 'relationship')]",
+  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736090",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007656#lateral-recess-of-fourth-ventricle",
   "name": "lateral recess of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007656",
-  "synonym": null
+  "synonym": [
+    "recessus lateralis (ventriculi quarti)"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004274#lateral-ventricle-choroid-plexus-epithelium",
+  "name": "lateral ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004274",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of lateral ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of lateral ventricle",
+    "choroid plexus epithelial tissue of lateral ventricle",
+    "choroid plexus epithelium of lateral ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelial tissue of choroid plexus of lateral ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelium of choroid plexus of lateral ventricle",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "lateral ventricle choroid plexus epithelial tissue",
+    "lateral ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelial tissue of choroid plexus",
+    "lateral ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006338#lateral-ventricle-choroid-plexus-stroma",
+  "name": "lateral ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006338",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralVentricleEpendyma",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004643#lateral-ventricle-ependyma",
+  "name": "lateral ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004643",
+  "synonym": [
+    "ependyma of lateral ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/leftLateralVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the left side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013161#left-lateral-ventricle",
+  "name": "left lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013161",
+  "synonym": [
+    "left telencephalic ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/opticRecessOfThirdVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Optic recess of third ventricle' is an anatomical entity. It is part of the third ventricle.",
-  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287) ('is_a' and 'relationship')]",
+  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108073",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002287#optic-recess-of-third-ventricle-1",
   "name": "optic recess of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002287",
   "synonym": [
     "optic recess",
-    "optic recesses",
     "preoptic recess",
-    "recessus opticus",
-    "recessus praeopticus",
     "recessus supraopticus",
     "supraoptic recess"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pinealRecessOfThirdVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283) ('is_a' and 'relationship')]",
+  "description": "The diverticulum of the thin roof of the dorsocaudal third ventricle that projects into the stalk of the pineal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022283#pineal-recess-of-third-ventricle",
+  "name": "pineal recess of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022283",
+  "synonym": [
+    "pineal recess",
+    "pineal recess of 3V",
+    "recessus pinealis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -17,7 +17,6 @@
     "cornu posterius ventriculi lateralis",
     "occipital horn",
     "occipital horn of lateral ventricle",
-    "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
     "ventriculus lateralis, cornu occipitale",

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorHornLateralVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Posterior horn lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe.",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
+  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109097",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004672#posterior-horn-lateral-ventricle-1",
   "name": "posterior horn lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004672",
   "synonym": [
-    "cornu occipitale",
     "cornu occipitale (ventriculi lateralis)",
     "cornu occipitale ventriculi lateralis",
-    "cornu posterius",
     "cornu posterius (ventriculi lateralis)",
     "cornu posterius ventriculi lateralis",
     "occipital horn",
@@ -22,6 +20,8 @@
     "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu occipitale",
+    "ventriculus lateralis, cornu posterius"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rightLateralVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the right side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013162#right-lateral-ventricle",
+  "name": "right lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013162",
+  "synonym": [
+    "right telencephalic ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -15,7 +15,6 @@
     "choroid membrane of fourth ventricle",
     "tela chorioidea fourth ventricle",
     "tela choroidea fourth ventricle",
-    "tela choroidea of fourth ventricle",
     "tela choroidea ventriculi quarti"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -4,11 +4,19 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telaChoroideaOfFourthVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Tela choroidea of fourth ventricle' is a tela choroidea. It is part of the fourth ventricle.",
-  "description": "Tela chorioidea that lines the fourth ventricle[ZFA]. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout:  The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla[WP].",
+  "definition": "Is a tela choroidea. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the fourth ventricle. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout: The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727490",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005287#tela-choroidea-of-fourth-ventricle",
   "name": "tela choroidea of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005287",
-  "synonym": null
+  "synonym": [
+    "choroid membrane",
+    "choroid membrane of fourth ventricle",
+    "tela chorioidea fourth ventricle",
+    "tela choroidea fourth ventricle",
+    "tela choroidea of fourth ventricle",
+    "tela choroidea ventriculi quarti"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telaChoroideaOfTelencephalicVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the telencephalic ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005289#tela-choroidea-of-telencephalic-ventricle",
+  "name": "tela choroidea of telencephalic ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005289",
+  "synonym": [
+    "tela chorioidea of lateral ventricle",
+    "tela chorioidea of telencephalic ventricle",
+    "tela chorioidea telencephalic ventricle",
+    "tela choroidea (ventriculi lateralis)",
+    "tela choroidea of lateral ventricle",
+    "tela choroidea telencephalic ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telaChoroideaOfThirdVentricle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the third ventricle. The part of the choroid plexus in relation to the body of the ventricle forms the vascular fringed margin of a triangular process of pia mater, named the tela chorioidea of the third ventricle, and projects from under cover of the lateral edge of the fornix. Blood is supplied by branches from the superior cerebellar artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005288#tela-choroidea-of-third-ventricle",
+  "name": "tela choroidea of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005288",
+  "synonym": [
+    "choroid membrane of third ventricle",
+    "tela chorioidea of third ventricle",
+    "tela chorioidea third ventricle",
+    "tela choroidea third ventricle",
+    "tela choroidea ventriculi tertii"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
     "lateral ventricle",
-    "telencephalic ventricle",
     "telencephalon lateral ventricle"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -4,22 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telencephalicVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Telencephalic ventricle' is a brain ventricle. It is part of the telencephalon.",
-  "description": "Part of the ventricular system of the brain in each of the cerebral hemispheres. The lateral ventricle in each hemisphere is separated from the other by the septum and each communicates with the THIRD VENTRICLE by the foramen of Monro, In species, particularly those with well developed cortex, the lateral ventrical may be subdivided into anterior, posterior and temporal horns and a body",
+  "definition": "Is a brain ventricle. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285) ('is_a' and 'relationship')]",
+  "description": "A brain ventricle that is part of a telencephalon. In mammals and species with an evaginated telencephalon, this is one of a pair of lateral structures, one in each hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106125",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002285#lateral-ventricle",
   "name": "telencephalic ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
-    "forebrain ventricle",
     "lateral ventricle",
-    "lateral ventricle of brain",
-    "lateral ventricles",
-    "LV",
-    "tectal ventricle",
     "telencephalic ventricle",
-    "telencephalic ventricles",
-    "telencephalic vesicle",
     "telencephalon lateral ventricle"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdVentricle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdVentricle.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdVentricle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Third ventricle' is a brain ventricle. It is part of the diencephalon.",
-  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon;  it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone.  It is bounded anteriorly by the lamina terminalis;  much of the medial surface is formed by the thalamus and hypothalamus;  part of the hypothalamus forms its floor (Nolte, the Human Brain, 6th ed., 2009, pg 101).",
+  "definition": "Is a brain ventricle. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon; it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111707",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002286#third-ventricle-1",
   "name": "third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002286",
   "synonym": [
     "3rd ventricle",
-    "3V",
-    "diencephalic ventricle",
-    "diencephalic vesicle",
-    "ventriculus diencephali",
-    "ventriculus tertius cerebri"
+    "ventriculus diencephali"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004275#third-ventricle-choroid-plexus-epithelium",
+  "name": "third ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004275",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of third ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of third ventricle",
+    "choroid plexus epithelial tissue of third ventricle",
+    "choroid plexus epithelium of third ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelial tissue of choroid plexus of third ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelium of choroid plexus of third ventricle",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "third ventricle choroid plexus epithelial tissue",
+    "third ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelial tissue of choroid plexus",
+    "third ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006339#third-ventricle-choroid-plexus-stroma",
+  "name": "third ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006339",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thirdVentricleEpendyma",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004642#third-ventricle-ependyma",
+  "name": "third ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004642",
+  "synonym": [
+    "3rd ventricle ependyma",
+    "ependyma of third ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -11,7 +11,6 @@
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
-    "anterior horn of lateral ventricle",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",

--- a/instances/v4.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/anteriorHornOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorHornOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Anterior horn of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
+  "description": "Part of the lateral ventricle that extends anteriorly into the frontal lobes, bordered by the head of the caudate nucleus on the lateral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002651)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0100702",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002651#anterior-horn-of-lateral-ventricle-1",
   "name": "anterior horn of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002651",
   "synonym": [
     "anterior horn of lateral ventricle",
-    "cornu anterius",
     "cornu anterius (ventriculi lateralis)",
     "cornu anterius ventriculi lateralis",
     "cornu frontale (ventriculi lateralis)",
     "cornu frontale ventriculi lateralis",
     "frontal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu anterius"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/bodyOfLateralVentricle.jsonld
@@ -4,20 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/bodyOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Body of lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996)",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
+  "description": "Part of lateral ventricle consisting of the central portion that lies dorsally, bounded by the thalamus on the ventral side (Adapted from Heimer, 1996) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002655)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101374",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002655#body-of-lateral-ventricle-1",
   "name": "body of lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002655",
   "synonym": [
     "central part of lateral ventricle",
-    "corpus",
     "corpus ventriculi lateralis",
     "lateral ventricular body",
-    "pars centralis",
     "pars centralis (ventriculi lateralis)",
     "pars centralis ventriculi lateralis",
-    "ventriculus lateralis"
+    "ventriculus lateralis, corpus",
+    "ventriculus lateralis, pars centralis"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/brainVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/brainVentricle.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Brain ventricle' is a brain ventricle/choroid plexus and ventricle of nervous system. It is part of the ventricular system of brain.",
-  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid.",
+  "definition": "Is a brain ventricle/choroid plexus and ventricle of nervous system. Is part of the ventricular system of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086) ('is_a' and 'relationship')]",
+  "description": "One of the system of communicating cavities in the brain that are continuous with the central canal of the spinal cord, that like it are derived from the medullary canal of the embryo, that are lined with an epithelial ependyma, and that contain a serous fluid. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004086)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730602",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004086#cerebral-ventricular-cavity",
   "name": "brain ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004086",
-  "synonym": null
+  "synonym": [
+    "cerebral ventricle",
+    "region of ventricular system of brain"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/brainVentriclechoroidPlexus.jsonld
@@ -2,13 +2,14 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentriclechoroidPlexus",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/brainVentricleChoroidPlexus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Brain ventricle/choroid plexus' is part of the brain.",
-  "description": "The brain ventricles or their associated choroid plexuses.",
+  "definition": "Is part of the brain. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
+  "description": "The brain ventricles or their associated choroid plexuses. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003947)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730467",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003947#brain-ventricle-choroid-plexus",
   "name": "brain ventricle/choroid plexus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003947",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/calcarAvisOfTheLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/calcarAvisOfTheLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the telencephalic ventricle and the hippocampal formation. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970) ('is_a' and 'relationship')]",
+  "description": "On the medial wall of the posterior cornu of the lateral ventricle is a longitudinal eminence, the calcar avis (hippocampus minor), which is an involution of the ventricular wall produced by the calcarine fissure. It is sometimes visible on ultrasonogram. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035970)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035970#calcar-avis-of-the-lateral-ventricle",
+  "name": "calcar avis of the lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035970",
+  "synonym": [
+    "hippocampus minor"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfFourthVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of fourth ventricle' is a choroid plexus and cerebellum vasculature. It is part of the fourth ventricle.",
-  "description": "Choroid plexus of the fourth ventricle",
+  "definition": "Is a choroid plexus and cerebellum vasculature. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290) ('is_a' and 'relationship')]",
+  "description": "Choroid plexus of the fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002290)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102143",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002290#choroid-plexus-of-fourth-ventricle",
   "name": "choroid plexus of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002290",
   "synonym": [
-    "4th ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of fourth ventricle",
     "chorioid plexus of fourth ventricle",
     "choroid plexus fourth ventricle",
@@ -19,3 +18,4 @@
     "fourth ventricle choroid plexus"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfLateralVentricle.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of lateral ventricle' is a choroid plexus. It is part of the telencephalic ventricle.",
-  "description": "Part of choroid plexus contained in the lateral ventricle",
+  "definition": "Is a choroid plexus. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002307)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102144",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002307#choroid-plexus-of-lateral-ventricle",
   "name": "choroid plexus of lateral ventricle",
@@ -18,3 +18,4 @@
     "lateral ventricle choroid plexus"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfTectalVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfTectalVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus. Is part of the midbrain cerebral aqueduct. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus that is part of a cerebral aqueduct. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007299)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007299#choroid-plexus-of-tectal-ventricle",
+  "name": "choroid plexus of tectal ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007299",
+  "synonym": [
+    "choroid plexus tectal ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/choroidPlexusOfThirdVentricle.jsonld
@@ -4,14 +4,13 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/choroidPlexusOfThirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Choroid plexus of third ventricle' is a choroid plexus. It is part of the third ventricle.",
-  "description": "Part of choroid plexus contained in the third ventricle",
+  "definition": "Is a choroid plexus. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288) ('is_a' and 'relationship')]",
+  "description": "Part of choroid plexus contained in the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002288)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0102145",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002288#choroid-plexus-of-third-ventricle",
   "name": "choroid plexus of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002288",
   "synonym": [
-    "3rd ventricle choroid plexus",
     "chorioid plexus of cerebral hemisphere of third ventricle",
     "chorioid plexus of third ventricle",
     "choroid plexus third ventricle",
@@ -20,3 +19,4 @@
     "third ventricle choroid plexus"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricle.jsonld
@@ -4,22 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle' is a brain ventricle. It is part of the hindbrain.",
-  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures.",
+  "definition": "Is a brain ventricle. Is part of the hindbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large irregularly shaped cavity located on the midline of the rhombencephalon, between the medulla, pons and the isthmus ventrally and the cerebellum dorsally. It is continuous with the cerebral aqueduct anteriorally and the central canal of the spinal cord posteriorly. It communicates with the subarachnoid space through its lateral and median apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002422)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104381",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002422#fourth-ventricle",
   "name": "fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002422",
   "synonym": [
-    "4th ventricle",
-    "fourth ventricle proper",
-    "hindbrain ventricle",
-    "IVth ventricle",
-    "rhombencephalic ventricle",
-    "rhombencephalic vesicle",
-    "ventricle IV",
-    "ventricle of hindbrain",
-    "ventricle of rhombencephalon",
-    "ventriculus quartus"
+    "ventricle IV"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleAperture.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleAperture",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle aperture' is part of the fourth ventricle.",
-  "description": "One of:  the 4th ventricle median or lateral apertures.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
+  "description": "One of: the 4th ventricle median or lateral apertures. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004668)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735066",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004668#fourth-ventricle-aperture",
   "name": "fourth ventricle aperture",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004668",
-  "synonym": null
+  "synonym": [
+    "aperture of 4th ventricle",
+    "aperture of fourth ventricle"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium.jsonld
@@ -4,11 +4,28 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleChoroidPlexusEpithelium",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus epithelium' is a choroid plexus epithelium. It is part of the choroid plexus of fourth ventricle.",
-  "description": null,
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004276)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0728876",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004276#fourth-ventricle-choroid-plexus-epithelium",
   "name": "fourth ventricle choroid plexus epithelium",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004276",
-  "synonym": null
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of fourth ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of fourth ventricle",
+    "choroid plexus epithelial tissue of fourth ventricle",
+    "choroid plexus epithelium of fourth ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelial tissue of choroid plexus of fourth ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of fourth ventricle",
+    "epithelium of choroid plexus of fourth ventricle",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "fourth ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "fourth ventricle choroid plexus epithelial tissue",
+    "fourth ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelial tissue of choroid plexus",
+    "fourth ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "fourth ventricle epithelium of choroid plexus"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleChoroidPlexusStroma.jsonld
@@ -4,11 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleChoroidPlexusStroma",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle choroid plexus stroma' is a choroid plexus stroma. It is part of the choroid plexus of fourth ventricle.",
-  "description": "A choroid plexus stroma that is part of a fourth ventricle.",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006340)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0726195",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006340#fourth-ventricle-choroid-plexus-stroma",
   "name": "fourth ventricle choroid plexus stroma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006340",
   "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleEpendyma.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleEpendyma",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Fourth ventricle ependyma' is a brain ependyma. It is part of the fourth ventricle.",
-  "description": null,
+  "definition": "Is a brain ependyma. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a fourth ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004644)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0729148",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004644#fourth-ventricle-ependyma",
   "name": "fourth ventricle ependyma",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004644",
-  "synonym": null
+  "synonym": [
+    "ependyma of fourth ventricle"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleLateralAperture.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleLateralAperture",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "description": "One of the two lateral openings of the fourth ventricle into the subarachnoid space at the cerebellopontine angle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003992)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003992#fourth-ventricle-lateral-aperture",
+  "name": "fourth ventricle lateral aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003992",
+  "synonym": [
+    "apertura lateralis",
+    "foramen of key and retzius",
+    "foramen of Key-Retzius",
+    "foramen of Luschka",
+    "foramen of Retzius",
+    "lateral aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -14,7 +14,6 @@
     "apertura mediana",
     "foramen of Magendie",
     "foramen of Majendie",
-    "fourth ventricle median aperture",
     "median aperture of fourth ventricle"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/fourthVentricleMedianAperture.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/fourthVentricleMedianAperture",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fourth ventricle aperture. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "description": "The large midline opening of the posterior inferior part of the roof of the fourth ventricle that connects the fourth ventricle to the posterior cerebromedullary cistern and the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0003991)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0003991#fourth-ventricle-median-aperture",
+  "name": "fourth ventricle median aperture",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0003991",
+  "synonym": [
+    "apertura mediana",
+    "foramen of Magendie",
+    "foramen of Majendie",
+    "fourth ventricle median aperture",
+    "median aperture of fourth ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -4,22 +4,22 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorHornOfTheLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Inferior horn of the lateral ventricle' is part of the telencephalic ventricle.",
-  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe.",
+  "definition": "Is part of the telencephalic ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
+  "description": "The part of the lateral ventricle extending downward and anteriorly in the temporal lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006091)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105444",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006091#inferior-horn-of-the-lateral-ventricle-1",
   "name": "inferior horn of the lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006091",
   "synonym": [
-    "cornu inferius",
     "cornu inferius (ventriculi lateralis)",
     "cornu inferius ventriculi lateralis",
-    "cornu temporale",
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
     "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu inferius",
+    "ventriculus lateralis, cornu temporale"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/inferiorHornOfTheLateralVentricle.jsonld
@@ -16,7 +16,6 @@
     "cornu temporale (ventriculi lateralis)",
     "cornu temporale ventriculi lateralis",
     "inferior horn of lateral ventricle",
-    "inferior horn of the lateral ventricle",
     "temporal horn of lateral ventricle",
     "ventriculus lateralis, cornu inferius",
     "ventriculus lateralis, cornu temporale"

--- a/instances/v4.0/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/infundibularRecessOf3rdVentricle.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/infundibularRecessOf3rdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the third ventricle and the future neurohypophysis. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "description": "A funnel-shaped diverticulum that extends downward from the anterior aspect of the floor of the third ventricle into the infundibulum of the hypophysis; the embryonic structure gives rise the neural component of the pituitary (pas nervosa). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006250)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006250#infundibular-recess-of-3rd-ventricle",
+  "name": "infundibular recess of 3rd ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006250",
+  "synonym": [
+    "infundibular recess",
+    "infundibular recess of third ventricle",
+    "recessus infundibularis",
+    "recessus infundibuli"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralEminenceOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lateral eminence of fourth ventricle' is part of the fourth ventricle.",
+  "definition": "Is part of the fourth ventricle. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034672)]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0734681",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": null
+  "synonym": [
+    "lateral eminence of fourth ventricle"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralEminenceOfFourthVentricle.jsonld
@@ -10,8 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034672#lateral-eminence-of-fourth-ventricle",
   "name": "lateral eminence of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034672",
-  "synonym": [
-    "lateral eminence of fourth ventricle"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralRecessOfFourthVentricle.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralRecessOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Lateral recess of fourth ventricle' is an anatomical entity. It is part of the fourth ventricle.",
-  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space.",
+  "definition": "Is an anatomical entity. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656) ('is_a' and 'relationship')]",
+  "description": "The lateral recess is a projection of the fourth ventricle which extends into the inferior cerebellar peduncle of the brainstem. The lateral aperture, an opening in each extremity of the lateral recess, provides a conduit for cerebrospinal fluid to flow from the brain's ventricular system into the subarachnoid space. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007656)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736090",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007656#lateral-recess-of-fourth-ventricle",
   "name": "lateral recess of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007656",
-  "synonym": null
+  "synonym": [
+    "recessus lateralis (ventriculi quarti)"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004274)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004274#lateral-ventricle-choroid-plexus-epithelium",
+  "name": "lateral ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004274",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of lateral ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of lateral ventricle",
+    "choroid plexus epithelial tissue of lateral ventricle",
+    "choroid plexus epithelium of lateral ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelial tissue of choroid plexus of lateral ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of lateral ventricle",
+    "epithelium of choroid plexus of lateral ventricle",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "lateral ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "lateral ventricle choroid plexus epithelial tissue",
+    "lateral ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelial tissue of choroid plexus",
+    "lateral ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "lateral ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of lateral ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006338#lateral-ventricle-choroid-plexus-stroma",
+  "name": "lateral ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006338",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/lateralVentricleEpendyma.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVentricleEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a lateral ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004643#lateral-ventricle-ependyma",
+  "name": "lateral ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004643",
+  "synonym": [
+    "ependyma of lateral ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/leftLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/leftLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the left cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the left side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013161)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013161#left-lateral-ventricle",
+  "name": "left lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013161",
+  "synonym": [
+    "left telencephalic ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/opticRecessOfThirdVentricle.jsonld
@@ -4,19 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/opticRecessOfThirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Optic recess of third ventricle' is an anatomical entity. It is part of the third ventricle.",
-  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287) ('is_a' and 'relationship')]",
+  "description": "Recess in third ventricle lying in front of the optic chiasm at the base of the lamina terminalis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108073",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002287#optic-recess-of-third-ventricle-1",
   "name": "optic recess of third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002287",
   "synonym": [
     "optic recess",
-    "optic recesses",
     "preoptic recess",
-    "recessus opticus",
-    "recessus praeopticus",
     "recessus supraopticus",
     "supraoptic recess"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pinealRecessOfThirdVentricle.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pinealRecessOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283) ('is_a' and 'relationship')]",
+  "description": "The diverticulum of the thin roof of the dorsocaudal third ventricle that projects into the stalk of the pineal gland. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022283)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022283#pineal-recess-of-third-ventricle",
+  "name": "pineal recess of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022283",
+  "synonym": [
+    "pineal recess",
+    "pineal recess of 3V",
+    "recessus pinealis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -17,7 +17,6 @@
     "cornu posterius ventriculi lateralis",
     "occipital horn",
     "occipital horn of lateral ventricle",
-    "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
     "ventriculus lateralis, cornu occipitale",

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorHornLateralVentricle.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorHornLateralVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior horn lateral ventricle' is a telencephalic ventricle.",
-  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe.",
+  "definition": "Is a telencephalic ventricle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
+  "description": "Part of the lateral ventricle that extends posteriorly into the occipital lobe. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004672)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109097",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004672#posterior-horn-lateral-ventricle-1",
   "name": "posterior horn lateral ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004672",
   "synonym": [
-    "cornu occipitale",
     "cornu occipitale (ventriculi lateralis)",
     "cornu occipitale ventriculi lateralis",
-    "cornu posterius",
     "cornu posterius (ventriculi lateralis)",
     "cornu posterius ventriculi lateralis",
     "occipital horn",
@@ -22,6 +20,8 @@
     "posterior horn lateral ventricle",
     "posterior horn of lateral ventricle",
     "posterior horn of the lateral ventricle",
-    "ventriculus lateralis"
+    "ventriculus lateralis, cornu occipitale",
+    "ventriculus lateralis, cornu posterius"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rightLateralVentricle.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rightLateralVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a telencephalic ventricle. Is part of the right cerebral hemisphere. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162) ('is_a' and 'relationship')]",
+  "description": "A telencephalic ventricle that is in the right side of a telencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0013162)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0013162#right-lateral-ventricle",
+  "name": "right lateral ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0013162",
+  "synonym": [
+    "right telencephalic ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -4,11 +4,19 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfFourthVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tela choroidea of fourth ventricle' is a tela choroidea. It is part of the fourth ventricle.",
-  "description": "Tela chorioidea that lines the fourth ventricle[ZFA]. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout:  The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla[WP].",
+  "definition": "Is a tela choroidea. Is part of the fourth ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the fourth ventricle. The tela chorioidea of the fourth ventricle is the name applied to the triangular fold of pia mater which is carried upward between the cerebellum and the medulla oblongata. It consists of two layers, which are continuous with each other in front, and are more or less adherent throughout: The posterior layer covers the antero-inferior surface of the cerebellum. The anterior layer is applied to the structures which form the lower part of the roof of the ventricle, and is continuous inferiorly with the pia mater on the inferior peduncles and closed part of the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005287)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0727490",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005287#tela-choroidea-of-fourth-ventricle",
   "name": "tela choroidea of fourth ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005287",
-  "synonym": null
+  "synonym": [
+    "choroid membrane",
+    "choroid membrane of fourth ventricle",
+    "tela chorioidea fourth ventricle",
+    "tela choroidea fourth ventricle",
+    "tela choroidea of fourth ventricle",
+    "tela choroidea ventriculi quarti"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfFourthVentricle.jsonld
@@ -15,7 +15,6 @@
     "choroid membrane of fourth ventricle",
     "tela chorioidea fourth ventricle",
     "tela choroidea fourth ventricle",
-    "tela choroidea of fourth ventricle",
     "tela choroidea ventriculi quarti"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfTelencephalicVentricle.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfTelencephalicVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the telencephalic ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the telencephalic ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005289)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005289#tela-choroidea-of-telencephalic-ventricle",
+  "name": "tela choroidea of telencephalic ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005289",
+  "synonym": [
+    "tela chorioidea of lateral ventricle",
+    "tela chorioidea of telencephalic ventricle",
+    "tela chorioidea telencephalic ventricle",
+    "tela choroidea (ventriculi lateralis)",
+    "tela choroidea of lateral ventricle",
+    "tela choroidea telencephalic ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telaChoroideaOfThirdVentricle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telaChoroideaOfThirdVentricle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tela choroidea. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288) ('is_a' and 'relationship')]",
+  "description": "Tela chorioidea that lines the third ventricle. The part of the choroid plexus in relation to the body of the ventricle forms the vascular fringed margin of a triangular process of pia mater, named the tela chorioidea of the third ventricle, and projects from under cover of the lateral edge of the fornix. Blood is supplied by branches from the superior cerebellar artery. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005288)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005288#tela-choroidea-of-third-ventricle",
+  "name": "tela choroidea of third ventricle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005288",
+  "synonym": [
+    "choroid membrane of third ventricle",
+    "tela chorioidea of third ventricle",
+    "tela chorioidea third ventricle",
+    "tela choroidea third ventricle",
+    "tela choroidea ventriculi tertii"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -12,7 +12,6 @@
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
     "lateral ventricle",
-    "telencephalic ventricle",
     "telencephalon lateral ventricle"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telencephalicVentricle.jsonld
@@ -4,22 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Telencephalic ventricle' is a brain ventricle. It is part of the telencephalon.",
-  "description": "Part of the ventricular system of the brain in each of the cerebral hemispheres. The lateral ventricle in each hemisphere is separated from the other by the septum and each communicates with the THIRD VENTRICLE by the foramen of Monro, In species, particularly those with well developed cortex, the lateral ventrical may be subdivided into anterior, posterior and temporal horns and a body",
+  "definition": "Is a brain ventricle. Is part of the telencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285) ('is_a' and 'relationship')]",
+  "description": "A brain ventricle that is part of a telencephalon. In mammals and species with an evaginated telencephalon, this is one of a pair of lateral structures, one in each hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002285)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106125",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002285#lateral-ventricle",
   "name": "telencephalic ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002285",
   "synonym": [
-    "forebrain ventricle",
     "lateral ventricle",
-    "lateral ventricle of brain",
-    "lateral ventricles",
-    "LV",
-    "tectal ventricle",
     "telencephalic ventricle",
-    "telencephalic ventricles",
-    "telencephalic vesicle",
     "telencephalon lateral ventricle"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdVentricle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdVentricle.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Third ventricle' is a brain ventricle. It is part of the diencephalon.",
-  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon;  it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone.  It is bounded anteriorly by the lamina terminalis;  much of the medial surface is formed by the thalamus and hypothalamus;  part of the hypothalamus forms its floor (Nolte, the Human Brain, 6th ed., 2009, pg 101).",
+  "definition": "Is a brain ventricle. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286) ('is_a' and 'relationship')]",
+  "description": "Part of the ventricular system of the brain, forming a single large cavity in the midline of the diencephalon; it is continuous with the lateral ventricles through the interventricular foramen and the fourth ventricle through the cerebral aqueduct. (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002286)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111707",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002286#third-ventricle-1",
   "name": "third ventricle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002286",
   "synonym": [
     "3rd ventricle",
-    "3V",
-    "diencephalic ventricle",
-    "diencephalic vesicle",
-    "ventriculus diencephali",
-    "ventriculus tertius cerebri"
+    "ventriculus diencephali"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleChoroidPlexusEpithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus epithelium. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus epithelium that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004275)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004275#third-ventricle-choroid-plexus-epithelium",
+  "name": "third ventricle choroid plexus epithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004275",
+  "synonym": [
+    "chorioid plexus of cerebral hemisphere epithelial tissue of third ventricle",
+    "chorioid plexus of cerebral hemisphere epithelium of third ventricle",
+    "choroid plexus epithelial tissue of third ventricle",
+    "choroid plexus epithelium of third ventricle",
+    "epithelial tissue of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelial tissue of choroid plexus of third ventricle",
+    "epithelium of chorioid plexus of cerebral hemisphere of third ventricle",
+    "epithelium of choroid plexus of third ventricle",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelial tissue",
+    "third ventricle chorioid plexus of cerebral hemisphere epithelium",
+    "third ventricle choroid plexus epithelial tissue",
+    "third ventricle epithelial tissue of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelial tissue of choroid plexus",
+    "third ventricle epithelium of chorioid plexus of cerebral hemisphere",
+    "third ventricle epithelium of choroid plexus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleChoroidPlexusStroma.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleChoroidPlexusStroma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a choroid plexus stroma. Is part of the choroid plexus of third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339) ('is_a' and 'relationship')]",
+  "description": "A choroid plexus stroma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006339)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006339#third-ventricle-choroid-plexus-stroma",
+  "name": "third ventricle choroid plexus stroma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006339",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thirdVentricleEpendyma.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thirdVentricleEpendyma",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain ependyma. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642) ('is_a' and 'relationship')]",
+  "description": "An ependyma that is part of a third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004642)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004642#third-ventricle-ependyma",
+  "name": "third ventricle ependyma",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004642",
+  "synonym": [
+    "3rd ventricle ependyma",
+    "ependyma of third ventricle"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'ventricle' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.