### PR TITLE
UBERON terms with 'tract' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryOpticTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035595) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035595#accessory-optic-tract",
+  "name": "accessory optic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035595",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/axonTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/axonTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/axonTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "description": "A group of axons linking two or more neuropils and having a common origin, termination. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001018#nerve-tract",
+  "name": "axon tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001018",
+  "synonym": [
+    "axonal tract",
+    "neuraxis tract",
+    "tract of neuraxis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "description": "A pathway containing fibers from midbrain nuclei that project to the inferior olivary complex, as well as fibers originating in the pontine reticular formation and the medullary reticular formation that project to several nuclei of the thalamus. It can be identified in the midbrain and the pons (Adapted from Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009643#central-tegmental-tract",
+  "name": "central tegmental tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009643",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Central tegmental tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002585) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101918",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002585#central-tegmental-tract-of-midbrain-1",
   "name": "central tegmental tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002585",
-  "synonym": [
-    "central tegmental tract of the midbrain",
-    "ctgmb",
-    "tractus tegmentalis centralis (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Central tegmental tract of pons' is a tract of brain. It is part of the pontine tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002783) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101919",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002783#central-tegmental-tract-of-pons-1",
   "name": "central tegmental tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002783",
-  "synonym": [
-    "central tegmental tract of the pons",
-    "tractus tegmentalis centralis (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/crossedTectoBulbarTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000335) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000335#crossed-tecto-bulbar-tract",
+  "name": "crossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000335",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dentatothalamicTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Dentatothalamic tract' is a tract of brain. It is part of the midbrain tegmentum.",
-  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [WP,unvetted].",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594) ('is_a' and 'relationship')]",
+  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103087",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002594#dentatothalamic-tract-1",
   "name": "dentatothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002594",
   "synonym": [
-    "dentatothalamic fibers",
-    "DT",
-    "tractus dentatothalamicus"
+    "dentatothalamic fibers"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalTrigeminalTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Dorsal trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [WP,unvetted].",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797) ('is_a' and 'relationship')]",
+  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103494",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002797#dorsal-trigeminal-tract-1",
   "name": "dorsal trigeminal tract",
@@ -13,18 +13,15 @@
   "synonym": [
     "dorsal ascending trigeminal tract",
     "dorsal division of trigeminal lemniscus",
-    "Dorsal secondary ascending tract of V",
-    "Dorsal secondary tract of V",
+    "dorsal secondary ascending tract of v",
+    "dorsal secondary tract of v",
     "dorsal trigeminal lemniscus",
     "dorsal trigeminal pathway",
-    "dorsal trigemino-thalamic tract",
     "dorsal trigeminothalamic tract",
-    "dorsal trigmino-thalamic tract",
     "posterior trigeminothalamic tract",
     "reticulothalamic tract",
-    "tractus trigeminalis dorsalis",
-    "tractus trigemino-thalamicus dorsalis",
     "tractus trigeminothalamicus posterior",
     "uncrossed dorsal trigeminothalamic tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/endohypothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "description": "CNS white matter, axonal tract interconnecting catecholaminergic cell groups in the posterior tuberculum and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005343#endohypothalamic-tract",
+  "name": "endohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005343",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/epiphysealTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/epiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/epiphysealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "description": "A cranial nerve fiber tract that innervates the parietal eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034714#epiphyseal-tract",
+  "name": "epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034714",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/forebrainIpsilateralFiberTracts",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022247) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022247#forebrain-ipsilateral-fiber-tracts",
+  "name": "forebrain ipsilateral fiber tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022247",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "description": "White matter tract containing fibers projecting from the habenular nuclei to the interpeduncular nucleus (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002138#fasciculus-retroflexus",
+  "name": "habenulo-interpeduncular tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002138",
+  "synonym": [
+    "fasciculus retroflexus",
+    "fasciculus retroflexus (Meynert)",
+    "habenulointerpeduncular fasciculus",
+    "habenulopeduncular tract",
+    "Meynert's retroflex bundle",
+    "tractus habenulo-interpeduncularis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
-  "synonym": [
-    "habenulo-interpeduncular tract of diencephalon",
-    "habenulo-interpeduncular tract of diencephalon"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -2,15 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTractOfDiencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of diencephalon' is a fasciculus of brain. It is part of the habenulo-interpeduncular tract and diencephalic white matter.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the habenulo-interpeduncular tract and the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022649) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104856",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
   "synonym": [
+    "habenulo-interpeduncular tract of diencephalon",
     "habenulo-interpeduncular tract of diencephalon"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -2,16 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenulointerpeduncularTractOfMidbrain",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of midbrain' is a fasciculus of brain. It is part of the midbrain tegmentum, habenulo-interpeduncular tract and white matter of midbrain.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the midbrain tegmentum, the habenulo-interpeduncular tract and the white matter of midbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023740) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104857",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
   "synonym": [
     "habenulo-interpeduncular tract of midbrain",
-    "hipm"
+    "habenulo-interpeduncular tract of midbrain"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
-  "synonym": [
-    "habenulo-interpeduncular tract of midbrain",
-    "habenulo-interpeduncular tract of midbrain"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillotectalAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697) ('is_a' and 'relationship')]",
+  "description": "The mammillotectal tract is the collection of axons that connects the ventral diencephalon to the superior colliculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006697#mammillotectal-axonal-tract",
+  "name": "mammillotectal axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006697",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillotegmentalAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698) ('is_a' and 'relationship')]",
+  "description": "The mammillotegmental tract is the collection of axons that connects the ventral diencephalon to the tegmentum and pons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006698#mammillotegmental-fasciculus",
+  "name": "mammillotegmental axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006698",
+  "synonym": [
+    "Gudden tract",
+    "mammillotegmental fasciculus",
+    "mammillotegmental tract",
+    "mammillotegmental tract of hypothalamus",
+    "von Gudden's tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillothalamicAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter and the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696) ('is_a' and 'relationship')]",
+  "description": "A fiber pathway that originates from neurons in the posterior hypothalamic region and projects to various nuclei of the anterior nuclear group of the thalamus. It is a composite structure that consists of the mammillothalamic tract of the hypothalamus and the mammillothalamic tract of the thalamus (Carpenter-1983). (from Brain Info.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006696#mammillothalamic-axonal-tract",
+  "name": "mammillothalamic axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006696",
+  "synonym": [
+    "fasciculus mammillothalamicus",
+    "mammillothalamic fasciculus",
+    "mammillothalamic tract",
+    "vicq d'azyr's bundle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
@@ -4,16 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillothalamicTractOfHypothalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Mammillothalamic tract of hypothalamus' is a tract of diencephalon. It is part of the mammillary axonal complex.",
-  "description": "Part of mammillothalamic tract contained within the hypothalamus",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990) ('is_a' and 'relationship')]",
+  "description": "Part of mammillothalamic tract contained within the hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106507",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002990#mammillothalamic-tract-of-hypothalamus-1",
   "name": "mammillothalamic tract of hypothalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002990",
-  "synonym": [
-    "fasciculus mamillothalamicus (hypothalami)",
-    "mammillothalamic tract of hypothalamus",
-    "mammillothalamic tract of the hypothalamus",
-    "mthh"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialLongitudinalCatecholaminergicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005341)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005341#medial-longitudinal-catecholaminergic-tract",
+  "name": "medial longitudinal catecholaminergic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005341",
+  "synonym": [
+    "mlct"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medullaReticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the medulla towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004173#medulla-reticulospinal-tract",
+  "name": "medulla reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004173",
+  "synonym": [
+    "medullary reticulospinal tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nigrostriatalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "description": "The term nigrostriatal fibers refers to a dopaminergic fiber pathway connecting the substantia nigra with the striatum. It is not readily distinguished in myelin-stained cross-sections (Carpenter-83). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014169#nigrostriatal-tract-1",
+  "name": "nigrostriatal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014169",
+  "synonym": [
+    "comb bundle",
+    "nigrostriatal bundle",
+    "nigrostriatal fibers",
+    "nigrostriatal tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -13,8 +13,7 @@
   "synonym": [
     "comb bundle",
     "nigrostriatal bundle",
-    "nigrostriatal fibers",
-    "nigrostriatal tract"
+    "nigrostriatal fibers"
   ]
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/opticTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/opticTract.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/opticTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Optic tract' is a tract of diencephalon. It is part of the diencephalic white matter.",
-  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm[ZFA]. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM)[NIF].",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908) ('is_a' and 'relationship')]",
+  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108074",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001908#optic-tract-1",
   "name": "optic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001908",
-  "synonym": null
+  "synonym": [
+    "optic lemniscus"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/pinealTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pinealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pinealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715) ('is_a' and 'relationship')]",
+  "description": "A cranial nerve fiber tract that innervates the pineal body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034715#pineal-tract",
+  "name": "pineal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034715",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ponsReticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004172#pons-reticulospinal-tract",
+  "name": "pons reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004172",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preopticohypothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005344)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005344#preopticohypothalamic-tract",
+  "name": "preopticohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005344",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
   "name": "reticulospinal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
-  "synonym": [
-    "reticulospinal tract",
-    "reticulospinal tract"
-  ]
+  "synonym": null
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/reticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943) ('is_a' and 'relationship')]",
+  "description": "The reticulospinal tract (or anterior reticulospinal tract) is an extrapyramidal motor tract which travels from the reticular formation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
+  "name": "reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
+  "synonym": [
+    "reticulospinal tract",
+    "reticulospinal tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralEpiphysealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716) ('is_a' and 'relationship')]",
+  "description": "The more rostral of the two branches of the epiphyseal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034716#rostral-epiphyseal-tract",
+  "name": "rostral epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034716",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rubrospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rubrospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rubrospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714) ('is_a' and 'relationship')]",
+  "description": "White matter tract arising in red nucleus and projecting to spinal cord ventral horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002714#rubrospinal-tract-1",
+  "name": "rubrospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002714",
+  "synonym": [
+    "Monakow's tract",
+    "rubrospinal tract (Monakow)"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondaryGustatoryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000430#secondary-gustatory-tract",
+  "name": "secondary gustatory tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000430",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/solitaryTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/solitaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/solitaryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718) ('is_a' and 'relationship')]",
+  "description": "The solitary tract is a compact fiber bundle that extends longitudinally through the posterolateral region of the medulla. The solitary tract is surrounded by the nucleus of the solitary tract, and descends to the upper cervical segments of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002718#solitary-tract-1",
+  "name": "solitary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002718",
+  "synonym": [
+    "respiratory bundle of Gierke"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/solitaryTractNuclearComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126) ('is_a' and 'relationship')]",
+  "description": "The solitary tract and nucleus are structures in the brainstem that carry and receive visceral sensation and taste from the facial (VII), glossopharyngeal (IX) and vagus (X) cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002126#solitary-tract-nuclear-complex",
+  "name": "solitary tract nuclear complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002126",
+  "synonym": [
+    "nuclei of solitary tract",
+    "nucleus tractus solitarii",
+    "solitary nuclei"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761) ('is_a' and 'relationship')]",
+  "description": "Brainstem tract formed by the central processes of first-order, trigeminal ganglion neurons that extends from the caudal medulla to the midpons. This tract conveys nociceptive and thermal information from the face to second-order neurons in the spinal nucleus of the trigeminal complex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014761#spinal-trigeminal-tract",
+  "name": "spinal trigeminal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014761",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTractOfMedulla",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of medulla' is a spinal trigeminal tract. It is part of the medulla oblongata.",
-  "description": "Part of spinal trigeminal tract located in the medulla",
+  "definition": "Is a spinal trigeminal tract. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715) ('is_a' and 'relationship')]",
+  "description": "Part of spinal trigeminal tract located in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110958",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002715#spinal-trigeminal-tract-of-medulla-1",
   "name": "spinal trigeminal tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002715",
