### PR TITLE
[part 9 of 12] A09 - unsorted UBERON terms (posteriorCoronaRadiata - ramusSupraotic)

### DIFF
--- a/instances/latest/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorCoronaRadiata",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the corona radiata of neuraxis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022427) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022427#posterior-corona-radiata",
+  "name": "posterior corona radiata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022427",
+  "synonym": [
+    "posterior portion of corona radiata"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorHypothalamicRegion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior hypothalamic region' is a regional part of brain. It is part of the hypothalamus.",
-  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat.",
+  "definition": "Is a regional part of brain. Is part of the hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770) ('is_a' and 'relationship')]",
+  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109099",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002770#posterior-hypothalamic-region-1",
   "name": "posterior hypothalamic region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002770",
   "synonym": [
-    "hypothalamus posterior",
     "mammillary level of hypothalamus",
     "mammillary region",
-    "PHR",
-    "posterior hypothalamus",
-    "regio hypothalamica posterior"
+    "posterior hypothalamus"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLimbOfInternalCapsule",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior limb of internal capsule' is a limb of internal capsule of telencephalon.",
-  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM)",
+  "definition": "Is a limb of internal capsule of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
+  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109100",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014527#posterior-limb-of-internal-capsule-1",
   "name": "posterior limb of internal capsule",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014527",
   "synonym": [
-    "capsula interna",
-    "crus posterius capsulae internae",
-    "pars posterior",
-    "posterior internal capsule",
-    "posterior limb",
-    "posterior limb of the internal capsule"
+    "capsula interna, pars posterior",
+    "crus posterius capsulae internae"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorMedianEminence",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior median eminence' is a regional part of brain. It is part of the median eminence of neurohypophysis.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the median eminence of neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002652) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109104",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002652#posterior-median-eminence-1",
   "name": "posterior median eminence",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002652",
-  "synonym": [
-    "PME",
-    "eminentia mediana posterior"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorNuclearComplexOfThalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior nuclear complex of thalamus' is a nuclear complex of neuraxis and gray matter of diencephalon. It is part of the dorsal thalamus.",
-  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction.  It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97)",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of diencephalon. Is part of the dorsal thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709) ('is_a' and 'relationship')]",
+  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction. It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109109",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002709#posterior-nuclear-complex",
   "name": "posterior nuclear complex of thalamus",
@@ -13,8 +13,6 @@
   "synonym": [
     "caudal thalamic nucleus",
     "nuclei posteriores thalami",
-    "parieto-occipital",
-    "PNC",
     "posterior complex of thalamus",
     "posterior complex of the thalamus",
     "posterior nuclear complex",
@@ -25,3 +23,4 @@
     "posterior thalamic nucleus"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorRecess.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorRecess.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorRecess",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338) ('is_a' and 'relationship')]",
+  "description": "Posterior protrusion of the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005338#posterior-recess",
+  "name": "posterior recess",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005338",
+  "synonym": [
+    "posterior recess of diencephalic ventricle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorThalamicPeduncle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a peduncle of thalamus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022243)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022243#posterior-thalamic-peduncle",
+  "name": "posterior thalamic peduncle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022243",
+  "synonym": [
+    "occipital peduncle",
+    "occipital thalamic peduncle",
+    "pedunculus ventrocaudalis thalami",
+    "posterior peduncle",
+    "ventrocaudal thalamic peduncle"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorThalamicRadiation",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The 'posterior thalamic radiation' is a white matter fibre bundle. It is part of the radiation of thalamus.",
-  "description": "",
+  "definition": "Is a radiation of cerebral hemisphere and radiation of thalamus. Is part of the retrolenticular part of internal capsule. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034747) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735032",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034747#posterior-thalamic-radiation",
   "name": "posterior thalamic radiation",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034747",
   "synonym": [
-    "pthr",
+    "posterior thalamic radiation",
     "radiatio posterior thalami",
-    "radiatio thalamica posterior",
-    "radiationes thalamicae posteriores"
+    "radiatio thalamica posterior"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postnatalSubventricularZone",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Postnatal subventricular zone' is a central nervous system cell part cluster and nervous system cell part layer. It is part of the forebrain.",
-  "description": "The subventricular zone (SVZ) is one of two sources of adult-born neurons in the mammalian brain, the other being the subgranular zone (SGZ) of the hippocampus. In most adult mammals, the SVZ is a three-layered sheath that lies along the lateral wall of the lateral ventricle and consists of type A, B, and C cells. Type A rest along the ventricle wall and are neuronal precursor cells, Type B are adjacent astrocytes, and Type C are immature precursors to the Type A neuroblasts. The neuronal precursor cells travel along the rostral migratory stream ensheathed in a tube of Type B astrocytes, until they reach the olfactory bulb. There they integrate into the existing cellular network and mature into local interneurons. While the majority become adult-born granule cells, a subset become periglomerular cells.Interestingly, the human SVZ differs from other mammals' in several ways. It consists of four layers rather than three: ependymal cells (layer I), a hypo cellular gap (layer II), a ribbon of astrocytes (layer III), and a transitional zone (layer IV). The astrocytes are capable of differentiating into many kinds of tissue including new neurons. However, there is no evidence that the proliferating neurons travel along the rostral migratory stream in a chain to populate the olfactory bulb with new interneurons, as is the case for other mammals.",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922) ('is_a' and 'relationship')]",
+  "description": "A mitotically active layer of cells surrounding the brain ventricles in the adult that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111233",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004922#subventricular-zone",
   "name": "postnatal subventricular zone",
@@ -13,16 +13,11 @@
   "synonym": [
     "adult subventricular zone",
     "brain subventricular zone",
-    "postnatal subependymal layer",
-    "postnatal subependymal plate",
-    "postnatal subependymal zone",
     "postnatal subventricular zone",
     "SEZ",
-    "subependymal layer",
-    "subependymal plate",
-    "subependymal zone",
     "subventricular zone",
     "subventricular zone of brain",
     "SVZ"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/postsubiculum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/postsubiculum.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postsubiculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Postsubiculum' is a regional part of brain. It is part of the retrohippocampal region.",
-  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex..  The border is characterized by an abrupt change in the cyto- and chemoarchitecture",
+  "definition": "Is a regional part of brain. Is part of the retrohippocampal region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971) ('is_a' and 'relationship')]",
+  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex. The border is characterized by an abrupt change in the cyto- and chemoarchitecture. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035971#postsubiculum",
   "name": "postsubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035971",
-  "synonym": [
-    "POST",
-    "postsubicular cortex"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preBotzingerComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the medulla oblongata. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "description": "The group of interneurons within the medulla oblongata's ventral respiratory group that are important for the generation of ventilatory (inspiratory) rhythmogenesis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006007#pre-botzinger-complex",
+  "name": "pre-Botzinger complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006007",
+  "synonym": [
+    "Pre-Bötzinger complex",
+    "preBötC"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/precentralOperculum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/precentralOperculum.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/precentralOperculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Precentral operculum' is a regional part of brain. It is part of the operculum of brain.",
-  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info).",
+  "definition": "Is a regional part of brain. Is part of the operculum of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605) ('is_a' and 'relationship')]",
+  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109194",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002605#precentral-operculum-1",
   "name": "precentral operculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002605",
   "synonym": [
-    "brodmann's area 6",
     "operculum precentrale"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/predorsalBundle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/predorsalBundle.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/predorsalBundle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Predorsal bundle' is a fasciculus of brain. It is part of the white matter of medulla oblongata.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002754) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109207",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002754#predorsal-bundle-1",
   "name": "predorsal bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002754",
   "synonym": [
-    "fasciculus praedorsalis (Tschermak)",
-    "fasciculus predorsalis",
-    "pd",
-    "Predorsal bundle of Edinger",
+    "predorsal bundle of Edinger",
     "predorsal fasciculus",
     "tectospinal fibers"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preoccipitalNotch",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Preoccipital notch' is an anatomical entity. It is part of the occipital lobe.",
-  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes.  It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia).",
+  "definition": "Is an anatomical entity. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698) ('is_a' and 'relationship')]",
+  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes. It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109223",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002698#preoccipital-notch-1",
   "name": "preoccipital notch",
@@ -15,9 +15,8 @@
     "incisura praeoccipitalis",
     "incisura preoccipitalis",
     "occipital notch",
-    "PON",
     "preoccipital incisura",
-    "preoccipital incisure",
-    "preoccipital notch"
+    "preoccipital incisure"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/preopercularRamule.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/preopercularRamule.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preopercularRamule",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ramus mandibularis externus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "description": "Ventral branch of the ramus mandibularis externus. This ramule have a superior and an inferior division, both innervating the preopercular line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010795#preopercular-ramule",
+  "name": "preopercular ramule",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010795",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/presubiculum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/presubiculum.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/presubiculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Presubiculum' is part of the hippocampal formation and parahippocampal gyrus.",
-  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus.",
+  "definition": "Is part of the hippocampal formation and the parahippocampal gyrus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
+  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109252",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001953#presubiculum-1",
   "name": "presubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001953",
   "synonym": [
-    "Area 27 of Brodmann",
-    "praesubiculum",
     "presubicular cortex (presubiculum)",
-    "presubiculum (Cajal)",
-    "PrS"
+    "presubiculum (Cajal)"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/pretectalRegion.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pretectalRegion.jsonld
@@ -4,22 +4,19 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pretectalRegion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Pretectal region' is a brain gray matter and nuclear complex of neuraxis.",
-  "description": "Region of brain lying between the midbrain tectum and the thalamus (Sefton and Dreher, in Paxinos, G The rat central nervous system, 1995, pg 859),  Situated at the level of poterior commissure and just rostral to the superior colliculus  (Brodal, Neurological Anatomy, 3rd ed, 1981, pg 542)",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
+  "description": "Nuclear complex between dorsal thalamus and optic tectum whose nuclei receive afferents primarily from the retina and the optic tectum and are involved in modulating motor behavior in response to visual input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109258",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001944#pretectal-region-1",
   "name": "pretectal region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001944",
   "synonym": [
-    "area praetectalis",
+    "area pretectalis",
     "area pretectalis",
     "nuclei pretectales",
-    "nucleus praetectalis",
-    "praetectum",
     "pretectal area",
     "pretectal nuclei",
-    "pretectal region",
-    "Pretectum",
-    "regio pretectalis"
+    "pretectum"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryMuscleSpindle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a muscle spindle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "description": "The sensory organ in muscle; involved in the stretch reflex and sensitive to stretch velocity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004010#primary-muscle-spindle",
+  "name": "primary muscle spindle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004010",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primarySuperiorOlive",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Primary superior olive' is a nuclear complex of neuraxis and gray matter of hindbrain. It is part of the superior olivary complex.",
-  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans.  (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617).  In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus.",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the superior olivary complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434) ('is_a' and 'relationship')]",
+  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans. (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617). In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111314",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022434#superior-olive",
   "name": "primary superior olive",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022434",
-  "synonym": [
-    "SOl",
-    "superior olive"
-  ]
+  "synonym": null
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primitiveMarginalSinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paired venous dural sinus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "description": "The primitive marginal sinuses (PMS) are embryonic sinuses forming the later superior sagittal sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0017638#primitive-marginal-sinus",
+  "name": "primitive marginal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0017638",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primitiveSuperiorSagittalSinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the venous dural sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009968)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009968#primitive-superior-sagittal-sinus",
+  "name": "primitive superior sagittal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009968",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/principalNeuronalCircuit",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circuit part of central nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "description": "A neuronal circuit bearing a principal projection neuron whose axon extends beyond the region where its soma is located to synapse on the dendrites of cells in other regions of the nervous system (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026546#principal-neuronal-circuit-1",
+  "name": "principal neuronal circuit",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026546",
+  "synonym": [
+    "principal neuronal circuit",
+    "principal neuronal circuit"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/proliferatingNeuroepithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a developing neuroepithelium. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "description": "An epithelium that is undergoing proliferation to provide large numbers of neuronal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034706#proliferating-neuroepithelium",
+  "name": "proliferating neuroepithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034706",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/prosomere.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/prosomere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/prosomere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "description": "A neuromere that is part of the presumptive forebrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014775#prosomere",
+  "name": "prosomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014775",
+  "synonym": [
+    "forebrain neuromere"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/putamen.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/putamen.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/putamen",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Putamen' is a telencephalic nucleus. It is part of the cerebral hemisphere and caudate-putamen.",
-  "description": "Subcortical nucleus of telencephalon , which together with the caudate nucleus, forms the striatum.  The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion.",
+  "definition": "Is a telencephalic nucleus. Is part of the cerebral hemisphere and the caudate-putamen. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874) ('is_a' and 'relationship')]",
+  "description": "Subcortical nucleus of telencephalic , which together with the caudate nucleus, forms the striatum. The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001874#putamen-1",
   "name": "putamen",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001874",
   "synonym": [
-    "Pu",
     "nucleus putamen"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pyramidOfMedullaOblongata",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159) ('is_a' and 'relationship')]",
+  "description": "The anterior or ventral portion of the medulla oblongata is named the pyramid and lies between the anterior median fissure and the antero-lateral sulcus. Its upper end is slightly constricted, and between it and the pons the fibers of the abducent nerve emerge; a little below the pons it becomes enlarged and prominent, and finally tapers into the anterior funiculus of the medulla spinalis, with which, at first sight, it appears to be directly continuous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005159#pyramid-of-medulla-oblongata",
+  "name": "pyramid of medulla oblongata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005159",
+  "synonym": [
+    "lobule VIII of Larsell",
+    "pyramid of medulla oblongata",
+    "pyramis (medullae oblongatae)",
+    "pyramis bulbi",
+    "pyramis medullae oblongatae"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pyramidalDecussation",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural decussation. Is part of the corticospinal tract and the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755) ('is_a' and 'relationship')]",
+  "description": "Part of medulla comprising a white matter structure containing nerve fibers of the pyramidal tract crossing from one side of the brain to the other (MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002755#pyramidal-decussation-1",
+  "name": "pyramidal decussation",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002755",
+  "synonym": [
+    "corticospinal decussation",
+    "decussatio pyramidum",
+    "decussatio pyramidum medullae oblongatae",
+    "decussation of corticospinal tract",
+    "decussation of pyramidal tract fibers",
+    "decussation of pyramids",
+    "decussation of pyramids of medulla",
+    "decussation of the pyramidal tract",
+    "motor decussation",
+    "motor decussation of medulla",
+    "pyramidal decussation (pourfour du petit)",
+    "pyramidal tract decussation"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/quadrigeminalCistern",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subarachnoid cistern. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "description": "The enclosed space extending forward between the corpus callosum and the thalamus that contains the internal cerebral veins. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004052#quadrigeminal-cistern",
+  "name": "quadrigeminal cistern",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004052",
+  "synonym": [
+    "ambient cistern",
+    "cistern of great cerebral vein",
+    "cisterna ambiens",
+    "cisterna quadrigeminalis",
+    "cisterna venae magnae cerebri",
+    "superior cistern"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfCerebralHemisphere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter and white matter radiation. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022260)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022260#radiation-of-cerebral-hemisphere",
+  "name": "radiation of cerebral hemisphere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022260",
+  "synonym": [
+    "cerebral hemisphere radiation"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfCorpusCallosum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the corpus callosum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924) ('is_a' and 'relationship')]",
+  "description": "The spreading out of the fibers of the corpus callosum in the centrum semiovale of each cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035924#radiation-of-corpus-callosum",
+  "name": "radiation of corpus callosum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035924",
+  "synonym": [
+    "corpus callosum radiation",
+    "radiatio corporis callosi"
+  ]
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfThalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The 'radiation of thalamus' is a white matter fibre bundle. It is part of of the thalamic complex.",
-  "description": "",
+  "definition": "Is a diencephalic white matter and white matter radiation. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034745) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724984",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034745#radiation-of-thalamus",
   "name": "radiation of thalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034745",
   "synonym": [
-    "thalamic radiation",
     "thalamus radiation"
   ]
 }
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulePalatinus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulePalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulePalatinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ramus nasalis internus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "description": "Ramules that descends towards the buccal roof and give rise to several short branches that anastomose with palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010665#ramule-palatinus",
+  "name": "ramule palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010665",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulePalatonasalis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671) ('is_a' and 'relationship')]",
+  "description": "Descends and branches to the buccal roof where it anastomoses with the palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010671#ramule-palatonasalis",
+  "name": "ramule palatonasalis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010671",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulesCutaneous",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve and the ramus nasalis internus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668) ('is_a' and 'relationship')]",
+  "description": "Many branches of the maxillary ramus that terminate in the integument of the maxillary region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010668#ramules-cutaneous",
+  "name": "ramules cutaneous",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010668",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulesNasalisLateralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the ophthalmic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652) ('is_a' and 'relationship')]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010652#ramules-nasalis-lateralis",
+  "name": "ramules nasalis lateralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010652",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulusSuprabranchialisAnterior",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "description": "Ramulus that innervates the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010798#ramulus-suprabranchialis-anterior",
+  "name": "ramulus suprabranchialis anterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010798",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulusSuprabranchialisPosterior",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "description": "Ramulus innervating the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010799#ramulus-suprabranchialis-posterior",
+  "name": "ramulus suprabranchialis posterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010799",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusAnteriorOfCNVIII",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "description": "Formed by fibers from the anterior semicircular canal and sacculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010735#ramus-anterior-of-cn-viii",
+  "name": "ramus anterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010735",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusBuccal.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusBuccal.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusBuccal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "description": "Ventral ramus of the ADLLN that innervates the infraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010759#ramus-buccal",
+  "name": "ramus buccal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010759",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusHyomandibularis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720) ('is_a' and 'relationship')]",
+  "description": "The posttrematic branch of the facial nerve, both motor and sensory in function. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010720#ramus-hyomandibularis",
+  "name": "ramus hyomandibularis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010720",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusLateral.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusLateral.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusLateral",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a posterior lateral line nerve (PLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "description": "Ventral division of the trunk of the PLLN, this prominent ramus extends over the lateral trunk and caudal musculature innervating the lateral line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010801#ramus-lateral",
+  "name": "ramus lateral",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010801",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMandibularisExternus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anteroventral lateral line nerve (AVLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "description": "Runs together with motor fibers of the hyomandibular trunk of VII. The mandibularis externus of AVLLN branches into three ramules. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010765#ramus-mandibularis-externus",
+  "name": "ramus mandibularis externus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010765",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusNasalisInternus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an ophthalmic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "description": "Distal part of the opthalmicus profundus gives rise to 2 ramules: palatinus and cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010661#ramus-nasalis-internus",
+  "name": "ramus nasalis internus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010661",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusNasalisMedialis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the ophthalmic nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010653#ramus-nasalis-medialis",
+  "name": "ramus nasalis medialis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010653",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusPalatinus.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusPalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPalatinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a facial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "description": "Sensory branch of facial nerve from palatal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010722#ramus-palatinus",
+  "name": "ramus palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010722",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPosteriorOfCNVIII",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "description": "Composed of two rami: a short ventral ramus innervating the cochlea (lagena and papille basilar), and a long dorsal ramus innervating the posterior semicircular canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010736#ramus-posterior-of-cn-viii",
+  "name": "ramus posterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010736",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPosteriorProfundusOfV3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the mandibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693) ('is_a' and 'relationship')]",
+  "description": "In the adult anuran, this innervates the muscles levator mandibulare internus and longus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010693#ramus-posterior-profundus-of-v3",
+  "name": "ramus posterior profundus of V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010693",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusRecurrens.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusRecurrens.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusRecurrens",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754) ('is_a' and 'relationship')]",
+  "description": "Branch of the vagus nerve that separates from the vagus well postcranially, then continues anteriorly to innervate the larynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010754#ramus-recurrens",
+  "name": "ramus recurrens",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010754",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusSuperficialOphthalmic",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "description": "Dorsal branch of ADLLN that innervates supraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010757#ramus-superficial-ophthalmic",
+  "name": "ramus superficial ophthalmic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010757",
+  "synonym": null
+}
+

--- a/instances/latest/terminologies/UBERONParcellation/ramusSupraotic.jsonld
+++ b/instances/latest/terminologies/UBERONParcellation/ramusSupraotic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusSupraotic",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "description": "Small ramus of the MLLN that innervates neuromasts located at the posterior margin of the otic capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010796#ramus-supraotic",
+  "name": "ramus supraotic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010796",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorCoronaRadiata",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the corona radiata of neuraxis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022427) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022427#posterior-corona-radiata",
+  "name": "posterior corona radiata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022427",
+  "synonym": [
+    "posterior portion of corona radiata"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorHypothalamicRegion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Posterior hypothalamic region' is a regional part of brain. It is part of the hypothalamus.",
-  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat.",
+  "definition": "Is a regional part of brain. Is part of the hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770) ('is_a' and 'relationship')]",
+  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109099",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002770#posterior-hypothalamic-region-1",
   "name": "posterior hypothalamic region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002770",
   "synonym": [
-    "hypothalamus posterior",
     "mammillary level of hypothalamus",
     "mammillary region",
-    "PHR",
-    "posterior hypothalamus",
-    "regio hypothalamica posterior"
+    "posterior hypothalamus"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorLimbOfInternalCapsule",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Posterior limb of internal capsule' is a limb of internal capsule of telencephalon.",
-  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM)",
+  "definition": "Is a limb of internal capsule of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
+  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109100",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014527#posterior-limb-of-internal-capsule-1",
   "name": "posterior limb of internal capsule",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014527",
   "synonym": [
-    "capsula interna",
-    "crus posterius capsulae internae",
-    "pars posterior",
-    "posterior internal capsule",
-    "posterior limb",
-    "posterior limb of the internal capsule"
+    "capsula interna, pars posterior",
+    "crus posterius capsulae internae"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorMedianEminence",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Posterior median eminence' is a regional part of brain. It is part of the median eminence of neurohypophysis.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the median eminence of neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002652) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109104",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002652#posterior-median-eminence-1",
   "name": "posterior median eminence",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002652",
-  "synonym": [
-    "PME",
-    "eminentia mediana posterior"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorNuclearComplexOfThalamus",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Posterior nuclear complex of thalamus' is a nuclear complex of neuraxis and gray matter of diencephalon. It is part of the dorsal thalamus.",
-  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction.  It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97)",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of diencephalon. Is part of the dorsal thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709) ('is_a' and 'relationship')]",
+  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction. It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109109",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002709#posterior-nuclear-complex",
   "name": "posterior nuclear complex of thalamus",
@@ -13,8 +13,6 @@
   "synonym": [
     "caudal thalamic nucleus",
     "nuclei posteriores thalami",
-    "parieto-occipital",
-    "PNC",
     "posterior complex of thalamus",
     "posterior complex of the thalamus",
     "posterior nuclear complex",
@@ -25,3 +23,4 @@
     "posterior thalamic nucleus"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorRecess.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorRecess.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorRecess",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338) ('is_a' and 'relationship')]",
+  "description": "Posterior protrusion of the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005338#posterior-recess",
+  "name": "posterior recess",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005338",
+  "synonym": [
+    "posterior recess of diencephalic ventricle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorThalamicPeduncle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a peduncle of thalamus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022243)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022243#posterior-thalamic-peduncle",
+  "name": "posterior thalamic peduncle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022243",
+  "synonym": [
+    "occipital peduncle",
+    "occipital thalamic peduncle",
+    "pedunculus ventrocaudalis thalami",
+    "posterior peduncle",
+    "ventrocaudal thalamic peduncle"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorThalamicRadiation",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "The 'posterior thalamic radiation' is a white matter fibre bundle. It is part of the radiation of thalamus.",
-  "description": "",
+  "definition": "Is a radiation of cerebral hemisphere and radiation of thalamus. Is part of the retrolenticular part of internal capsule. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034747) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735032",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034747#posterior-thalamic-radiation",
   "name": "posterior thalamic radiation",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034747",
   "synonym": [
-    "pthr",
+    "posterior thalamic radiation",
     "radiatio posterior thalami",
-    "radiatio thalamica posterior",
-    "radiationes thalamicae posteriores"
+    "radiatio thalamica posterior"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postnatalSubventricularZone",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Postnatal subventricular zone' is a central nervous system cell part cluster and nervous system cell part layer. It is part of the forebrain.",
-  "description": "The subventricular zone (SVZ) is one of two sources of adult-born neurons in the mammalian brain, the other being the subgranular zone (SGZ) of the hippocampus. In most adult mammals, the SVZ is a three-layered sheath that lies along the lateral wall of the lateral ventricle and consists of type A, B, and C cells. Type A rest along the ventricle wall and are neuronal precursor cells, Type B are adjacent astrocytes, and Type C are immature precursors to the Type A neuroblasts. The neuronal precursor cells travel along the rostral migratory stream ensheathed in a tube of Type B astrocytes, until they reach the olfactory bulb. There they integrate into the existing cellular network and mature into local interneurons. While the majority become adult-born granule cells, a subset become periglomerular cells.Interestingly, the human SVZ differs from other mammals' in several ways. It consists of four layers rather than three: ependymal cells (layer I), a hypo cellular gap (layer II), a ribbon of astrocytes (layer III), and a transitional zone (layer IV). The astrocytes are capable of differentiating into many kinds of tissue including new neurons. However, there is no evidence that the proliferating neurons travel along the rostral migratory stream in a chain to populate the olfactory bulb with new interneurons, as is the case for other mammals.",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922) ('is_a' and 'relationship')]",
+  "description": "A mitotically active layer of cells surrounding the brain ventricles in the adult that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111233",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004922#subventricular-zone",
   "name": "postnatal subventricular zone",
@@ -13,16 +13,11 @@
   "synonym": [
     "adult subventricular zone",
     "brain subventricular zone",
-    "postnatal subependymal layer",
-    "postnatal subependymal plate",
-    "postnatal subependymal zone",
     "postnatal subventricular zone",
     "SEZ",
-    "subependymal layer",
-    "subependymal plate",
-    "subependymal zone",
     "subventricular zone",
     "subventricular zone of brain",
     "SVZ"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/postsubiculum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/postsubiculum.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/postsubiculum",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Postsubiculum' is a regional part of brain. It is part of the retrohippocampal region.",
-  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex..  The border is characterized by an abrupt change in the cyto- and chemoarchitecture",
+  "definition": "Is a regional part of brain. Is part of the retrohippocampal region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971) ('is_a' and 'relationship')]",
+  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex. The border is characterized by an abrupt change in the cyto- and chemoarchitecture. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035971#postsubiculum",
   "name": "postsubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035971",
-  "synonym": [
-    "POST",
-    "postsubicular cortex"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preBotzingerComplex",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the medulla oblongata. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "description": "The group of interneurons within the medulla oblongata's ventral respiratory group that are important for the generation of ventilatory (inspiratory) rhythmogenesis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006007#pre-botzinger-complex",
+  "name": "pre-Botzinger complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006007",
+  "synonym": [
+    "Pre-Bötzinger complex",
+    "preBötC"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/precentralOperculum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/precentralOperculum.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/precentralOperculum",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Precentral operculum' is a regional part of brain. It is part of the operculum of brain.",
-  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info).",
+  "definition": "Is a regional part of brain. Is part of the operculum of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605) ('is_a' and 'relationship')]",
+  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109194",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002605#precentral-operculum-1",
   "name": "precentral operculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002605",
   "synonym": [
-    "brodmann's area 6",
     "operculum precentrale"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/predorsalBundle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/predorsalBundle.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/predorsalBundle",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Predorsal bundle' is a fasciculus of brain. It is part of the white matter of medulla oblongata.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002754) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109207",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002754#predorsal-bundle-1",
   "name": "predorsal bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002754",
   "synonym": [
-    "fasciculus praedorsalis (Tschermak)",
-    "fasciculus predorsalis",
-    "pd",
-    "Predorsal bundle of Edinger",
+    "predorsal bundle of Edinger",
     "predorsal fasciculus",
     "tectospinal fibers"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preoccipitalNotch",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Preoccipital notch' is an anatomical entity. It is part of the occipital lobe.",
-  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes.  It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia).",
+  "definition": "Is an anatomical entity. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698) ('is_a' and 'relationship')]",
+  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes. It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109223",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002698#preoccipital-notch-1",
   "name": "preoccipital notch",
@@ -15,9 +15,8 @@
     "incisura praeoccipitalis",
     "incisura preoccipitalis",
     "occipital notch",
-    "PON",
     "preoccipital incisura",
-    "preoccipital incisure",
-    "preoccipital notch"
+    "preoccipital incisure"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/preopercularRamule.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/preopercularRamule.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/preopercularRamule",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ramus mandibularis externus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "description": "Ventral branch of the ramus mandibularis externus. This ramule have a superior and an inferior division, both innervating the preopercular line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010795#preopercular-ramule",
+  "name": "preopercular ramule",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010795",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/presubiculum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/presubiculum.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/presubiculum",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Presubiculum' is part of the hippocampal formation and parahippocampal gyrus.",
-  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus.",
+  "definition": "Is part of the hippocampal formation and the parahippocampal gyrus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
+  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109252",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001953#presubiculum-1",
   "name": "presubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001953",
   "synonym": [
-    "Area 27 of Brodmann",
-    "praesubiculum",
     "presubicular cortex (presubiculum)",
-    "presubiculum (Cajal)",
-    "PrS"
+    "presubiculum (Cajal)"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pretectalRegion.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pretectalRegion.jsonld
@@ -4,22 +4,19 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pretectalRegion",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Pretectal region' is a brain gray matter and nuclear complex of neuraxis.",
-  "description": "Region of brain lying between the midbrain tectum and the thalamus (Sefton and Dreher, in Paxinos, G The rat central nervous system, 1995, pg 859),  Situated at the level of poterior commissure and just rostral to the superior colliculus  (Brodal, Neurological Anatomy, 3rd ed, 1981, pg 542)",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
+  "description": "Nuclear complex between dorsal thalamus and optic tectum whose nuclei receive afferents primarily from the retina and the optic tectum and are involved in modulating motor behavior in response to visual input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109258",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001944#pretectal-region-1",
   "name": "pretectal region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001944",
   "synonym": [
-    "area praetectalis",
+    "area pretectalis",
     "area pretectalis",
     "nuclei pretectales",
-    "nucleus praetectalis",
-    "praetectum",
     "pretectal area",
     "pretectal nuclei",
-    "pretectal region",
-    "Pretectum",
-    "regio pretectalis"
+    "pretectum"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primaryMuscleSpindle",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a muscle spindle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "description": "The sensory organ in muscle; involved in the stretch reflex and sensitive to stretch velocity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004010#primary-muscle-spindle",
+  "name": "primary muscle spindle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004010",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primarySuperiorOlive",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Primary superior olive' is a nuclear complex of neuraxis and gray matter of hindbrain. It is part of the superior olivary complex.",
-  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans.  (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617).  In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus.",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the superior olivary complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434) ('is_a' and 'relationship')]",
+  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans. (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617). In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111314",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022434#superior-olive",
   "name": "primary superior olive",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022434",
-  "synonym": [
-    "SOl",
-    "superior olive"
-  ]
+  "synonym": null
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primitiveMarginalSinus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a paired venous dural sinus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "description": "The primitive marginal sinuses (PMS) are embryonic sinuses forming the later superior sagittal sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0017638#primitive-marginal-sinus",
+  "name": "primitive marginal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0017638",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/primitiveSuperiorSagittalSinus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the venous dural sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009968)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009968#primitive-superior-sagittal-sinus",
+  "name": "primitive superior sagittal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009968",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/principalNeuronalCircuit",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a circuit part of central nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "description": "A neuronal circuit bearing a principal projection neuron whose axon extends beyond the region where its soma is located to synapse on the dendrites of cells in other regions of the nervous system (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026546#principal-neuronal-circuit-1",
+  "name": "principal neuronal circuit",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026546",
+  "synonym": [
+    "principal neuronal circuit",
+    "principal neuronal circuit"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/proliferatingNeuroepithelium",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a developing neuroepithelium. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "description": "An epithelium that is undergoing proliferation to provide large numbers of neuronal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034706#proliferating-neuroepithelium",
+  "name": "proliferating neuroepithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034706",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/prosomere.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/prosomere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/prosomere",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "description": "A neuromere that is part of the presumptive forebrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014775#prosomere",
+  "name": "prosomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014775",
+  "synonym": [
+    "forebrain neuromere"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/putamen.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/putamen.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/putamen",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "'Putamen' is a telencephalic nucleus. It is part of the cerebral hemisphere and caudate-putamen.",
-  "description": "Subcortical nucleus of telencephalon , which together with the caudate nucleus, forms the striatum.  The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion.",
+  "definition": "Is a telencephalic nucleus. Is part of the cerebral hemisphere and the caudate-putamen. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874) ('is_a' and 'relationship')]",
+  "description": "Subcortical nucleus of telencephalic , which together with the caudate nucleus, forms the striatum. The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001874#putamen-1",
   "name": "putamen",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001874",
   "synonym": [
-    "Pu",
     "nucleus putamen"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pyramidOfMedullaOblongata",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159) ('is_a' and 'relationship')]",
+  "description": "The anterior or ventral portion of the medulla oblongata is named the pyramid and lies between the anterior median fissure and the antero-lateral sulcus. Its upper end is slightly constricted, and between it and the pons the fibers of the abducent nerve emerge; a little below the pons it becomes enlarged and prominent, and finally tapers into the anterior funiculus of the medulla spinalis, with which, at first sight, it appears to be directly continuous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005159#pyramid-of-medulla-oblongata",
+  "name": "pyramid of medulla oblongata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005159",
+  "synonym": [
+    "lobule VIII of Larsell",
+    "pyramid of medulla oblongata",
+    "pyramis (medullae oblongatae)",
+    "pyramis bulbi",
+    "pyramis medullae oblongatae"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pyramidalDecussation",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neural decussation. Is part of the corticospinal tract and the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755) ('is_a' and 'relationship')]",
+  "description": "Part of medulla comprising a white matter structure containing nerve fibers of the pyramidal tract crossing from one side of the brain to the other (MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002755#pyramidal-decussation-1",
+  "name": "pyramidal decussation",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002755",
+  "synonym": [
+    "corticospinal decussation",
+    "decussatio pyramidum",
+    "decussatio pyramidum medullae oblongatae",
+    "decussation of corticospinal tract",
+    "decussation of pyramidal tract fibers",
+    "decussation of pyramids",
+    "decussation of pyramids of medulla",
+    "decussation of the pyramidal tract",
+    "motor decussation",
+    "motor decussation of medulla",
+    "pyramidal decussation (pourfour du petit)",
+    "pyramidal tract decussation"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/quadrigeminalCistern",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a subarachnoid cistern. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "description": "The enclosed space extending forward between the corpus callosum and the thalamus that contains the internal cerebral veins. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004052#quadrigeminal-cistern",
+  "name": "quadrigeminal cistern",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004052",
+  "synonym": [
+    "ambient cistern",
+    "cistern of great cerebral vein",
+    "cisterna ambiens",
+    "cisterna quadrigeminalis",
+    "cisterna venae magnae cerebri",
+    "superior cistern"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/radiationOfCerebralHemisphere",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter and white matter radiation. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022260)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022260#radiation-of-cerebral-hemisphere",
+  "name": "radiation of cerebral hemisphere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022260",
+  "synonym": [
+    "cerebral hemisphere radiation"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/radiationOfCorpusCallosum",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the corpus callosum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924) ('is_a' and 'relationship')]",
+  "description": "The spreading out of the fibers of the corpus callosum in the centrum semiovale of each cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035924#radiation-of-corpus-callosum",
+  "name": "radiation of corpus callosum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035924",
+  "synonym": [
+    "corpus callosum radiation",
+    "radiatio corporis callosi"
+  ]
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/radiationOfThalamus",
   "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-  "definition": "The 'radiation of thalamus' is a white matter fibre bundle. It is part of of the thalamic complex.",
-  "description": "",
+  "definition": "Is a diencephalic white matter and white matter radiation. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034745) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724984",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034745#radiation-of-thalamus",
   "name": "radiation of thalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034745",
   "synonym": [
-    "thalamic radiation",
     "thalamus radiation"
   ]
 }
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulePalatinus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulePalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulePalatinus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a ramus nasalis internus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "description": "Ramules that descends towards the buccal roof and give rise to several short branches that anastomose with palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010665#ramule-palatinus",
+  "name": "ramule palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010665",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulePalatonasalis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671) ('is_a' and 'relationship')]",
+  "description": "Descends and branches to the buccal roof where it anastomoses with the palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010671#ramule-palatonasalis",
+  "name": "ramule palatonasalis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010671",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulesCutaneous",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve and the ramus nasalis internus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668) ('is_a' and 'relationship')]",
+  "description": "Many branches of the maxillary ramus that terminate in the integument of the maxillary region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010668#ramules-cutaneous",
+  "name": "ramules cutaneous",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010668",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulesNasalisLateralis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the ophthalmic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652) ('is_a' and 'relationship')]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010652#ramules-nasalis-lateralis",
+  "name": "ramules nasalis lateralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010652",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulusSuprabranchialisAnterior",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "description": "Ramulus that innervates the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010798#ramulus-suprabranchialis-anterior",
+  "name": "ramulus suprabranchialis anterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010798",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramulusSuprabranchialisPosterior",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "description": "Ramulus innervating the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010799#ramulus-suprabranchialis-posterior",
+  "name": "ramulus suprabranchialis posterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010799",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusAnteriorOfCNVIII",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "description": "Formed by fibers from the anterior semicircular canal and sacculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010735#ramus-anterior-of-cn-viii",
+  "name": "ramus anterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010735",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusBuccal.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusBuccal.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusBuccal",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "description": "Ventral ramus of the ADLLN that innervates the infraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010759#ramus-buccal",
+  "name": "ramus buccal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010759",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusHyomandibularis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720) ('is_a' and 'relationship')]",
+  "description": "The posttrematic branch of the facial nerve, both motor and sensory in function. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010720#ramus-hyomandibularis",
+  "name": "ramus hyomandibularis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010720",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusLateral.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusLateral.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusLateral",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a posterior lateral line nerve (PLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "description": "Ventral division of the trunk of the PLLN, this prominent ramus extends over the lateral trunk and caudal musculature innervating the lateral line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010801#ramus-lateral",
+  "name": "ramus lateral",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010801",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusMandibularisExternus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anteroventral lateral line nerve (AVLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "description": "Runs together with motor fibers of the hyomandibular trunk of VII. The mandibularis externus of AVLLN branches into three ramules. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010765#ramus-mandibularis-externus",
+  "name": "ramus mandibularis externus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010765",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusNasalisInternus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an ophthalmic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "description": "Distal part of the opthalmicus profundus gives rise to 2 ramules: palatinus and cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010661#ramus-nasalis-internus",
+  "name": "ramus nasalis internus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010661",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusNasalisMedialis",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the ophthalmic nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010653#ramus-nasalis-medialis",
+  "name": "ramus nasalis medialis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010653",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusPalatinus.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusPalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusPalatinus",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a facial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "description": "Sensory branch of facial nerve from palatal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010722#ramus-palatinus",
+  "name": "ramus palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010722",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusPosteriorOfCNVIII",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "description": "Composed of two rami: a short ventral ramus innervating the cochlea (lagena and papille basilar), and a long dorsal ramus innervating the posterior semicircular canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010736#ramus-posterior-of-cn-viii",
+  "name": "ramus posterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010736",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusPosteriorProfundusOfV3",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the mandibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693) ('is_a' and 'relationship')]",
+  "description": "In the adult anuran, this innervates the muscles levator mandibulare internus and longus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010693#ramus-posterior-profundus-of-v3",
+  "name": "ramus posterior profundus of V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010693",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusRecurrens.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusRecurrens.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusRecurrens",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754) ('is_a' and 'relationship')]",
+  "description": "Branch of the vagus nerve that separates from the vagus well postcranially, then continues anteriorly to innervate the larynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010754#ramus-recurrens",
+  "name": "ramus recurrens",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010754",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusSuperficialOphthalmic",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "description": "Dorsal branch of ADLLN that innervates supraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010757#ramus-superficial-ophthalmic",
+  "name": "ramus superficial ophthalmic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010757",
+  "synonym": null
+}
+

--- a/instances/v3.0/terminologies/UBERONParcellation/ramusSupraotic.jsonld
+++ b/instances/v3.0/terminologies/UBERONParcellation/ramusSupraotic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/ramusSupraotic",
+  "@type": "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "description": "Small ramus of the MLLN that innervates neuromasts located at the posterior margin of the otic capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010796#ramus-supraotic",
+  "name": "ramus supraotic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010796",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorCoronaRadiata.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorCoronaRadiata",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the corona radiata of neuraxis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022427) ('is_a' and 'relationship')]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022427#posterior-corona-radiata",
+  "name": "posterior corona radiata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022427",
+  "synonym": [
+    "posterior portion of corona radiata"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorHypothalamicRegion.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorHypothalamicRegion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior hypothalamic region' is a regional part of brain. It is part of the hypothalamus.",
-  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat.",
+  "definition": "Is a regional part of brain. Is part of the hypothalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770) ('is_a' and 'relationship')]",
+  "description": "The part of the hypothalamus posterior to the middle region consisting of several nuclei including the medial mamillary nucleus, lateral mamillary nucleus, and posterior hypothalamic nucleus (posterior hypothalamic area). The posterior hypothalamic area is concerned with control of sympathetic responses and is sensitive to conditions of decreasing temperature and controls the mechanisms for the conservation and increased production of heat. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002770)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109099",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002770#posterior-hypothalamic-region-1",
   "name": "posterior hypothalamic region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002770",
   "synonym": [
-    "hypothalamus posterior",
     "mammillary level of hypothalamus",
     "mammillary region",
-    "PHR",
-    "posterior hypothalamus",
-    "regio hypothalamica posterior"
+    "posterior hypothalamus"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorLimbOfInternalCapsule.jsonld
@@ -4,18 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorLimbOfInternalCapsule",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior limb of internal capsule' is a limb of internal capsule of telencephalon.",
-  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM)",
+  "definition": "Is a limb of internal capsule of telencephalon. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
+  "description": "Portion of internal capsule lying between the globus pallidus and the thalamus (Nolte, The Human Brain, 6th ed., 2009, pg 409, modified by MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014527)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109100",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014527#posterior-limb-of-internal-capsule-1",
   "name": "posterior limb of internal capsule",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014527",
   "synonym": [
-    "capsula interna",
-    "crus posterius capsulae internae",
-    "pars posterior",
-    "posterior internal capsule",
-    "posterior limb",
-    "posterior limb of the internal capsule"
+    "capsula interna, pars posterior",
+    "crus posterius capsulae internae"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorMedianEminence.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorMedianEminence",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior median eminence' is a regional part of brain. It is part of the median eminence of neurohypophysis.",
-  "description": "",
+  "definition": "Is a regional part of brain. Is part of the median eminence of neurohypophysis. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002652) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109104",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002652#posterior-median-eminence-1",
   "name": "posterior median eminence",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002652",
-  "synonym": [
-    "PME",
-    "eminentia mediana posterior"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorNuclearComplexOfThalamus.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorNuclearComplexOfThalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Posterior nuclear complex of thalamus' is a nuclear complex of neuraxis and gray matter of diencephalon. It is part of the dorsal thalamus.",
-  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction.  It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97)",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of diencephalon. Is part of the dorsal thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709) ('is_a' and 'relationship')]",
+  "description": "Part of thalamus comprising ill defined cellular groups in the caudal thalamus at the meso-diencephalic junction. It is not a homogeneous structure but consists of several distinct cellular groups, including the suprageniculate and limitans nuclei, the magnocellular division of the medial geniculate body, portions of the pulvinar nucleus and an area of mixed cell types intercalated between the ventroposterior nucleus and the nucleus lateral posterior (Brodal, Neurological Anatomy, 3rd ed., 1981, pg 97) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002709)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109109",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002709#posterior-nuclear-complex",
   "name": "posterior nuclear complex of thalamus",
@@ -13,8 +13,6 @@
   "synonym": [
     "caudal thalamic nucleus",
     "nuclei posteriores thalami",
-    "parieto-occipital",
-    "PNC",
     "posterior complex of thalamus",
     "posterior complex of the thalamus",
     "posterior nuclear complex",
@@ -25,3 +23,4 @@
     "posterior thalamic nucleus"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorRecess.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorRecess.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorRecess",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the third ventricle. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338) ('is_a' and 'relationship')]",
+  "description": "Posterior protrusion of the third ventricle. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_2005338)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:2005338#posterior-recess",
+  "name": "posterior recess",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_2005338",
+  "synonym": [
+    "posterior recess of diencephalic ventricle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorThalamicPeduncle.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorThalamicPeduncle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a peduncle of thalamus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022243)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022243#posterior-thalamic-peduncle",
+  "name": "posterior thalamic peduncle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022243",
+  "synonym": [
+    "occipital peduncle",
+    "occipital thalamic peduncle",
+    "pedunculus ventrocaudalis thalami",
+    "posterior peduncle",
+    "ventrocaudal thalamic peduncle"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/posteriorThalamicRadiation.jsonld
@@ -4,16 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorThalamicRadiation",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The 'posterior thalamic radiation' is a white matter fibre bundle. It is part of the radiation of thalamus.",
-  "description": "",
+  "definition": "Is a radiation of cerebral hemisphere and radiation of thalamus. Is part of the retrolenticular part of internal capsule. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034747) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0735032",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034747#posterior-thalamic-radiation",
   "name": "posterior thalamic radiation",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034747",
   "synonym": [
-    "pthr",
+    "posterior thalamic radiation",
     "radiatio posterior thalami",
-    "radiatio thalamica posterior",
-    "radiationes thalamicae posteriores"
+    "radiatio thalamica posterior"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postnatalSubventricularZone.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postnatalSubventricularZone",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Postnatal subventricular zone' is a central nervous system cell part cluster and nervous system cell part layer. It is part of the forebrain.",
-  "description": "The subventricular zone (SVZ) is one of two sources of adult-born neurons in the mammalian brain, the other being the subgranular zone (SGZ) of the hippocampus. In most adult mammals, the SVZ is a three-layered sheath that lies along the lateral wall of the lateral ventricle and consists of type A, B, and C cells. Type A rest along the ventricle wall and are neuronal precursor cells, Type B are adjacent astrocytes, and Type C are immature precursors to the Type A neuroblasts. The neuronal precursor cells travel along the rostral migratory stream ensheathed in a tube of Type B astrocytes, until they reach the olfactory bulb. There they integrate into the existing cellular network and mature into local interneurons. While the majority become adult-born granule cells, a subset become periglomerular cells.Interestingly, the human SVZ differs from other mammals' in several ways. It consists of four layers rather than three: ependymal cells (layer I), a hypo cellular gap (layer II), a ribbon of astrocytes (layer III), and a transitional zone (layer IV). The astrocytes are capable of differentiating into many kinds of tissue including new neurons. However, there is no evidence that the proliferating neurons travel along the rostral migratory stream in a chain to populate the olfactory bulb with new interneurons, as is the case for other mammals.",
+  "definition": "Is a central nervous system cell part cluster and nervous system cell part layer. Is part of the forebrain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922) ('is_a' and 'relationship')]",
+  "description": "A mitotically active layer of cells surrounding the brain ventricles in the adult that consists of migrating neuroblasts, astrocytes and transitory amplifying progenitor cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004922)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111233",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004922#subventricular-zone",
   "name": "postnatal subventricular zone",
@@ -13,16 +13,11 @@
   "synonym": [
     "adult subventricular zone",
     "brain subventricular zone",
-    "postnatal subependymal layer",
-    "postnatal subependymal plate",
-    "postnatal subependymal zone",
     "postnatal subventricular zone",
     "SEZ",
-    "subependymal layer",
-    "subependymal plate",
-    "subependymal zone",
     "subventricular zone",
     "subventricular zone of brain",
     "SVZ"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/postsubiculum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/postsubiculum.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/postsubiculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Postsubiculum' is a regional part of brain. It is part of the retrohippocampal region.",
-  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex..  The border is characterized by an abrupt change in the cyto- and chemoarchitecture",
+  "definition": "Is a regional part of brain. Is part of the retrohippocampal region. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971) ('is_a' and 'relationship')]",
+  "description": "Division of subicular cortex characterized by projections from the anterodorsal thalamic nucleus and to a lesser extent the anteroventral nucleus, bordered ventrally and laterally by the presubiculum and dorsally and medially by the retrosplenial granular a cortex. The border is characterized by an abrupt change in the cyto- and chemoarchitecture. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035971)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109164",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035971#postsubiculum",
   "name": "postsubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035971",
-  "synonym": [
-    "POST",
-    "postsubicular cortex"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preBotzingerComplex.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preBotzingerComplex",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the medulla oblongata. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "description": "The group of interneurons within the medulla oblongata's ventral respiratory group that are important for the generation of ventilatory (inspiratory) rhythmogenesis. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0006007)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0006007#pre-botzinger-complex",
+  "name": "pre-Botzinger complex",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0006007",
+  "synonym": [
+    "Pre-Bötzinger complex",
+    "preBötC"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/precentralOperculum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/precentralOperculum.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/precentralOperculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Precentral operculum' is a regional part of brain. It is part of the operculum of brain.",
-  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info).",
+  "definition": "Is a regional part of brain. Is part of the operculum of brain. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605) ('is_a' and 'relationship')]",
+  "description": "The ventrolateral lip of the precentral gyrus, which overlies the insula and is bounded by the lateral fissure (Brain Info). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002605)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109194",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002605#precentral-operculum-1",
   "name": "precentral operculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002605",
   "synonym": [
-    "brodmann's area 6",
     "operculum precentrale"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/predorsalBundle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/predorsalBundle.jsonld
@@ -4,18 +4,16 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/predorsalBundle",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Predorsal bundle' is a fasciculus of brain. It is part of the white matter of medulla oblongata.",
-  "description": "",
+  "definition": "Is a fasciculus of brain. Is part of the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002754) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109207",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002754#predorsal-bundle-1",
   "name": "predorsal bundle",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002754",
   "synonym": [
-    "fasciculus praedorsalis (Tschermak)",
-    "fasciculus predorsalis",
-    "pd",
-    "Predorsal bundle of Edinger",
+    "predorsal bundle of Edinger",
     "predorsal fasciculus",
     "tectospinal fibers"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preoccipitalNotch.jsonld
@@ -4,8 +4,8 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preoccipitalNotch",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Preoccipital notch' is an anatomical entity. It is part of the occipital lobe.",
-  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes.  It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia).",
+  "definition": "Is an anatomical entity. Is part of the occipital lobe. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698) ('is_a' and 'relationship')]",
+  "description": "Small indentation on the inferior surface of the cerebral cortex at the border of the occiptal and parietal lobes. It is considered as a landmark because the occipital lobe is located just behind the line that connects that notch with the parietoccipital sulcus (adapted from Wikipedia). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002698)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109223",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002698#preoccipital-notch-1",
   "name": "preoccipital notch",
@@ -15,9 +15,8 @@
     "incisura praeoccipitalis",
     "incisura preoccipitalis",
     "occipital notch",
-    "PON",
     "preoccipital incisura",
-    "preoccipital incisure",
-    "preoccipital notch"
+    "preoccipital incisure"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/preopercularRamule.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/preopercularRamule.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/preopercularRamule",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ramus mandibularis externus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "description": "Ventral branch of the ramus mandibularis externus. This ramule have a superior and an inferior division, both innervating the preopercular line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010795)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010795#preopercular-ramule",
+  "name": "preopercular ramule",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010795",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/presubiculum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/presubiculum.jsonld
@@ -4,17 +4,15 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/presubiculum",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Presubiculum' is part of the hippocampal formation and parahippocampal gyrus.",
-  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus.",
+  "definition": "Is part of the hippocampal formation and the parahippocampal gyrus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
+  "description": "A modified six-layered cortex between the subiculum and the main part of the parahippocampal gyrus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001953)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109252",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001953#presubiculum-1",
   "name": "presubiculum",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001953",
   "synonym": [
-    "Area 27 of Brodmann",
-    "praesubiculum",
     "presubicular cortex (presubiculum)",
-    "presubiculum (Cajal)",
-    "PrS"
+    "presubiculum (Cajal)"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pretectalRegion.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pretectalRegion.jsonld
@@ -4,22 +4,19 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pretectalRegion",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Pretectal region' is a brain gray matter and nuclear complex of neuraxis.",
-  "description": "Region of brain lying between the midbrain tectum and the thalamus (Sefton and Dreher, in Paxinos, G The rat central nervous system, 1995, pg 859),  Situated at the level of poterior commissure and just rostral to the superior colliculus  (Brodal, Neurological Anatomy, 3rd ed, 1981, pg 542)",
+  "definition": "Is a brain gray matter and nuclear complex of neuraxis. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
+  "description": "Nuclear complex between dorsal thalamus and optic tectum whose nuclei receive afferents primarily from the retina and the optic tectum and are involved in modulating motor behavior in response to visual input. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001944)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109258",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001944#pretectal-region-1",
   "name": "pretectal region",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001944",
   "synonym": [
-    "area praetectalis",
+    "area pretectalis",
     "area pretectalis",
     "nuclei pretectales",
-    "nucleus praetectalis",
-    "praetectum",
     "pretectal area",
     "pretectal nuclei",
-    "pretectal region",
-    "Pretectum",
-    "regio pretectalis"
+    "pretectum"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primaryMuscleSpindle.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primaryMuscleSpindle",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a muscle spindle. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "description": "The sensory organ in muscle; involved in the stretch reflex and sensitive to stretch velocity. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004010)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004010#primary-muscle-spindle",
+  "name": "primary muscle spindle",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004010",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primarySuperiorOlive.jsonld
@@ -4,14 +4,12 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primarySuperiorOlive",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Primary superior olive' is a nuclear complex of neuraxis and gray matter of hindbrain. It is part of the superior olivary complex.",
-  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans.  (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617).  In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus.",
+  "definition": "Is a nuclear complex of neuraxis and gray matter of hindbrain. Is part of the superior olivary complex. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434) ('is_a' and 'relationship')]",
+  "description": "Part of the superior olivary complex of nuclei in the caudal pontine tegmentum, situated within the trapezoid body in humans. (Brodal, Neurological Anatomy, 3rd edition, 1981, pg 617). In many species, it comprises a medial superior olivary nucleus and a lateral superior olivary nucleus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022434)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0111314",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022434#superior-olive",
   "name": "primary superior olive",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022434",
-  "synonym": [
-    "SOl",
-    "superior olive"
-  ]
+  "synonym": null
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primitiveMarginalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primitiveMarginalSinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a paired venous dural sinus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "description": "The primitive marginal sinuses (PMS) are embryonic sinuses forming the later superior sagittal sinus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0017638)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0017638#primitive-marginal-sinus",
+  "name": "primitive marginal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0017638",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/primitiveSuperiorSagittalSinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/primitiveSuperiorSagittalSinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the venous dural sinus. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0009968)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0009968#primitive-superior-sagittal-sinus",
+  "name": "primitive superior sagittal sinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0009968",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/principalNeuronalCircuit.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/principalNeuronalCircuit",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a circuit part of central nervous system. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "description": "A neuronal circuit bearing a principal projection neuron whose axon extends beyond the region where its soma is located to synapse on the dendrites of cells in other regions of the nervous system (BB). [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0026546)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0026546#principal-neuronal-circuit-1",
+  "name": "principal neuronal circuit",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0026546",
+  "synonym": [
+    "principal neuronal circuit",
+    "principal neuronal circuit"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/proliferatingNeuroepithelium.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/proliferatingNeuroepithelium",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a developing neuroepithelium. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "description": "An epithelium that is undergoing proliferation to provide large numbers of neuronal cells. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034706)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034706#proliferating-neuroepithelium",
+  "name": "proliferating neuroepithelium",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034706",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/prosomere.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/prosomere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/prosomere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuromere. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "description": "A neuromere that is part of the presumptive forebrain. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0014775)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0014775#prosomere",
+  "name": "prosomere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0014775",
+  "synonym": [
+    "forebrain neuromere"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/putamen.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/putamen.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/putamen",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "'Putamen' is a telencephalic nucleus. It is part of the cerebral hemisphere and caudate-putamen.",
-  "description": "Subcortical nucleus of telencephalon , which together with the caudate nucleus, forms the striatum.  The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion.",
+  "definition": "Is a telencephalic nucleus. Is part of the cerebral hemisphere and the caudate-putamen. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874) ('is_a' and 'relationship')]",
+  "description": "Subcortical nucleus of telencephalic , which together with the caudate nucleus, forms the striatum. The putamen lies lateral to the internal capsule and medial to the external medullary lamina, and is separated from the caudate nucleus by the fibers of the internal capsule for most of its length, except at its anterior portion. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0001874)]",
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0109549",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0001874#putamen-1",
   "name": "putamen",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0001874",
   "synonym": [
-    "Pu",
     "nucleus putamen"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pyramidOfMedullaOblongata.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pyramidOfMedullaOblongata",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a regional part of brain. Is part of the medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159) ('is_a' and 'relationship')]",
+  "description": "The anterior or ventral portion of the medulla oblongata is named the pyramid and lies between the anterior median fissure and the antero-lateral sulcus. Its upper end is slightly constricted, and between it and the pons the fibers of the abducent nerve emerge; a little below the pons it becomes enlarged and prominent, and finally tapers into the anterior funiculus of the medulla spinalis, with which, at first sight, it appears to be directly continuous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0005159)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0005159#pyramid-of-medulla-oblongata",
+  "name": "pyramid of medulla oblongata",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0005159",
+  "synonym": [
+    "lobule VIII of Larsell",
+    "pyramid of medulla oblongata",
+    "pyramis (medullae oblongatae)",
+    "pyramis bulbi",
+    "pyramis medullae oblongatae"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/pyramidalDecussation.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pyramidalDecussation",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neural decussation. Is part of the corticospinal tract and the white matter of medulla oblongata. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755) ('is_a' and 'relationship')]",
+  "description": "Part of medulla comprising a white matter structure containing nerve fibers of the pyramidal tract crossing from one side of the brain to the other (MM) [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0002755)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0002755#pyramidal-decussation-1",
+  "name": "pyramidal decussation",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0002755",
+  "synonym": [
+    "corticospinal decussation",
+    "decussatio pyramidum",
+    "decussatio pyramidum medullae oblongatae",
+    "decussation of corticospinal tract",
+    "decussation of pyramidal tract fibers",
+    "decussation of pyramids",
+    "decussation of pyramids of medulla",
+    "decussation of the pyramidal tract",
+    "motor decussation",
+    "motor decussation of medulla",
+    "pyramidal decussation (pourfour du petit)",
+    "pyramidal tract decussation"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/quadrigeminalCistern.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/quadrigeminalCistern",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a subarachnoid cistern. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "description": "The enclosed space extending forward between the corpus callosum and the thalamus that contains the internal cerebral veins. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0004052)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0004052#quadrigeminal-cistern",
+  "name": "quadrigeminal cistern",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0004052",
+  "synonym": [
+    "ambient cistern",
+    "cistern of great cerebral vein",
+    "cisterna ambiens",
+    "cisterna quadrigeminalis",
+    "cisterna venae magnae cerebri",
+    "superior cistern"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/radiationOfCerebralHemisphere.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfCerebralHemisphere",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a cerebral hemisphere white matter and white matter radiation. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0022260)]",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0022260#radiation-of-cerebral-hemisphere",
+  "name": "radiation of cerebral hemisphere",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0022260",
+  "synonym": [
+    "cerebral hemisphere radiation"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/radiationOfCorpusCallosum.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfCorpusCallosum",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a neuron projection bundle and central nervous system cell part cluster. Is part of the corpus callosum. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924) ('is_a' and 'relationship')]",
+  "description": "The spreading out of the fibers of the corpus callosum in the centrum semiovale of each cerebral hemisphere. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0035924)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0035924#radiation-of-corpus-callosum",
+  "name": "radiation of corpus callosum",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0035924",
+  "synonym": [
+    "corpus callosum radiation",
+    "radiatio corporis callosi"
+  ]
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/radiationOfThalamus.jsonld
@@ -4,14 +4,14 @@
   },
   "@id": "https://openminds.om-i.org/instances/UBERONParcellation/radiationOfThalamus",
   "@type": "https://openminds.om-i.org/types/UBERONParcellation",
-  "definition": "The 'radiation of thalamus' is a white matter fibre bundle. It is part of of the thalamic complex.",
-  "description": "",
+  "definition": "Is a diencephalic white matter and white matter radiation. Is part of the dorsal plus ventral thalamus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_0034745) ('is_a' and 'relationship')]",
+  "description": null,
   "interlexIdentifier": "http://uri.interlex.org/base/ilx_0724984",
   "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:0034745#radiation-of-thalamus",
   "name": "radiation of thalamus",
   "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_0034745",
   "synonym": [
-    "thalamic radiation",
     "thalamus radiation"
   ]
 }
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulePalatinus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulePalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulePalatinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a ramus nasalis internus. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "description": "Ramules that descends towards the buccal roof and give rise to several short branches that anastomose with palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010665)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010665#ramule-palatinus",
+  "name": "ramule palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010665",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulePalatonasalis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulePalatonasalis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the maxillary nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671) ('is_a' and 'relationship')]",
+  "description": "Descends and branches to the buccal roof where it anastomoses with the palatine ramus of the facial nerve. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010671)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010671#ramule-palatonasalis",
+  "name": "ramule palatonasalis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010671",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulesCutaneous.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulesCutaneous",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the maxillary nerve and the ramus nasalis internus. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668) ('is_a' and 'relationship')]",
+  "description": "Many branches of the maxillary ramus that terminate in the integument of the maxillary region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010668)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010668#ramules-cutaneous",
+  "name": "ramules cutaneous",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010668",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulesNasalisLateralis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulesNasalisLateralis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a nerve of head region. Is part of the ophthalmic nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652) ('is_a' and 'relationship')]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010652)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010652#ramules-nasalis-lateralis",
+  "name": "ramules nasalis lateralis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010652",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulusSuprabranchialisAnterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulusSuprabranchialisAnterior",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "description": "Ramulus that innervates the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010798)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010798#ramulus-suprabranchialis-anterior",
+  "name": "ramulus suprabranchialis anterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010798",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramulusSuprabranchialisPosterior.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramulusSuprabranchialisPosterior",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "description": "Ramulus innervating the suprabranchial line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010799)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010799#ramulus-suprabranchialis-posterior",
+  "name": "ramulus suprabranchialis posterior",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010799",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusAnteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusAnteriorOfCNVIII",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "description": "Formed by fibers from the anterior semicircular canal and sacculus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010735)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010735#ramus-anterior-of-cn-viii",
+  "name": "ramus anterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010735",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusBuccal.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusBuccal.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusBuccal",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "description": "Ventral ramus of the ADLLN that innervates the infraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010759)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010759#ramus-buccal",
+  "name": "ramus buccal",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010759",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusHyomandibularis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusHyomandibularis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the facial nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720) ('is_a' and 'relationship')]",
+  "description": "The posttrematic branch of the facial nerve, both motor and sensory in function. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010720)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010720#ramus-hyomandibularis",
+  "name": "ramus hyomandibularis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010720",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusLateral.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusLateral.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusLateral",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a posterior lateral line nerve (PLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "description": "Ventral division of the trunk of the PLLN, this prominent ramus extends over the lateral trunk and caudal musculature innervating the lateral line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010801)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010801#ramus-lateral",
+  "name": "ramus lateral",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010801",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusMandibularisExternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusMandibularisExternus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anteroventral lateral line nerve (AVLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "description": "Runs together with motor fibers of the hyomandibular trunk of VII. The mandibularis externus of AVLLN branches into three ramules. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010765)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010765#ramus-mandibularis-externus",
+  "name": "ramus mandibularis externus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010765",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusNasalisInternus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusNasalisInternus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an ophthalmic nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "description": "Distal part of the opthalmicus profundus gives rise to 2 ramules: palatinus and cutaneous. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010661)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010661#ramus-nasalis-internus",
+  "name": "ramus nasalis internus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010661",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusNasalisMedialis.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusNasalisMedialis",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the ophthalmic nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "description": "First branch gives rise to two ramules that border the naris and innervate the surrounding tissue. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010653)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010653#ramus-nasalis-medialis",
+  "name": "ramus nasalis medialis",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010653",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusPalatinus.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusPalatinus.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPalatinus",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a facial nerve. [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "description": "Sensory branch of facial nerve from palatal region. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010722)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010722#ramus-palatinus",
+  "name": "ramus palatinus",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010722",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusPosteriorOfCNVIII.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPosteriorOfCNVIII",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is part of the vestibulocochlear nerve. [auto-generated from 'relationship' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "description": "Composed of two rami: a short ventral ramus innervating the cochlea (lagena and papille basilar), and a long dorsal ramus innervating the posterior semicircular canal. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010736)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010736#ramus-posterior-of-cn-viii",
+  "name": "ramus posterior of CN VIII",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010736",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusPosteriorProfundusOfV3.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusPosteriorProfundusOfV3",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the mandibular nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693) ('is_a' and 'relationship')]",
+  "description": "In the adult anuran, this innervates the muscles levator mandibulare internus and longus. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010693)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010693#ramus-posterior-profundus-of-v3",
+  "name": "ramus posterior profundus of V3",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010693",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusRecurrens.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusRecurrens.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusRecurrens",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anatomical entity. Is part of the vagus nerve. [auto-generated from properties of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754) ('is_a' and 'relationship')]",
+  "description": "Branch of the vagus nerve that separates from the vagus well postcranially, then continues anteriorly to innervate the larynx. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010754)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010754#ramus-recurrens",
+  "name": "ramus recurrens",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010754",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusSuperficialOphthalmic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusSuperficialOphthalmic",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is an anterodorsal lateral line nerve (ADLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "description": "Dorsal branch of ADLLN that innervates supraorbital line of neuromasts. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010757)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010757#ramus-superficial-ophthalmic",
+  "name": "ramus superficial ophthalmic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010757",
+  "synonym": null
+}
+

--- a/instances/v4.0/terminologies/UBERONParcellation/ramusSupraotic.jsonld
+++ b/instances/v4.0/terminologies/UBERONParcellation/ramusSupraotic.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/UBERONParcellation/ramusSupraotic",
+  "@type": "https://openminds.om-i.org/types/UBERONParcellation",
+  "definition": "Is a middle lateral line nerve (MLLN). [auto-generated from 'is_a' property of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "description": "Small ramus of the MLLN that innervates neuromasts located at the posterior margin of the otic capsule. [definition of the [UBERON ontology term](http://purl.obolibrary.org/obo/UBERON_3010796)]",
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": "https://knowledge-space.org/wiki/UBERON:3010796#ramus-supraotic",
+  "name": "ramus supraotic",
+  "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/UBERON_3010796",
+  "synonym": null
+}
+


### PR DESCRIPTION
generation of terms is described in https://github.com/openMetadataInitiative/openMINDS_instances/issues/133 and fully-automated (with minor clean-ups here and there)