### PR TITLE
UBERON terms with 'rhombomere' in their name

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "description": "A segment of the developing hindbrain. In the vertebrate embryo, a rhombomere is a transiently divided segment of the developing neural tube, within the hindbrain region (a neuromere) in the area that will eventually become the rhombencephalon. The rhombomeres appear as a series of slightly constricted swellings in the neural tube, caudal to the cephalic flexure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001892#rhombomere-1",
+  "name": "rhombomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
+  "synonym": [
+    "hindbrain neuromere",
+    "rhombomere"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -11,8 +11,7 @@
   "name": "rhombomere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
   "synonym": [
-    "hindbrain neuromere",
-    "rhombomere"
+    "hindbrain neuromere"
   ]
 }
 

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere1.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere1.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "description": "Hindbrain segment or neuromere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005499#rhombomere-1",
+  "name": "rhombomere 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005499",
+  "synonym": [
+    "r1"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere10.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere10.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere10",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019285)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019285#rhombomere-10",
+  "name": "rhombomere 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019285",
+  "synonym": [
+    "r10"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere11.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere11.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere11",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019286)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019286#rhombomere-11",
+  "name": "rhombomere 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019286",
+  "synonym": [
+    "r11"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005566) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005566#rhombomere-floor-plate",
+  "name": "rhombomere 1 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005566",
+  "synonym": [
+    "floor plate r1",
+    "floor plate rhombomere 1"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005568#rhombomere-roof-plate",
+  "name": "rhombomere 1 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005568",
+  "synonym": [
+    "roof plate rhombomere 1"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere2.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere2.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "description": "The second transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005569#rhombomere-2",
+  "name": "rhombomere 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005569",
+  "synonym": [
+    "r2"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005570#rhombomere-2-floor-plate",
+  "name": "rhombomere 2 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005570",
+  "synonym": [
+    "floor plate r2",
+    "floor plate rhombomere 2",
+    "floorplate r2"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005572#rhombomere-2-roof-plate",
+  "name": "rhombomere 2 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005572",
+  "synonym": [
+    "roof plate rhombomere 2"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere3.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "description": "The third transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005507#rhombomere-3",
+  "name": "rhombomere 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005507",
+  "synonym": [
+    "r3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005573#rhombomere-3-floor-plate",
+  "name": "rhombomere 3 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005573",
+  "synonym": [
+    "floor plate r3",
+    "floor plate rhombomere 3",
+    "floorplate r3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005575#rhombomere-3-roof-plate",
+  "name": "rhombomere 3 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005575",
+  "synonym": [
+    "roof plate rhombomere 3"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere4.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere4.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "description": "The fourth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005511#rhombomere-4",
+  "name": "rhombomere 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005511",
+  "synonym": [
+    "r4"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005576#rhombomere-4-floor-plate",
+  "name": "rhombomere 4 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005576",
+  "synonym": [
+    "floor plate r4",
+    "floor plate rhombomere 4",
+    "floorplate r4"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005578#rhombomere-4-roof-plate",
+  "name": "rhombomere 4 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005578",
+  "synonym": [
+    "roof plate rhombomere 4"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere5.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere5.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "description": "The fifth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005515#rhombomere-5",
+  "name": "rhombomere 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005515",
+  "synonym": [
+    "r5"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005579#rhombomere-5-floor-plate",
+  "name": "rhombomere 5 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005579",
+  "synonym": [
+    "floor plate r5",
+    "floor plate rhombomere 5",
+    "floorplate r5"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005581#rhombomere-5-roof-plate",
+  "name": "rhombomere 5 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005581",
+  "synonym": [
+    "roof plate rhombomere 5"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere6.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere6.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "description": "The sixth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005519#rhombomere-6",
+  "name": "rhombomere 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005519",
+  "synonym": [
+    "r6"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005582#rhombomere-6-floor-plate",
+  "name": "rhombomere 6 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005582",
+  "synonym": [
+    "floor plate r6",
+    "floor plate rhombomere 6",
+    "floorplate r6"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005584#rhombomere-6-roof-plate",
+  "name": "rhombomere 6 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005584",
+  "synonym": [
+    "roof plate rhombomere 6"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere7.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere7.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "description": "The seventh transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005523#rhombomere-7",
+  "name": "rhombomere 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005523",
+  "synonym": [
+    "r7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005585#rhombomere-7-floor-plate",
+  "name": "rhombomere 7 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005585",
+  "synonym": [
+    "floor plate r7",
+    "floor plate rhombomere 7",
+    "floorplate r7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005587#rhombomere-7-roof-plate",
+  "name": "rhombomere 7 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005587",
+  "synonym": [
+    "roof plate rhombomere 7"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere8.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere8.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "description": "The eighth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005527#rhombomere-8",
+  "name": "rhombomere 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005527",
+  "synonym": [
+    "r8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005588#rhombomere-8-floor-plate",
+  "name": "rhombomere 8 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005588",
+  "synonym": [
+    "floor plate r8",
+    "floor plate rhombomere 8",
+    "floorplate r8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005590#rhombomere-8-roof-plate",
+  "name": "rhombomere 8 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005590",
+  "synonym": [
+    "roof plate rhombomere 8"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomere9.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomere9.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019284)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019284#rhombomere-9",
+  "name": "rhombomere 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019284",
+  "synonym": [
+    "r9"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereFloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005500#rhombomere-floor-plate",
+  "name": "rhombomere floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005500",
+  "synonym": [
+    "floor plate hindbrain",
+    "floor plate rhombomere region",
+    "rhombencephalon floor plate"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereRoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005502)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005502#rhombomere-roof-plate",
+  "name": "rhombomere roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005502",
+  "synonym": [
+    "roof plate rhombomere",
+    "roof plate rhombomere region",
+    "roof plate rhombomeres"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "description": "A segment of the developing hindbrain. In the vertebrate embryo, a rhombomere is a transiently divided segment of the developing neural tube, within the hindbrain region (a neuromere) in the area that will eventually become the rhombencephalon. The rhombomeres appear as a series of slightly constricted swellings in the neural tube, caudal to the cephalic flexure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001892#rhombomere-1",
+  "name": "rhombomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
+  "synonym": [
+    "hindbrain neuromere",
+    "rhombomere"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -11,8 +11,7 @@
   "name": "rhombomere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
   "synonym": [
-    "hindbrain neuromere",
-    "rhombomere"
+    "hindbrain neuromere"
   ]
 }
 

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere1.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere1.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere1",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "description": "Hindbrain segment or neuromere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005499#rhombomere-1",
+  "name": "rhombomere 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005499",
+  "synonym": [
+    "r1"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere10.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere10.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere10",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019285)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019285#rhombomere-10",
+  "name": "rhombomere 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019285",
+  "synonym": [
+    "r10"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere11.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere11.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere11",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019286)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019286#rhombomere-11",
+  "name": "rhombomere 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019286",
+  "synonym": [
+    "r11"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere1FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005566) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005566#rhombomere-floor-plate",
+  "name": "rhombomere 1 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005566",
+  "synonym": [
+    "floor plate r1",
+    "floor plate rhombomere 1"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere1RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005568#rhombomere-roof-plate",
+  "name": "rhombomere 1 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005568",
+  "synonym": [
+    "roof plate rhombomere 1"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere2.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere2.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere2",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "description": "The second transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005569#rhombomere-2",
+  "name": "rhombomere 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005569",
+  "synonym": [
+    "r2"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere2FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005570#rhombomere-2-floor-plate",
+  "name": "rhombomere 2 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005570",
+  "synonym": [
+    "floor plate r2",
+    "floor plate rhombomere 2",
+    "floorplate r2"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere2RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005572#rhombomere-2-roof-plate",
+  "name": "rhombomere 2 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005572",
+  "synonym": [
+    "roof plate rhombomere 2"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere3.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "description": "The third transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005507#rhombomere-3",
+  "name": "rhombomere 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005507",
+  "synonym": [
+    "r3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere3FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005573#rhombomere-3-floor-plate",
+  "name": "rhombomere 3 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005573",
+  "synonym": [
+    "floor plate r3",
+    "floor plate rhombomere 3",
+    "floorplate r3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere3RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005575#rhombomere-3-roof-plate",
+  "name": "rhombomere 3 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005575",
+  "synonym": [
+    "roof plate rhombomere 3"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere4.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere4.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere4",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "description": "The fourth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005511#rhombomere-4",
+  "name": "rhombomere 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005511",
+  "synonym": [
+    "r4"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere4FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005576#rhombomere-4-floor-plate",
+  "name": "rhombomere 4 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005576",
+  "synonym": [
+    "floor plate r4",
+    "floor plate rhombomere 4",
+    "floorplate r4"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere4RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005578#rhombomere-4-roof-plate",
+  "name": "rhombomere 4 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005578",
+  "synonym": [
+    "roof plate rhombomere 4"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere5.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere5.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere5",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "description": "The fifth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005515#rhombomere-5",
+  "name": "rhombomere 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005515",
+  "synonym": [
+    "r5"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere5FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005579#rhombomere-5-floor-plate",
+  "name": "rhombomere 5 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005579",
+  "synonym": [
+    "floor plate r5",
+    "floor plate rhombomere 5",
+    "floorplate r5"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere5RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005581#rhombomere-5-roof-plate",
+  "name": "rhombomere 5 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005581",
+  "synonym": [
+    "roof plate rhombomere 5"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere6.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere6.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere6",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "description": "The sixth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005519#rhombomere-6",
+  "name": "rhombomere 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005519",
+  "synonym": [
+    "r6"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere6FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005582#rhombomere-6-floor-plate",
+  "name": "rhombomere 6 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005582",
+  "synonym": [
+    "floor plate r6",
+    "floor plate rhombomere 6",
+    "floorplate r6"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere6RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005584#rhombomere-6-roof-plate",
+  "name": "rhombomere 6 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005584",
+  "synonym": [
+    "roof plate rhombomere 6"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere7.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere7.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere7",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "description": "The seventh transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005523#rhombomere-7",
+  "name": "rhombomere 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005523",
+  "synonym": [
+    "r7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere7FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005585#rhombomere-7-floor-plate",
+  "name": "rhombomere 7 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005585",
+  "synonym": [
+    "floor plate r7",
+    "floor plate rhombomere 7",
+    "floorplate r7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere7RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005587#rhombomere-7-roof-plate",
+  "name": "rhombomere 7 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005587",
+  "synonym": [
+    "roof plate rhombomere 7"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere8.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere8.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere8",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "description": "The eighth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005527#rhombomere-8",
+  "name": "rhombomere 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005527",
+  "synonym": [
+    "r8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere8FloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005588#rhombomere-8-floor-plate",
+  "name": "rhombomere 8 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005588",
+  "synonym": [
+    "floor plate r8",
+    "floor plate rhombomere 8",
+    "floorplate r8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere8RoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005590#rhombomere-8-roof-plate",
+  "name": "rhombomere 8 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005590",
+  "synonym": [
+    "roof plate rhombomere 8"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomere9.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomere9.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomere9",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019284)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019284#rhombomere-9",
+  "name": "rhombomere 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019284",
+  "synonym": [
+    "r9"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomereFloorPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005500#rhombomere-floor-plate",
+  "name": "rhombomere floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005500",
+  "synonym": [
+    "floor plate hindbrain",
+    "floor plate rhombomere region",
+    "rhombencephalon floor plate"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/rhombomereRoofPlate",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005502)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005502#rhombomere-roof-plate",
+  "name": "rhombomere roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005502",
+  "synonym": [
+    "roof plate rhombomere",
+    "roof plate rhombomere region",
+    "roof plate rhombomeres"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "description": "A segment of the developing hindbrain. In the vertebrate embryo, a rhombomere is a transiently divided segment of the developing neural tube, within the hindbrain region (a neuromere) in the area that will eventually become the rhombencephalon. The rhombomeres appear as a series of slightly constricted swellings in the neural tube, caudal to the cephalic flexure. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001892)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001892#rhombomere-1",
+  "name": "rhombomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
+  "synonym": [
+    "hindbrain neuromere",
+    "rhombomere"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere.jsonld
@@ -11,8 +11,7 @@
   "name": "rhombomere",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001892",
   "synonym": [
-    "hindbrain neuromere",
-    "rhombomere"
+    "hindbrain neuromere"
   ]
 }
 

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere1.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere1.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "description": "Hindbrain segment or neuromere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005499)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005499#rhombomere-1",
+  "name": "rhombomere 1",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005499",
+  "synonym": [
+    "r1"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere10.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere10.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere10",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019285)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019285#rhombomere-10",
+  "name": "rhombomere 10",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019285",
+  "synonym": [
+    "r10"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere11.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere11.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere11",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019286)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019286#rhombomere-11",
+  "name": "rhombomere 11",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019286",
+  "synonym": [
+    "r11"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere1FloorPlate.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005566) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005566#rhombomere-floor-plate",
+  "name": "rhombomere 1 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005566",
+  "synonym": [
+    "floor plate r1",
+    "floor plate rhombomere 1"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere1RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere1RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 1. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 1. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005568)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005568#rhombomere-roof-plate",
+  "name": "rhombomere 1 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005568",
+  "synonym": [
+    "roof plate rhombomere 1"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere2.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere2.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "description": "The second transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005569)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005569#rhombomere-2",
+  "name": "rhombomere 2",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005569",
+  "synonym": [
+    "r2"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere2FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005570)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005570#rhombomere-2-floor-plate",
+  "name": "rhombomere 2 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005570",
+  "synonym": [
+    "floor plate r2",
+    "floor plate rhombomere 2",
+    "floorplate r2"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere2RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere2RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 2. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 2. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005572)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005572#rhombomere-2-roof-plate",
+  "name": "rhombomere 2 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005572",
+  "synonym": [
+    "roof plate rhombomere 2"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere3.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "description": "The third transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005507)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005507#rhombomere-3",
+  "name": "rhombomere 3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005507",
+  "synonym": [
+    "r3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere3FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005573)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005573#rhombomere-3-floor-plate",
+  "name": "rhombomere 3 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005573",
+  "synonym": [
+    "floor plate r3",
+    "floor plate rhombomere 3",
+    "floorplate r3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere3RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere3RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 3. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 3. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005575)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005575#rhombomere-3-roof-plate",
+  "name": "rhombomere 3 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005575",
+  "synonym": [
+    "roof plate rhombomere 3"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere4.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere4.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "description": "The fourth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005511)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005511#rhombomere-4",
+  "name": "rhombomere 4",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005511",
+  "synonym": [
+    "r4"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere4FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005576)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005576#rhombomere-4-floor-plate",
+  "name": "rhombomere 4 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005576",
+  "synonym": [
+    "floor plate r4",
+    "floor plate rhombomere 4",
+    "floorplate r4"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere4RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere4RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 4. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 4. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005578)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005578#rhombomere-4-roof-plate",
+  "name": "rhombomere 4 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005578",
+  "synonym": [
+    "roof plate rhombomere 4"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere5.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere5.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "description": "The fifth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005515)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005515#rhombomere-5",
+  "name": "rhombomere 5",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005515",
+  "synonym": [
+    "r5"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere5FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005579)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005579#rhombomere-5-floor-plate",
+  "name": "rhombomere 5 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005579",
+  "synonym": [
+    "floor plate r5",
+    "floor plate rhombomere 5",
+    "floorplate r5"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere5RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere5RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 5. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 5. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005581)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005581#rhombomere-5-roof-plate",
+  "name": "rhombomere 5 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005581",
+  "synonym": [
+    "roof plate rhombomere 5"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere6.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere6.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "description": "The sixth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005519)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005519#rhombomere-6",
+  "name": "rhombomere 6",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005519",
+  "synonym": [
+    "r6"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere6FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005582)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005582#rhombomere-6-floor-plate",
+  "name": "rhombomere 6 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005582",
+  "synonym": [
+    "floor plate r6",
+    "floor plate rhombomere 6",
+    "floorplate r6"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere6RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere6RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 6. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 6. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005584)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005584#rhombomere-6-roof-plate",
+  "name": "rhombomere 6 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005584",
+  "synonym": [
+    "roof plate rhombomere 6"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere7.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere7.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "description": "The seventh transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005523)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005523#rhombomere-7",
+  "name": "rhombomere 7",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005523",
+  "synonym": [
+    "r7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere7FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005585)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005585#rhombomere-7-floor-plate",
+  "name": "rhombomere 7 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005585",
+  "synonym": [
+    "floor plate r7",
+    "floor plate rhombomere 7",
+    "floorplate r7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere7RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere7RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 7. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 7. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005587)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005587#rhombomere-7-roof-plate",
+  "name": "rhombomere 7 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005587",
+  "synonym": [
+    "roof plate rhombomere 7"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere8.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere8.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "description": "The eighth transiently divided segment of the developing rhombencephalon; rhombomeres are lineage restricted, express different genes from one another, and adopt different developmental fates; rhombomeres are numbered in caudal to rostral order. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005527)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005527#rhombomere-8",
+  "name": "rhombomere 8",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005527",
+  "synonym": [
+    "r8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere8FloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8FloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere floor plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588) ('is_a' and 'relationship')]",
+  "description": "A rhombomere floor plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005588)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005588#rhombomere-8-floor-plate",
+  "name": "rhombomere 8 floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005588",
+  "synonym": [
+    "floor plate r8",
+    "floor plate rhombomere 8",
+    "floorplate r8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere8RoofPlate.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere8RoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere roof plate. Is part of the rhombomere 8. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590) ('is_a' and 'relationship')]",
+  "description": "A rhombomere roof plate that is part of a rhombomere 8. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005590)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005590#rhombomere-8-roof-plate",
+  "name": "rhombomere 8 roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005590",
+  "synonym": [
+    "roof plate rhombomere 8"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomere9.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomere9.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomere9",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a rhombomere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0019284)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0019284#rhombomere-9",
+  "name": "rhombomere 9",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0019284",
+  "synonym": [
+    "r9"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomereFloorPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereFloorPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005500)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005500#rhombomere-floor-plate",
+  "name": "rhombomere floor plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005500",
+  "synonym": [
+    "floor plate hindbrain",
+    "floor plate rhombomere region",
+    "rhombencephalon floor plate"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/rhombomereRoofPlate.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/rhombomereRoofPlate",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the rhombomere. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005502)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005502#rhombomere-roof-plate",
+  "name": "rhombomere roof plate",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005502",
+  "synonym": [
+    "roof plate rhombomere",
+    "roof plate rhombomere region",
+    "roof plate rhombomeres"
+  ]
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)

Filtering:
any term with 'rhombomere' in name

Note: This is not to definitively group terms but to create smaller PRs with terms that are potentially related. Hopefully, this makes it easier to review but please do not request to remove terms because they do not fit into the grouping. Only consider whether or not they are suitable UBERONParcellations.