-  "synonym": [
-    "spinal trigeminal tract of the medulla",
-    "tractus spinalis nervi trigemini (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of pons' is a spinal trigeminal tract. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a spinal trigeminal tract. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002800) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110959",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002800#spinal-trigeminal-tract-of-pons-1",
   "name": "spinal trigeminal tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002800",
-  "synonym": [
-    "spinal trigeminal tract of the pons",
-    "tractus spinalis nervi trigemini (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinoOlivaryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719) ('is_a' and 'relationship')]",
+  "description": "The spino-olivary tract is located in the ventral funiculus of the spinal cord. This tract carries proprioception information from muscles and tendons as well as cutaneous impulses to the olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002719#spino-olivary-tract-1",
+  "name": "spino-olivary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002719",
+  "synonym": [
+    "helweg's tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/spinothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinothalamicTract.jsonld
@@ -4,13 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "",
-  "description": "The 'spinothalamic tract' is a white matter fibre bundle. It originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus.",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
+  "description": "A tract that originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus. It is formed in the medulla by merger of the anterior spinothalamic tract and lateral spinothalamic tract (adapted from Braininfo.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110973",
-  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract-1",
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract",
   "name": "spinothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007703",
-  "synonym": [
-    "spth"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfMedulla",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of medulla' is a tract of brain. It is part of the medulla oblongata and spinothalamic tract.",
-  "description": "Part of spinothalamic tract in the medulla",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002944#spinothalamic-tract-of-medulla-1",
   "name": "spinothalamic tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002944",
-  "synonym": [
-    "spinothalamic tract",
-    "spinothalamic tract of the medulla",
-    "tractus spinothalamicus (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and spinothalamic tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002609) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110975",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002609#spinothalamic-tract-of-midbrain-1",
   "name": "spinothalamic tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002609",
-  "synonym": [
-    "spinothalamic tract of the midbrain",
-    "stmb",
-    "tractus spinothalamicus (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of pons' is a tract of brain. It is part of the pontine tegmentum and spinothalamic tract.",
-  "description": "Part of spinothalamic tract that is in the pontine tegmentum",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110976",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002798#spinothalamic-tract-of-pons-1",
   "name": "spinothalamic tract of pons",
@@ -15,11 +15,9 @@
     "pons of varolius spinothalamic tract of medulla",
     "pons spinothalamic tract",
     "pons spinothalamic tract of medulla",
-    "spinotectal pathway",
     "spinothalamic tract of medulla of pons",
     "spinothalamic tract of medulla of pons of varolius",
-    "spinothalamic tract of pons of varolius",
-    "spinothalamic tract of the pons",
-    "tractus spinothalamicus (pontis)"
+    "spinothalamic tract of pons of varolius"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/supraopticTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/supraopticTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/supraopticTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002244)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002244#supraoptic-tract",
+  "name": "supraoptic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002244",
+  "synonym": [
+    "SOT"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/supraopticohypophysialTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the anterior hypothalamic region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002699) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002699#supraopticohypophysial-tract-1",
+  "name": "supraopticohypophysial tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002699",
+  "synonym": [
+    "supra-opticohypophysial tract",
+    "supraopticohypophyseal tract",
+    "tractus supraopticohypophysialis"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tectobulbarTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tectobulbarTract.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectobulbarTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tectobulbar tract' is a tract of brain. It is part of the medulla oblongata.",
-  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain.",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164) ('is_a' and 'relationship')]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111548",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002164#tectobulbar-tract-1",
   "name": "tectobulbar tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002164",
   "synonym": [
-    "tecto-bulbar tract",
-    "tractus tectobulbaris"
+    "tecto-bulbar tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/tectopontineTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tectopontineTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectopontineTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tectopontine tract' is a tract of brain. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002930) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002930#tectopontine-tract-1",
   "name": "tectopontine tract",
@@ -13,7 +13,7 @@
   "synonym": [
     "fibrae tectopontinae",
     "tectopontine fibers",
-    "tectopontine fibres",
-    "tractus tectopontinus"
+    "tectopontine fibres"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/tectospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tectospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the superior colliculus of the midbrain towards target cells in the ventral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002949#tectospinal-tract-1",
+  "name": "tectospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002949",
+  "synonym": [
+    "Held's bundle",
+    "tectospinal pathway"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tectothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tectothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035570#tectothalamic-tract",
+  "name": "tectothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035570",
+  "synonym": [
+    "tectothalamic fibers"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/telencephalicTracts.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/telencephalicTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicTracts",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000597)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000597#telencephalic-tracts",
+  "name": "telencephalic tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000597",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thalamicFiberTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Thalamic fiber tract' is a tract of diencephalon. It is part of the dorsal plus ventral thalamus.",
+  "definition": "Is a tract of diencephalon. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025261) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730765",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025261#thalamic-fiber-tracts",
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
-  "synonym": null
+  "synonym": [
+    "thalamic fiber tracts",
+    "thalamic fiber tracts"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -11,7 +11,6 @@
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
   "synonym": [
-    "thalamic fiber tracts",
     "thalamic fiber tracts"
   ]
 }

--- a/instances/latest/terminologies/UBERONParcellation/tractOfBrain.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tractOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfBrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tract of brain' is an axon tract. It is part of the brain and white matter.",
-  "description": "An axon tract that is part of a brain.",
+  "definition": "Is an axon tract. Is part of the brain and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736079",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007702#tract-of-brain",
   "name": "tract of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007702",
-  "synonym": null
+  "synonym": [
+    "brain tract"
+  ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfDiencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a diencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011591#tract-of-diencephalon",
+  "name": "tract of diencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011591",
+  "synonym": [
+    "diencephalon tract"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfThePostopticCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a diencephalic white matter. Is part of the postoptic commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001366) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001366#tract-of-the-postoptic-commissure",
+  "name": "tract of the postoptic commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001366",
+  "synonym": [
+    "TPOC"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractusSacciVasculosi",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035146)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035146#tractus-sacci-vasculosi",
+  "name": "tractus sacci vasculosi",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035146",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "description": "The trigeminothalamic tract is one of the major routes of nociceptive and temperature signaling from the face. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004171#trigeminal-tract",
+  "name": "trigeminothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004171",
+  "synonym": [
+    "tractus trigeminothalamicus"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/uncrossedTectoBulbarTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000296) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000296#uncrossed-tecto-bulbar-tract",
+  "name": "uncrossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000296",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralTrigeminalTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Ventral trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons .",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549) ('is_a' and 'relationship')]",
+  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112361",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002549#ventral-trigeminal-tract-1",
   "name": "ventral trigeminal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002549",
   "synonym": [
     "anterior trigeminothalamic tract",
-    "tractus trigeminalis ventralis",
     "tractus trigeminothalamicus anterior",
     "trigeminal lemniscus-2",
     "ventral crossed tract",
     "ventral secondary ascending tract of V",
     "ventral trigeminal pathway",
-    "ventral trigeminal tract",
     "ventral trigeminothalamic tract"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the vestibular nucleus of the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002768#vestibulospinal-tract-1",
+  "name": "vestibulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002768",
+  "synonym": [
+    "vestibulo-spinal tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/accessoryOpticTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035595) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035595#accessory-optic-tract",
+  "name": "accessory optic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035595",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/axonTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/axonTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/axonTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "description": "A group of axons linking two or more neuropils and having a common origin, termination. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001018#nerve-tract",
+  "name": "axon tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001018",
+  "synonym": [
+    "axonal tract",
+    "neuraxis tract",
+    "tract of neuraxis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralTegmentalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "description": "A pathway containing fibers from midbrain nuclei that project to the inferior olivary complex, as well as fibers originating in the pontine reticular formation and the medullary reticular formation that project to several nuclei of the thalamus. It can be identified in the midbrain and the pons (Adapted from Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009643#central-tegmental-tract",
+  "name": "central tegmental tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009643",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralTegmentalTractOfMidbrain",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Central tegmental tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002585) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101918",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002585#central-tegmental-tract-of-midbrain-1",
   "name": "central tegmental tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002585",
-  "synonym": [
-    "central tegmental tract of the midbrain",
-    "ctgmb",
-    "tractus tegmentalis centralis (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/centralTegmentalTractOfPons",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Central tegmental tract of pons' is a tract of brain. It is part of the pontine tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002783) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101919",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002783#central-tegmental-tract-of-pons-1",
   "name": "central tegmental tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002783",
-  "synonym": [
-    "central tegmental tract of the pons",
-    "tractus tegmentalis centralis (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/crossedTectoBulbarTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000335) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000335#crossed-tecto-bulbar-tract",
+  "name": "crossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000335",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dentatothalamicTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Dentatothalamic tract' is a tract of brain. It is part of the midbrain tegmentum.",
-  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [WP,unvetted].",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594) ('is_a' and 'relationship')]",
+  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103087",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002594#dentatothalamic-tract-1",
   "name": "dentatothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002594",
   "synonym": [
-    "dentatothalamic fibers",
-    "DT",
-    "tractus dentatothalamicus"
+    "dentatothalamic fibers"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalTrigeminalTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Dorsal trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [WP,unvetted].",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797) ('is_a' and 'relationship')]",
+  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103494",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002797#dorsal-trigeminal-tract-1",
   "name": "dorsal trigeminal tract",
@@ -13,18 +13,15 @@
   "synonym": [
     "dorsal ascending trigeminal tract",
     "dorsal division of trigeminal lemniscus",
-    "Dorsal secondary ascending tract of V",
-    "Dorsal secondary tract of V",
+    "dorsal secondary ascending tract of v",
+    "dorsal secondary tract of v",
     "dorsal trigeminal lemniscus",
     "dorsal trigeminal pathway",
-    "dorsal trigemino-thalamic tract",
     "dorsal trigeminothalamic tract",
-    "dorsal trigmino-thalamic tract",
     "posterior trigeminothalamic tract",
     "reticulothalamic tract",
-    "tractus trigeminalis dorsalis",
-    "tractus trigemino-thalamicus dorsalis",
     "tractus trigeminothalamicus posterior",
     "uncrossed dorsal trigeminothalamic tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/endohypothalamicTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "description": "CNS white matter, axonal tract interconnecting catecholaminergic cell groups in the posterior tuberculum and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005343#endohypothalamic-tract",
+  "name": "endohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005343",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/epiphysealTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/epiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/epiphysealTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "description": "A cranial nerve fiber tract that innervates the parietal eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034714#epiphyseal-tract",
+  "name": "epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034714",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/forebrainIpsilateralFiberTracts",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022247) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022247#forebrain-ipsilateral-fiber-tracts",
+  "name": "forebrain ipsilateral fiber tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022247",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/habenuloInterpeduncularTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "description": "White matter tract containing fibers projecting from the habenular nuclei to the interpeduncular nucleus (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002138#fasciculus-retroflexus",
+  "name": "habenulo-interpeduncular tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002138",
+  "synonym": [
+    "fasciculus retroflexus",
+    "fasciculus retroflexus (Meynert)",
+    "habenulointerpeduncular fasciculus",
+    "habenulopeduncular tract",
+    "Meynert's retroflex bundle",
+    "tractus habenulo-interpeduncularis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -2,15 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon",
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/habenuloInterpeduncularTractOfDiencephalon",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of diencephalon' is a fasciculus of brain. It is part of the habenulo-interpeduncular tract and diencephalic white matter.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the habenulo-interpeduncular tract and the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022649) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104856",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
   "synonym": [
+    "habenulo-interpeduncular tract of diencephalon",
     "habenulo-interpeduncular tract of diencephalon"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
-  "synonym": [
-    "habenulo-interpeduncular tract of diencephalon",
-    "habenulo-interpeduncular tract of diencephalon"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -2,16 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/habenulointerpeduncularTractOfMidbrain",
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/habenuloInterpeduncularTractOfMidbrain",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of midbrain' is a fasciculus of brain. It is part of the midbrain tegmentum, habenulo-interpeduncular tract and white matter of midbrain.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the midbrain tegmentum, the habenulo-interpeduncular tract and the white matter of midbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023740) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104857",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
   "synonym": [
     "habenulo-interpeduncular tract of midbrain",
-    "hipm"
+    "habenulo-interpeduncular tract of midbrain"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
-  "synonym": [
-    "habenulo-interpeduncular tract of midbrain",
-    "habenulo-interpeduncular tract of midbrain"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mammillotectalAxonalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697) ('is_a' and 'relationship')]",
+  "description": "The mammillotectal tract is the collection of axons that connects the ventral diencephalon to the superior colliculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006697#mammillotectal-axonal-tract",
+  "name": "mammillotectal axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006697",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mammillotegmentalAxonalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698) ('is_a' and 'relationship')]",
+  "description": "The mammillotegmental tract is the collection of axons that connects the ventral diencephalon to the tegmentum and pons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006698#mammillotegmental-fasciculus",
+  "name": "mammillotegmental axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006698",
+  "synonym": [
+    "Gudden tract",
+    "mammillotegmental fasciculus",
+    "mammillotegmental tract",
+    "mammillotegmental tract of hypothalamus",
+    "von Gudden's tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mammillothalamicAxonalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter and the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696) ('is_a' and 'relationship')]",
+  "description": "A fiber pathway that originates from neurons in the posterior hypothalamic region and projects to various nuclei of the anterior nuclear group of the thalamus. It is a composite structure that consists of the mammillothalamic tract of the hypothalamus and the mammillothalamic tract of the thalamus (Carpenter-1983). (from Brain Info.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006696#mammillothalamic-axonal-tract",
+  "name": "mammillothalamic axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006696",
+  "synonym": [
+    "fasciculus mammillothalamicus",
+    "mammillothalamic fasciculus",
+    "mammillothalamic tract",
+    "vicq d'azyr's bundle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
@@ -4,16 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/mammillothalamicTractOfHypothalamus",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Mammillothalamic tract of hypothalamus' is a tract of diencephalon. It is part of the mammillary axonal complex.",
-  "description": "Part of mammillothalamic tract contained within the hypothalamus",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990) ('is_a' and 'relationship')]",
+  "description": "Part of mammillothalamic tract contained within the hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106507",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002990#mammillothalamic-tract-of-hypothalamus-1",
   "name": "mammillothalamic tract of hypothalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002990",
-  "synonym": [
-    "fasciculus mamillothalamicus (hypothalami)",
-    "mammillothalamic tract of hypothalamus",
-    "mammillothalamic tract of the hypothalamus",
-    "mthh"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/medialLongitudinalCatecholaminergicTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005341)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005341#medial-longitudinal-catecholaminergic-tract",
+  "name": "medial longitudinal catecholaminergic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005341",
+  "synonym": [
+    "mlct"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/medullaReticulospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the medulla towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004173#medulla-reticulospinal-tract",
+  "name": "medulla reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004173",
+  "synonym": [
+    "medullary reticulospinal tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -13,8 +13,7 @@
   "synonym": [
     "comb bundle",
     "nigrostriatal bundle",
-    "nigrostriatal fibers",
-    "nigrostriatal tract"
+    "nigrostriatal fibers"
   ]
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nigrostriatalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "description": "The term nigrostriatal fibers refers to a dopaminergic fiber pathway connecting the substantia nigra with the striatum. It is not readily distinguished in myelin-stained cross-sections (Carpenter-83). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014169#nigrostriatal-tract-1",
+  "name": "nigrostriatal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014169",
+  "synonym": [
+    "comb bundle",
+    "nigrostriatal bundle",
+    "nigrostriatal fibers",
+    "nigrostriatal tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/opticTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/opticTract.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/opticTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Optic tract' is a tract of diencephalon. It is part of the diencephalic white matter.",
-  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm[ZFA]. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM)[NIF].",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908) ('is_a' and 'relationship')]",
+  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108074",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001908#optic-tract-1",
   "name": "optic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001908",
-  "synonym": null
+  "synonym": [
+    "optic lemniscus"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pinealTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pinealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pinealTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715) ('is_a' and 'relationship')]",
+  "description": "A cranial nerve fiber tract that innervates the pineal body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034715#pineal-tract",
+  "name": "pineal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034715",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ponsReticulospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004172#pons-reticulospinal-tract",
+  "name": "pons reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004172",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preopticohypothalamicTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005344)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005344#preopticohypothalamic-tract",
+  "name": "preopticohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005344",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
   "name": "reticulospinal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
-  "synonym": [
-    "reticulospinal tract",
-    "reticulospinal tract"
-  ]
+  "synonym": null
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/reticulospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943) ('is_a' and 'relationship')]",
+  "description": "The reticulospinal tract (or anterior reticulospinal tract) is an extrapyramidal motor tract which travels from the reticular formation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
+  "name": "reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
+  "synonym": [
+    "reticulospinal tract",
+    "reticulospinal tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rostralEpiphysealTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716) ('is_a' and 'relationship')]",
+  "description": "The more rostral of the two branches of the epiphyseal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034716#rostral-epiphyseal-tract",
+  "name": "rostral epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034716",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rubrospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rubrospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rubrospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714) ('is_a' and 'relationship')]",
+  "description": "White matter tract arising in red nucleus and projecting to spinal cord ventral horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002714#rubrospinal-tract-1",
+  "name": "rubrospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002714",
+  "synonym": [
+    "Monakow's tract",
+    "rubrospinal tract (Monakow)"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/secondaryGustatoryTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000430#secondary-gustatory-tract",
+  "name": "secondary gustatory tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000430",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/solitaryTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/solitaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/solitaryTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718) ('is_a' and 'relationship')]",
+  "description": "The solitary tract is a compact fiber bundle that extends longitudinally through the posterolateral region of the medulla. The solitary tract is surrounded by the nucleus of the solitary tract, and descends to the upper cervical segments of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002718#solitary-tract-1",
+  "name": "solitary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002718",
+  "synonym": [
+    "respiratory bundle of Gierke"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/solitaryTractNuclearComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126) ('is_a' and 'relationship')]",
+  "description": "The solitary tract and nucleus are structures in the brainstem that carry and receive visceral sensation and taste from the facial (VII), glossopharyngeal (IX) and vagus (X) cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002126#solitary-tract-nuclear-complex",
+  "name": "solitary tract nuclear complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002126",
+  "synonym": [
+    "nuclei of solitary tract",
+    "nucleus tractus solitarii",
+    "solitary nuclei"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalTrigeminalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761) ('is_a' and 'relationship')]",
+  "description": "Brainstem tract formed by the central processes of first-order, trigeminal ganglion neurons that extends from the caudal medulla to the midpons. This tract conveys nociceptive and thermal information from the face to second-order neurons in the spinal nucleus of the trigeminal complex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014761#spinal-trigeminal-tract",
+  "name": "spinal trigeminal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014761",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalTrigeminalTractOfMedulla",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of medulla' is a spinal trigeminal tract. It is part of the medulla oblongata.",
-  "description": "Part of spinal trigeminal tract located in the medulla",
+  "definition": "Is a spinal trigeminal tract. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715) ('is_a' and 'relationship')]",
+  "description": "Part of spinal trigeminal tract located in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110958",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002715#spinal-trigeminal-tract-of-medulla-1",
   "name": "spinal trigeminal tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002715",
-  "synonym": [
-    "spinal trigeminal tract of the medulla",
-    "tractus spinalis nervi trigemini (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinalTrigeminalTractOfPons",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of pons' is a spinal trigeminal tract. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a spinal trigeminal tract. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002800) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110959",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002800#spinal-trigeminal-tract-of-pons-1",
   "name": "spinal trigeminal tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002800",
-  "synonym": [
-    "spinal trigeminal tract of the pons",
-    "tractus spinalis nervi trigemini (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinoOlivaryTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719) ('is_a' and 'relationship')]",
+  "description": "The spino-olivary tract is located in the ventral funiculus of the spinal cord. This tract carries proprioception information from muscles and tendons as well as cutaneous impulses to the olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002719#spino-olivary-tract-1",
+  "name": "spino-olivary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002719",
+  "synonym": [
+    "helweg's tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTract.jsonld
@@ -4,13 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinothalamicTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "",
-  "description": "The 'spinothalamic tract' is a white matter fibre bundle. It originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus.",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
+  "description": "A tract that originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus. It is formed in the medulla by merger of the anterior spinothalamic tract and lateral spinothalamic tract (adapted from Braininfo.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110973",
-  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract-1",
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract",
   "name": "spinothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007703",
-  "synonym": [
-    "spth"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinothalamicTractOfMedulla",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Spinothalamic tract of medulla' is a tract of brain. It is part of the medulla oblongata and spinothalamic tract.",
-  "description": "Part of spinothalamic tract in the medulla",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002944#spinothalamic-tract-of-medulla-1",
   "name": "spinothalamic tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002944",
-  "synonym": [
-    "spinothalamic tract",
-    "spinothalamic tract of the medulla",
-    "tractus spinothalamicus (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinothalamicTractOfMidbrain",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Spinothalamic tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and spinothalamic tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002609) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110975",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002609#spinothalamic-tract-of-midbrain-1",
   "name": "spinothalamic tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002609",
-  "synonym": [
-    "spinothalamic tract of the midbrain",
-    "stmb",
-    "tractus spinothalamicus (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/spinothalamicTractOfPons",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Spinothalamic tract of pons' is a tract of brain. It is part of the pontine tegmentum and spinothalamic tract.",
-  "description": "Part of spinothalamic tract that is in the pontine tegmentum",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110976",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002798#spinothalamic-tract-of-pons-1",
   "name": "spinothalamic tract of pons",
@@ -15,11 +15,9 @@
     "pons of varolius spinothalamic tract of medulla",
     "pons spinothalamic tract",
     "pons spinothalamic tract of medulla",
-    "spinotectal pathway",
     "spinothalamic tract of medulla of pons",
     "spinothalamic tract of medulla of pons of varolius",
-    "spinothalamic tract of pons of varolius",
-    "spinothalamic tract of the pons",
-    "tractus spinothalamicus (pontis)"
+    "spinothalamic tract of pons of varolius"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/supraopticTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/supraopticTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/supraopticTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a brain white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002244)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002244#supraoptic-tract",
+  "name": "supraoptic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002244",
+  "synonym": [
+    "SOT"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/supraopticohypophysialTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the anterior hypothalamic region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002699) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002699#supraopticohypophysial-tract-1",
+  "name": "supraopticohypophysial tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002699",
+  "synonym": [
+    "supra-opticohypophysial tract",
+    "supraopticohypophyseal tract",
+    "tractus supraopticohypophysialis"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tectobulbarTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tectobulbarTract.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tectobulbarTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Tectobulbar tract' is a tract of brain. It is part of the medulla oblongata.",
-  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain.",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164) ('is_a' and 'relationship')]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111548",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002164#tectobulbar-tract-1",
   "name": "tectobulbar tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002164",
   "synonym": [
-    "tecto-bulbar tract",
-    "tractus tectobulbaris"
+    "tecto-bulbar tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tectopontineTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tectopontineTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tectopontineTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Tectopontine tract' is a tract of brain. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002930) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002930#tectopontine-tract-1",
   "name": "tectopontine tract",
@@ -13,7 +13,7 @@
   "synonym": [
     "fibrae tectopontinae",
     "tectopontine fibers",
-    "tectopontine fibres",
-    "tractus tectopontinus"
+    "tectopontine fibres"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tectospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tectospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tectospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the superior colliculus of the midbrain towards target cells in the ventral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002949#tectospinal-tract-1",
+  "name": "tectospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002949",
+  "synonym": [
+    "Held's bundle",
+    "tectospinal pathway"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tectothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tectothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tectothalamicTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035570#tectothalamic-tract",
+  "name": "tectothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035570",
+  "synonym": [
+    "tectothalamic fibers"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/telencephalicTracts.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/telencephalicTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/telencephalicTracts",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a white matter of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000597)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000597#telencephalic-tracts",
+  "name": "telencephalic tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000597",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/thalamicFiberTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Thalamic fiber tract' is a tract of diencephalon. It is part of the dorsal plus ventral thalamus.",
+  "definition": "Is a tract of diencephalon. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025261) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730765",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025261#thalamic-fiber-tracts",
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
-  "synonym": null
+  "synonym": [
+    "thalamic fiber tracts",
+    "thalamic fiber tracts"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -11,7 +11,6 @@
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
   "synonym": [
-    "thalamic fiber tracts",
     "thalamic fiber tracts"
   ]
 }

--- a/instances/v3.0/terminologies/UBERONParcellation/tractOfBrain.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tractOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tractOfBrain",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Tract of brain' is an axon tract. It is part of the brain and white matter.",
-  "description": "An axon tract that is part of a brain.",
+  "definition": "Is an axon tract. Is part of the brain and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736079",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007702#tract-of-brain",
   "name": "tract of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007702",
-  "synonym": null
+  "synonym": [
+    "brain tract"
+  ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tractOfDiencephalon",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a diencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011591#tract-of-diencephalon",
+  "name": "tract of diencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011591",
+  "synonym": [
+    "diencephalon tract"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tractOfThePostopticCommissure",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a diencephalic white matter. Is part of the postoptic commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001366) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001366#tract-of-the-postoptic-commissure",
+  "name": "tract of the postoptic commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001366",
+  "synonym": [
+    "TPOC"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/tractusSacciVasculosi",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035146)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035146#tractus-sacci-vasculosi",
+  "name": "tractus sacci vasculosi",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035146",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/trigeminothalamicTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "description": "The trigeminothalamic tract is one of the major routes of nociceptive and temperature signaling from the face. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004171#trigeminal-tract",
+  "name": "trigeminothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004171",
+  "synonym": [
+    "tractus trigeminothalamicus"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/uncrossedTectoBulbarTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000296) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000296#uncrossed-tecto-bulbar-tract",
+  "name": "uncrossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000296",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ventralTrigeminalTract",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Ventral trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons .",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549) ('is_a' and 'relationship')]",
+  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112361",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002549#ventral-trigeminal-tract-1",
   "name": "ventral trigeminal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002549",
   "synonym": [
     "anterior trigeminothalamic tract",
-    "tractus trigeminalis ventralis",
     "tractus trigeminothalamicus anterior",
     "trigeminal lemniscus-2",
     "ventral crossed tract",
     "ventral secondary ascending tract of V",
     "ventral trigeminal pathway",
-    "ventral trigeminal tract",
     "ventral trigeminothalamic tract"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/vestibulospinalTract",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the vestibular nucleus of the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002768#vestibulospinal-tract-1",
+  "name": "vestibulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002768",
+  "synonym": [
+    "vestibulo-spinal tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/accessoryOpticTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/accessoryOpticTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035595) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035595#accessory-optic-tract",
+  "name": "accessory optic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035595",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/axonTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/axonTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/axonTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "description": "A group of axons linking two or more neuropils and having a common origin, termination. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001018)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001018#nerve-tract",
+  "name": "axon tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001018",
+  "synonym": [
+    "axonal tract",
+    "neuraxis tract",
+    "tract of neuraxis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "description": "A pathway containing fibers from midbrain nuclei that project to the inferior olivary complex, as well as fibers originating in the pontine reticular formation and the medullary reticular formation that project to several nuclei of the thalamus. It can be identified in the midbrain and the pons (Adapted from Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009643)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009643#central-tegmental-tract",
+  "name": "central tegmental tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009643",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Central tegmental tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002585) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101918",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002585#central-tegmental-tract-of-midbrain-1",
   "name": "central tegmental tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002585",
-  "synonym": [
-    "central tegmental tract of the midbrain",
-    "ctgmb",
-    "tractus tegmentalis centralis (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/centralTegmentalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/centralTegmentalTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Central tegmental tract of pons' is a tract of brain. It is part of the pontine tegmentum and central tegmental tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the central tegmental tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002783) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0101919",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002783#central-tegmental-tract-of-pons-1",
   "name": "central tegmental tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002783",
-  "synonym": [
-    "central tegmental tract of the pons",
-    "tractus tegmentalis centralis (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/crossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/crossedTectoBulbarTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000335) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000335#crossed-tecto-bulbar-tract",
+  "name": "crossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000335",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dentatothalamicTract.jsonld
@@ -4,15 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dentatothalamicTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Dentatothalamic tract' is a tract of brain. It is part of the midbrain tegmentum.",
-  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [WP,unvetted].",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594) ('is_a' and 'relationship')]",
+  "description": "The dentatothalamic tract (or dentatorubrothalamic tract) is a tract which connects the dentate nucleus and the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002594)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103087",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002594#dentatothalamic-tract-1",
   "name": "dentatothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002594",
   "synonym": [
-    "dentatothalamic fibers",
-    "DT",
-    "tractus dentatothalamicus"
+    "dentatothalamic fibers"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/dorsalTrigeminalTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalTrigeminalTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Dorsal trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [WP,unvetted].",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797) ('is_a' and 'relationship')]",
+  "description": "The dorsal trigeminal tract (dorsal trigeminothalamic tract, or lemniscus) is a tract which receives signals from Meissner's corpuscles and Pacinian corpuscles. this tract arises from Principal trigeminal nucleus and terminates in the VPM nucleus of the thalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002797)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0103494",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002797#dorsal-trigeminal-tract-1",
   "name": "dorsal trigeminal tract",
@@ -13,18 +13,15 @@
   "synonym": [
     "dorsal ascending trigeminal tract",
     "dorsal division of trigeminal lemniscus",
-    "Dorsal secondary ascending tract of V",
-    "Dorsal secondary tract of V",
+    "dorsal secondary ascending tract of v",
+    "dorsal secondary tract of v",
     "dorsal trigeminal lemniscus",
     "dorsal trigeminal pathway",
-    "dorsal trigemino-thalamic tract",
     "dorsal trigeminothalamic tract",
-    "dorsal trigmino-thalamic tract",
     "posterior trigeminothalamic tract",
     "reticulothalamic tract",
-    "tractus trigeminalis dorsalis",
-    "tractus trigemino-thalamicus dorsalis",
     "tractus trigeminothalamicus posterior",
     "uncrossed dorsal trigeminothalamic tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/endohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/endohypothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "description": "CNS white matter, axonal tract interconnecting catecholaminergic cell groups in the posterior tuberculum and hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005343)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005343#endohypothalamic-tract",
+  "name": "endohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005343",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/epiphysealTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/epiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/epiphysealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "description": "A cranial nerve fiber tract that innervates the parietal eye. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034714#epiphyseal-tract",
+  "name": "epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034714",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/forebrainIpsilateralFiberTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/forebrainIpsilateralFiberTracts",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022247) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022247#forebrain-ipsilateral-fiber-tracts",
+  "name": "forebrain ipsilateral fiber tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022247",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/habenuloInterpeduncularTract.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a fasciculus of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "description": "White matter tract containing fibers projecting from the habenular nuclei to the interpeduncular nucleus (Maryann Martone) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002138)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002138#fasciculus-retroflexus",
+  "name": "habenulo-interpeduncular tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002138",
+  "synonym": [
+    "fasciculus retroflexus",
+    "fasciculus retroflexus (Meynert)",
+    "habenulointerpeduncular fasciculus",
+    "habenulopeduncular tract",
+    "Meynert's retroflex bundle",
+    "tractus habenulo-interpeduncularis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
-  "synonym": [
-    "habenulo-interpeduncular tract of diencephalon",
-    "habenulo-interpeduncular tract of diencephalon"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon.jsonld
@@ -2,15 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenulointerpeduncularTractOfDiencephalon",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTractOfDiencephalon",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of diencephalon' is a fasciculus of brain. It is part of the habenulo-interpeduncular tract and diencephalic white matter.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the habenulo-interpeduncular tract and the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022649) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104856",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022649#habenulo-interpeduncular-tract-of-diencephalon-1",
   "name": "habenulo-interpeduncular tract of diencephalon",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022649",
   "synonym": [
+    "habenulo-interpeduncular tract of diencephalon",
     "habenulo-interpeduncular tract of diencephalon"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -2,16 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenulointerpeduncularTractOfMidbrain",
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/habenuloInterpeduncularTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Habenulo-interpeduncular tract of midbrain' is a fasciculus of brain. It is part of the midbrain tegmentum, habenulo-interpeduncular tract and white matter of midbrain.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the midbrain tegmentum, the habenulo-interpeduncular tract and the white matter of midbrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0023740) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104857",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
   "synonym": [
     "habenulo-interpeduncular tract of midbrain",
-    "hipm"
+    "habenulo-interpeduncular tract of midbrain"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/habenulointerpeduncularTractOfMidbrain.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0023740#habenulo-interpeduncular-tract-of-midbrain-1",
   "name": "habenulo-interpeduncular tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0023740",
-  "synonym": [
-    "habenulo-interpeduncular tract of midbrain",
-    "habenulo-interpeduncular tract of midbrain"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mammillotectalAxonalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillotectalAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697) ('is_a' and 'relationship')]",
+  "description": "The mammillotectal tract is the collection of axons that connects the ventral diencephalon to the superior colliculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006697)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006697#mammillotectal-axonal-tract",
+  "name": "mammillotectal axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006697",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mammillotegmentalAxonalTract.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillotegmentalAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698) ('is_a' and 'relationship')]",
+  "description": "The mammillotegmental tract is the collection of axons that connects the ventral diencephalon to the tegmentum and pons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006698)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006698#mammillotegmental-fasciculus",
+  "name": "mammillotegmental axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006698",
+  "synonym": [
+    "Gudden tract",
+    "mammillotegmental fasciculus",
+    "mammillotegmental tract",
+    "mammillotegmental tract of hypothalamus",
+    "von Gudden's tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mammillothalamicAxonalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillothalamicAxonalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter and the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696) ('is_a' and 'relationship')]",
+  "description": "A fiber pathway that originates from neurons in the posterior hypothalamic region and projects to various nuclei of the anterior nuclear group of the thalamus. It is a composite structure that consists of the mammillothalamic tract of the hypothalamus and the mammillothalamic tract of the thalamus (Carpenter-1983). (from Brain Info.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006696)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006696#mammillothalamic-axonal-tract",
+  "name": "mammillothalamic axonal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006696",
+  "synonym": [
+    "fasciculus mammillothalamicus",
+    "mammillothalamic fasciculus",
+    "mammillothalamic tract",
+    "vicq d'azyr's bundle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/mammillothalamicTractOfHypothalamus.jsonld
@@ -4,16 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/mammillothalamicTractOfHypothalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Mammillothalamic tract of hypothalamus' is a tract of diencephalon. It is part of the mammillary axonal complex.",
-  "description": "Part of mammillothalamic tract contained within the hypothalamus",
+  "definition": "Is a tract of diencephalon. Is part of the mammillary axonal complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990) ('is_a' and 'relationship')]",
+  "description": "Part of mammillothalamic tract contained within the hypothalamus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002990)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106507",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002990#mammillothalamic-tract-of-hypothalamus-1",
   "name": "mammillothalamic tract of hypothalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002990",
-  "synonym": [
-    "fasciculus mamillothalamicus (hypothalami)",
-    "mammillothalamic tract of hypothalamus",
-    "mammillothalamic tract of the hypothalamus",
-    "mthh"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/medialLongitudinalCatecholaminergicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medialLongitudinalCatecholaminergicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005341)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005341#medial-longitudinal-catecholaminergic-tract",
+  "name": "medial longitudinal catecholaminergic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005341",
+  "synonym": [
+    "mlct"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/medullaReticulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/medullaReticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the medulla towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004173)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004173#medulla-reticulospinal-tract",
+  "name": "medulla reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004173",
+  "synonym": [
+    "medullary reticulospinal tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nigrostriatalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "description": "The term nigrostriatal fibers refers to a dopaminergic fiber pathway connecting the substantia nigra with the striatum. It is not readily distinguished in myelin-stained cross-sections (Carpenter-83). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014169)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014169#nigrostriatal-tract-1",
+  "name": "nigrostriatal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014169",
+  "synonym": [
+    "comb bundle",
+    "nigrostriatal bundle",
+    "nigrostriatal fibers",
+    "nigrostriatal tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/nigrostriatalTract.jsonld
@@ -13,8 +13,7 @@
   "synonym": [
     "comb bundle",
     "nigrostriatal bundle",
-    "nigrostriatal fibers",
-    "nigrostriatal tract"
+    "nigrostriatal fibers"
   ]
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/opticTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/opticTract.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/opticTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Optic tract' is a tract of diencephalon. It is part of the diencephalic white matter.",
-  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm[ZFA]. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM)[NIF].",
+  "definition": "Is a tract of diencephalon. Is part of the diencephalic white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908) ('is_a' and 'relationship')]",
+  "description": "Diencephalic white matter (tract) which is comprised of retinal ganglion cell axons after which they have passed through the optic chiasm. Predominantly white matter structure found in diencephalon consisting of fibers originating in the retina. The optic tract is considered to extend from the point of the optic chiasm and terminates largely, although not exclusively, in the lateral geniculate complex. Other fibers end in the superior colliculus and other structures in the diencephalon, midbrain and brainstem (MM). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001908)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0108074",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001908#optic-tract-1",
   "name": "optic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001908",
-  "synonym": null
+  "synonym": [
+    "optic lemniscus"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pinealTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pinealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pinealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715) ('is_a' and 'relationship')]",
+  "description": "A cranial nerve fiber tract that innervates the pineal body. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034715)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034715#pineal-tract",
+  "name": "pineal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034715",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ponsReticulospinalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ponsReticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "description": "Axon tract that carries efferent (outgoing) action potentials from the cell body in the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004172)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004172#pons-reticulospinal-tract",
+  "name": "pons reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004172",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preopticohypothalamicTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preopticohypothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005344)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005344#preopticohypothalamic-tract",
+  "name": "preopticohypothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005344",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -10,9 +10,6 @@
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
   "name": "reticulospinal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
-  "synonym": [
-    "reticulospinal tract",
-    "reticulospinal tract"
-  ]
+  "synonym": null
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/reticulospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/reticulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. Is part of the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943) ('is_a' and 'relationship')]",
+  "description": "The reticulospinal tract (or anterior reticulospinal tract) is an extrapyramidal motor tract which travels from the reticular formation. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022943)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022943#reticulospinal-tract-1",
+  "name": "reticulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022943",
+  "synonym": [
+    "reticulospinal tract",
+    "reticulospinal tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rostralEpiphysealTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rostralEpiphysealTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a central nervous system cell part cluster and cranial neuron projection bundle. Is part of the epiphyseal tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716) ('is_a' and 'relationship')]",
+  "description": "The more rostral of the two branches of the epiphyseal tract. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034716)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034716#rostral-epiphyseal-tract",
+  "name": "rostral epiphyseal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034716",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rubrospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rubrospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rubrospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714) ('is_a' and 'relationship')]",
+  "description": "White matter tract arising in red nucleus and projecting to spinal cord ventral horn. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002714)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002714#rubrospinal-tract-1",
+  "name": "rubrospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002714",
+  "synonym": [
+    "Monakow's tract",
+    "rubrospinal tract (Monakow)"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/secondaryGustatoryTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/secondaryGustatoryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of medulla oblongata. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000430)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000430#secondary-gustatory-tract",
+  "name": "secondary gustatory tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000430",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/solitaryTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/solitaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/solitaryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718) ('is_a' and 'relationship')]",
+  "description": "The solitary tract is a compact fiber bundle that extends longitudinally through the posterolateral region of the medulla. The solitary tract is surrounded by the nucleus of the solitary tract, and descends to the upper cervical segments of the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002718)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002718#solitary-tract-1",
+  "name": "solitary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002718",
+  "synonym": [
+    "respiratory bundle of Gierke"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/solitaryTractNuclearComplex.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/solitaryTractNuclearComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126) ('is_a' and 'relationship')]",
+  "description": "The solitary tract and nucleus are structures in the brainstem that carry and receive visceral sensation and taste from the facial (VII), glossopharyngeal (IX) and vagus (X) cranial nerves. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002126)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002126#solitary-tract-nuclear-complex",
+  "name": "solitary tract nuclear complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002126",
+  "synonym": [
+    "nuclei of solitary tract",
+    "nucleus tractus solitarii",
+    "solitary nuclei"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the brainstem. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761) ('is_a' and 'relationship')]",
+  "description": "Brainstem tract formed by the central processes of first-order, trigeminal ganglion neurons that extends from the caudal medulla to the midpons. This tract conveys nociceptive and thermal information from the face to second-order neurons in the spinal nucleus of the trigeminal complex. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014761)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014761#spinal-trigeminal-tract",
+  "name": "spinal trigeminal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014761",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfMedulla.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTractOfMedulla",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of medulla' is a spinal trigeminal tract. It is part of the medulla oblongata.",
-  "description": "Part of spinal trigeminal tract located in the medulla",
+  "definition": "Is a spinal trigeminal tract. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715) ('is_a' and 'relationship')]",
+  "description": "Part of spinal trigeminal tract located in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002715)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110958",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002715#spinal-trigeminal-tract-of-medulla-1",
   "name": "spinal trigeminal tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002715",
-  "synonym": [
-    "spinal trigeminal tract of the medulla",
-    "tractus spinalis nervi trigemini (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinalTrigeminalTractOfPons.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinalTrigeminalTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinal trigeminal tract of pons' is a spinal trigeminal tract. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a spinal trigeminal tract. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002800) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110959",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002800#spinal-trigeminal-tract-of-pons-1",
   "name": "spinal trigeminal tract of pons",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002800",
-  "synonym": [
-    "spinal trigeminal tract of the pons",
-    "tractus spinalis nervi trigemini (pontis)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinoOlivaryTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinoOlivaryTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719) ('is_a' and 'relationship')]",
+  "description": "The spino-olivary tract is located in the ventral funiculus of the spinal cord. This tract carries proprioception information from muscles and tendons as well as cutaneous impulses to the olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002719)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002719#spino-olivary-tract-1",
+  "name": "spino-olivary tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002719",
+  "synonym": [
+    "helweg's tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTract.jsonld
@@ -4,13 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "",
-  "description": "The 'spinothalamic tract' is a white matter fibre bundle. It originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus.",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
+  "description": "A tract that originates from neurons in the spinal central gray and projects to various somatosensory nuclei of the thalamus. It is formed in the medulla by merger of the anterior spinothalamic tract and lateral spinothalamic tract (adapted from Braininfo.org) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007703)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110973",
-  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract-1",
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007703#spinothalamic-tract",
   "name": "spinothalamic tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007703",
-  "synonym": [
-    "spth"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfMedulla.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfMedulla",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of medulla' is a tract of brain. It is part of the medulla oblongata and spinothalamic tract.",
-  "description": "Part of spinothalamic tract in the medulla",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the medulla. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110974",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002944#spinothalamic-tract-of-medulla-1",
   "name": "spinothalamic tract of medulla",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002944",
-  "synonym": [
-    "spinothalamic tract",
-    "spinothalamic tract of the medulla",
-    "tractus spinothalamicus (myelencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfMidbrain.jsonld
@@ -4,15 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfMidbrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of midbrain' is a tract of brain. It is part of the midbrain tegmentum and spinothalamic tract.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the midbrain tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002609) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110975",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002609#spinothalamic-tract-of-midbrain-1",
   "name": "spinothalamic tract of midbrain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002609",
-  "synonym": [
-    "spinothalamic tract of the midbrain",
-    "stmb",
-    "tractus spinothalamicus (mesencephali)"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/spinothalamicTractOfPons.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/spinothalamicTractOfPons",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Spinothalamic tract of pons' is a tract of brain. It is part of the pontine tegmentum and spinothalamic tract.",
-  "description": "Part of spinothalamic tract that is in the pontine tegmentum",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum and the spinothalamic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798) ('is_a' and 'relationship')]",
+  "description": "Part of spinothalamic tract that is in the pontine tegmentum. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002798)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0110976",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002798#spinothalamic-tract-of-pons-1",
   "name": "spinothalamic tract of pons",
@@ -15,11 +15,9 @@
     "pons of varolius spinothalamic tract of medulla",
     "pons spinothalamic tract",
     "pons spinothalamic tract of medulla",
-    "spinotectal pathway",
     "spinothalamic tract of medulla of pons",
     "spinothalamic tract of medulla of pons of varolius",
-    "spinothalamic tract of pons of varolius",
-    "spinothalamic tract of the pons",
-    "tractus spinothalamicus (pontis)"
+    "spinothalamic tract of pons of varolius"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/supraopticTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/supraopticTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/supraopticTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a brain white matter. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2002244)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2002244#supraoptic-tract",
+  "name": "supraoptic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2002244",
+  "synonym": [
+    "SOT"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/supraopticohypophysialTract.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/supraopticohypophysialTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the anterior hypothalamic region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002699) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002699#supraopticohypophysial-tract-1",
+  "name": "supraopticohypophysial tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002699",
+  "synonym": [
+    "supra-opticohypophysial tract",
+    "supraopticohypophyseal tract",
+    "tractus supraopticohypophysialis"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tectobulbarTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tectobulbarTract.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectobulbarTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tectobulbar tract' is a tract of brain. It is part of the medulla oblongata.",
-  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain.",
+  "definition": "Is a tract of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164) ('is_a' and 'relationship')]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the optic tectum towards target cells in the premotor reticulospinal system in the hindbrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002164)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111548",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002164#tectobulbar-tract-1",
   "name": "tectobulbar tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002164",
   "synonym": [
-    "tecto-bulbar tract",
-    "tractus tectobulbaris"
+    "tecto-bulbar tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tectopontineTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tectopontineTract.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectopontineTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tectopontine tract' is a tract of brain. It is part of the pontine tegmentum.",
-  "description": "",
+  "definition": "Is a tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002930) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002930#tectopontine-tract-1",
   "name": "tectopontine tract",
@@ -13,7 +13,7 @@
   "synonym": [
     "fibrae tectopontinae",
     "tectopontine fibers",
-    "tectopontine fibres",
-    "tractus tectopontinus"
+    "tectopontine fibres"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tectospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tectospinalTract.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the superior colliculus of the midbrain towards target cells in the ventral spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002949)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002949#tectospinal-tract-1",
+  "name": "tectospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002949",
+  "synonym": [
+    "Held's bundle",
+    "tectospinal pathway"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tectothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tectothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tectothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of diencephalon. Is part of the optic tract. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035570) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035570#tectothalamic-tract",
+  "name": "tectothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035570",
+  "synonym": [
+    "tectothalamic fibers"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/telencephalicTracts.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/telencephalicTracts.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalicTracts",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a white matter of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000597)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000597#telencephalic-tracts",
+  "name": "telencephalic tracts",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000597",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -4,11 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/thalamicFiberTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Thalamic fiber tract' is a tract of diencephalon. It is part of the dorsal plus ventral thalamus.",
+  "definition": "Is a tract of diencephalon. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0025261) ('is_a' and 'relationship')]",
   "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0730765",
-  "knowledgeSpaceLink": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0025261#thalamic-fiber-tracts",
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
-  "synonym": null
+  "synonym": [
+    "thalamic fiber tracts",
+    "thalamic fiber tracts"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/thalamicFiberTract.jsonld
@@ -11,7 +11,6 @@
   "name": "thalamic fiber tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0025261",
   "synonym": [
-    "thalamic fiber tracts",
     "thalamic fiber tracts"
   ]
 }

--- a/instances/v4.0/terminologies/UBERONParcellation/tractOfBrain.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tractOfBrain.jsonld
@@ -4,11 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfBrain",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Tract of brain' is an axon tract. It is part of the brain and white matter.",
-  "description": "An axon tract that is part of a brain.",
+  "definition": "Is an axon tract. Is part of the brain and the white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a brain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0007702)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0736079",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0007702#tract-of-brain",
   "name": "tract of brain",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0007702",
-  "synonym": null
+  "synonym": [
+    "brain tract"
+  ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tractOfDiencephalon.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfDiencephalon",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. Is part of the diencephalon. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591) ('is_a' and 'relationship')]",
+  "description": "An axon tract that is part of a diencephalon. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0011591)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0011591#tract-of-diencephalon",
+  "name": "tract of diencephalon",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0011591",
+  "synonym": [
+    "diencephalon tract"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tractOfThePostopticCommissure.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractOfThePostopticCommissure",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a diencephalic white matter. Is part of the postoptic commissure. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2001366) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2001366#tract-of-the-postoptic-commissure",
+  "name": "tract of the postoptic commissure",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2001366",
+  "synonym": [
+    "TPOC"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/tractusSacciVasculosi.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/tractusSacciVasculosi",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035146)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035146#tractus-sacci-vasculosi",
+  "name": "tractus sacci vasculosi",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035146",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/trigeminothalamicTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/trigeminothalamicTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an axon tract. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "description": "The trigeminothalamic tract is one of the major routes of nociceptive and temperature signaling from the face. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004171)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004171#trigeminal-tract",
+  "name": "trigeminothalamic tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004171",
+  "synonym": [
+    "tractus trigeminothalamicus"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/uncrossedTectoBulbarTract.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/uncrossedTectoBulbarTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tectobulbar tract. Is part of the brainstem and spinal white matter. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2000296) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2000296#uncrossed-tecto-bulbar-tract",
+  "name": "uncrossed tecto-bulbar tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2000296",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ventralTrigeminalTract.jsonld
@@ -4,21 +4,20 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ventralTrigeminalTract",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Ventral trigeminal tract' is a trigeminothalamic tract and tract of brain. It is part of the pontine tegmentum.",
-  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons .",
+  "definition": "Is a trigeminothalamic tract and tract of brain. Is part of the pontine tegmentum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549) ('is_a' and 'relationship')]",
+  "description": "The Anterior trigeminothalamic tract (or ventral trigeminothalamic tract) serves as pain, temperature, and light touch pathway from the face, head and neck. It receives input from trigeminal nerve, facial nerve, glossopharyngeal nerve and vagus nerve. It receives discriminative tactile and pressure input from the contralateral principal sensory nucleus of CN V, which terminates in the ventral posteromedial nucleus of the thalamus. It then ascends to the contralateral sensory cortex via three neurons. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002549)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0112361",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002549#ventral-trigeminal-tract-1",
   "name": "ventral trigeminal tract",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002549",
   "synonym": [
     "anterior trigeminothalamic tract",
-    "tractus trigeminalis ventralis",
     "tractus trigeminothalamicus anterior",
     "trigeminal lemniscus-2",
     "ventral crossed tract",
     "ventral secondary ascending tract of V",
     "ventral trigeminal pathway",
-    "ventral trigeminal tract",
     "ventral trigeminothalamic tract"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/vestibulospinalTract.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/vestibulospinalTract",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a tract of brain. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "description": "A long process of a CNS neuron, that carries efferent (outgoing) action potentials from the cell body in the vestibular nucleus of the pons towards target cells in the spinal cord. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002768)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002768#vestibulospinal-tract-1",
+  "name": "vestibulospinal tract",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002768",
+  "synonym": [
+    "vestibulo-spinal tract"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'tract' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.