### PR TITLE
Complete MarsAtlas 

### DIFF
--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
@@ -204,7 +204,7 @@
     "https://meca-brain.org/contact/"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "Colin27-MNI",

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
@@ -1,0 +1,213 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": {
+    "@id": "https://openminds.om-i.org/instances/commonCoordinateSpaceVersion/MNI-Colin27_1998"
+  },
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-colin27/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution) \\n Please make sure to follow the copyright of the [Colin27 average brain in the MNI space](https://www.mcgill.ca/bic/software/tools-data-analysis/anatomical-mri/atlases/colin-27). You may also cite its original publication, [Holmes et al. (1998)](http://doi.org/10.1097/00004728-199803000-00032).",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    },
+    {
+      "@id": "http://doi.org/10.1097/00004728-199803000-00032"
+    }
+  ],
+  "releaseDate": "2018-01-08",
+  "repository": {
+    "@id": "https://www.dropbox.com/s/ndz8qtqblkciole/MarsAtlas-MNI-Colin27.zip?dl=0"
+  },
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the first version of this brain atlas. The MarsAtlas parcellation scheme was applied to the original version (1998) of the Colin27 average brain in the MNI space resulting in 41 cortical and 7 subcortical annotations."
+}
+

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -1,0 +1,184 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1002/hbm.23121"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Guillaume Auzias*, Olivier Coulon*, Andrea Brovelli (2016) MarsAtlas : A cortical parcellation atlas for functional mapping, Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    }
+  ],
+  "releaseDate": "2016-01-27",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+}
+

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -179,6 +179,6 @@
   },
   "usedSpecimen": null,
   "versionIdentifier": "cortical model",
-  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitly provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
 }
 

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -175,7 +175,7 @@
     "https://meca-brain.org/contact/"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationModel"
   },
   "usedSpecimen": null,
   "versionIdentifier": "cortical model",

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
@@ -1,0 +1,210 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_subcortical-extension",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-subcortical/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": {
+    "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+  },
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    }
+  ],
+  "releaseDate": "2017-01-25",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This version of the parcellation scheme 7 subcortical areas were added on each hemisphere. The cortical parcellation areas remain unchanged."
+}
+

--- a/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
+++ b/instances/latest/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
@@ -201,7 +201,7 @@
     "https://meca-brain.org/contact/"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationModel"
   },
   "usedSpecimen": null,
   "versionIdentifier": "subcortical extension",

--- a/instances/latest/brainAtlases/MarsAtlas.jsonld
+++ b/instances/latest/brainAtlases/MarsAtlas.jsonld
@@ -1,0 +1,204 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlas/MarsAtlas",
+  "@type": "https://openminds.om-i.org/types/BrainAtlas",
+  "abbreviation": "MarsAtlas",
+  "author": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullName": "Marseille Atlas",
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminology",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_subcortical-extension"
+    }
+  ],
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": null,
+  "ontologyIdentifier": null,
+  "shortName": "MarsAtlas",
+  "usedSpecies": {
+    "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusAccumbens"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/amygdala"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ACC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorCingulateCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFcdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFcdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCcm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MTCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "STCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudateNucleus"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "cingular region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_cingularCortex",
+  "name": "cingular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cingulateCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Cu",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cuneusCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "IPCd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_frontalLobe",
+  "name": "frontal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/frontalLobe"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/hippocampalFormation"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "insula lobe"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_insula",
+  "name": "insula",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insula"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Insula",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insularCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ICC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/isthmusOfCingulateCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVisualArea"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ITCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "SPCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "occipital region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_occipitalLobe",
+  "name": "occipital lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalLobe"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "orbito-frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_orbito-FrontalCortex",
+  "name": "orbito-frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/orbitofrontalCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pallidum"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "parietal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_parietalLobe",
+  "name": "parietal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalLobe"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorCingulateCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/putamen"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pfrdli",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pfrdls",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ITCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteromedialVisualArea"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MTCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "STCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMrv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "SPC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorParietalCortex"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCs",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "temporal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_temporalLobe",
+  "name": "temporal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/temporalLobe"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalPlusVentralThalamus"
+  }
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "IPCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
+++ b/instances/latest/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
+++ b/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
@@ -1,0 +1,213 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": {
+    "@id": "https://openminds.ebrains.eu/instances/commonCoordinateSpaceVersion/MNI-Colin27_1998"
+  },
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-colin27/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution) \\n Please make sure to follow the copyright of the [Colin27 average brain in the MNI space](https://www.mcgill.ca/bic/software/tools-data-analysis/anatomical-mri/atlases/colin-27). You may also cite its original publication, [Holmes et al. (1998)](http://doi.org/10.1097/00004728-199803000-00032).",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    },
+    {
+      "@id": "http://doi.org/10.1097/00004728-199803000-00032"
+    }
+  ],
+  "releaseDate": "2018-01-08",
+  "repository": {
+    "@id": "https://www.dropbox.com/s/ndz8qtqblkciole/MarsAtlas-MNI-Colin27.zip?dl=0"
+  },
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.ebrains.eu/instances/atlasType/deterministicAtlas"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the first version of this brain atlas. The MarsAtlas parcellation scheme was applied to the original version (1998) of the Colin27 average brain in the MNI space resulting in 41 cortical and 7 subcortical annotations."
+}
+

--- a/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -1,0 +1,184 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_cortical-model",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1002/hbm.23121"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Guillaume Auzias*, Olivier Coulon*, Andrea Brovelli (2016) MarsAtlas : A cortical parcellation atlas for functional mapping, Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    }
+  ],
+  "releaseDate": "2016-01-27",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.ebrains.eu/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+}
+

--- a/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -179,6 +179,6 @@
   },
   "usedSpecimen": null,
   "versionIdentifier": "cortical model",
-  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitly provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
 }
 

--- a/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
+++ b/instances/v3.0/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
@@ -1,0 +1,210 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_subcortical-extension",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-subcortical/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": {
+    "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+  },
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    }
+  ],
+  "releaseDate": "2017-01-25",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.ebrains.eu/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This version of the parcellation scheme 7 subcortical areas were added on each hemisphere. The cortical parcellation areas remain unchanged."
+}
+

--- a/instances/v3.0/brainAtlases/MarsAtlas.jsonld
+++ b/instances/v3.0/brainAtlases/MarsAtlas.jsonld
@@ -1,0 +1,204 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/brainAtlas/MarsAtlas",
+  "@type": "https://openminds.ebrains.eu/sands/BrainAtlas",
+  "abbreviation": "MarsAtlas",
+  "author": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullName": "Marseille Atlas",
+  "hasTerminology": {
+    "@type": "https://openminds.ebrains.eu/sands/ParcellationTerminology",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_accumbens"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_amygdala"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudate"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cuneus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_hippocampus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insularCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_pallidum"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_puttamen"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_thalamus"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/MarsAtlas_subcortical-extension"
+    }
+  ],
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": null,
+  "ontologyIdentifier": null,
+  "shortName": "MarsAtlas",
+  "usedSpecies": {
+    "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_accumbens",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/nucleusAccumbens"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_amygdala",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/amygdala"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "ACC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/anteriorCingulateCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFcdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFcdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "VCcm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "MTCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "STCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_caudate",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/caudateNucleus"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "cingular region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_cingularCortex",
+  "name": "cingular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cingulateCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cuneus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Cu",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/cuneusCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "IPCd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Mdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PMdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Sdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Mdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PMdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Sdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_frontalLobe",
+  "name": "frontal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/frontalLobe"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_hippocampus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/hippocampalFormation"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "insula lobe"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_insula",
+  "name": "insula",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insula"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insularCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Insula",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/insularCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "ICC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/isthmusOfCingulateCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_lateralVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "VCl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/lateralVisualArea"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "ITCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "SPCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_midCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "MCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "occipital region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_occipitalLobe",
+  "name": "occipital lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/occipitalLobe"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "orbito-frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_orbito-FrontalCortex",
+  "name": "orbito-frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/orbitofrontalCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_pallidum",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/pallidum"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "parietal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_parietalLobe",
+  "name": "parietal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/parietalLobe"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/posteriorCingulateCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_puttamen",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/putamen"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFrd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Pfrdli",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Pfrdls",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "ITCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "VCrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/anteromedialVisualArea"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "MTCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "STCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PMrv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFrvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_superiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "SPC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/superiorParietalCortex"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_superiorVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "VCs",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "temporal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_temporalLobe",
+  "name": "temporal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/temporalLobe"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_thalamus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.ebrains.eu/instances/UBERONParcellation/dorsalPlusVentralThalamus"
+  }
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "IPCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Mv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "OFCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "Sv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "OFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "OFCvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
+  "abbreviation": "PFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v3.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.ebrains.eu/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.ebrains.eu/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
+++ b/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_Colin27-MNI.jsonld
@@ -1,0 +1,213 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": {
+    "@id": "https://openminds.om-i.org/instances/commonCoordinateSpaceVersion/MNI-Colin27_1998"
+  },
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-colin27/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution) \\n Please make sure to follow the copyright of the [Colin27 average brain in the MNI space](https://www.mcgill.ca/bic/software/tools-data-analysis/anatomical-mri/atlases/colin-27). You may also cite its original publication, [Holmes et al. (1998)](http://doi.org/10.1097/00004728-199803000-00032).",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    },
+    {
+      "@id": "http://doi.org/10.1097/00004728-199803000-00032"
+    }
+  ],
+  "releaseDate": "2018-01-08",
+  "repository": {
+    "@id": "https://www.dropbox.com/s/ndz8qtqblkciole/MarsAtlas-MNI-Colin27.zip?dl=0"
+  },
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the first version of this brain atlas. The MarsAtlas parcellation scheme was applied to the original version (1998) of the Colin27 average brain in the MNI space resulting in 41 cortical and 7 subcortical annotations."
+}
+

--- a/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -1,0 +1,184 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1002/hbm.23121"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Guillaume Auzias*, Olivier Coulon*, Andrea Brovelli (2016) MarsAtlas : A cortical parcellation atlas for functional mapping, Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    }
+  ],
+  "releaseDate": "2016-01-27",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+}
+

--- a/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
+++ b/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_cortical-model.jsonld
@@ -179,6 +179,6 @@
   },
   "usedSpecimen": null,
   "versionIdentifier": "cortical model",
-  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitely provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
+  "versionInnovation": "This is the first version of this parcellation scheme. It contains 41 cortical parcellation areas on each hemisphere belonging to 7 parent regions, and builds on the [HipHop parameterization pipeline](https://meca-brain.org/software/hip-hop/). The pipeline performs a parameterization of the white matter surface and implicitly provides an inter-subject cortical surface matching. The resulting 2D coordinate system (longitude/latitude) is fitted to a model of cortical organization, which means that a number of sulcal lines have a constant coordinate (longitude or latitude) and that some pairs of sulci have the same coordinate because they are aligned in this model."
 }
 

--- a/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
+++ b/instances/v4.0/brainAtlasVersions/MarsAtlas/MarsAtlas_subcortical-extension.jsonld
@@ -1,0 +1,210 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_subcortical-extension",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarsAtlas",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": null,
+  "copyright": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": {
+    "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+  },
+  "fullDocumentation": {
+    "@id": "https://meca-brain.org/software/marsatlas-subcortical/"
+  },
+  "fullName": "Marseille Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": "Please cite the following publications: \\n- Auzias*, G., Coulon*, C. & Brovelli, A. (2016) MarsAtlas : A cortical parcellation atlas for functional mapping. Human Brain Mapping 37(4), p. 1573-1592, doi:10.1002/hbm.23121 (* equal contribution) \\n- Brovelli, A., Badier, J.-M., Bonini, F., Bartolomei, F., Coulon*, O. & Auzias*, G. (2017) Dynamic Reconfiguration of Visuomotor-Related Functional Connectivity Networks. The Journal of Neuroscience, 37(4), p. 839–853, doi:10.1523/JNEUROSCI.1672-16.2017 (*equal contribution)",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": {
+    "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+  },
+  "keyword": null,
+  "license": null,
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1002/hbm.23121"
+    },
+    {
+      "@id": "https://doi.org/10.1109/tmi.2013.2241651"
+    },
+    {
+      "@id": "https://doi.org/10.1523/JNEUROSCI.1672-16.2017"
+    }
+  ],
+  "releaseDate": "2017-01-25",
+  "repository": null,
+  "shortName": "MarsAtlas",
+  "supportChannel": [
+    "https://meca-brain.org/contact/"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This version of the parcellation scheme 7 subcortical areas were added on each hemisphere. The cortical parcellation areas remain unchanged."
+}
+

--- a/instances/v4.0/brainAtlases/MarsAtlas.jsonld
+++ b/instances/v4.0/brainAtlases/MarsAtlas.jsonld
@@ -1,0 +1,204 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlas/MarsAtlas",
+  "@type": "https://openminds.om-i.org/types/BrainAtlas",
+  "abbreviation": "MarsAtlas",
+  "author": null,
+  "custodian": null,
+  "description": "The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.",
+  "digitalIdentifier": null,
+  "fullName": "Marseille Atlas",
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminology",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_accumbens"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_amygdala"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudate"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cuneus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_hippocampus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_lateralVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_midCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_pallidum"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_puttamen"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_thalamus"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralMotorCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_Colin27-MNI"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_cortical-model"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarsAtlas_subcortical-extension"
+    }
+  ],
+  "homepage": "https://meca-brain.org/software/",
+  "howToCite": null,
+  "ontologyIdentifier": null,
+  "shortName": "MarsAtlas",
+  "usedSpecies": {
+    "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_accumbens.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/nucleusAccumbens"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_amygdala.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/amygdala"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_anteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ACC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteriorCingulateCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFcdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFcdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCcm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MTCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "STCc",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_caudate.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/caudateNucleus"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_cingularCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "cingular region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_cingularCortex",
+  "name": "cingular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cingulateCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_cuneus.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Cu",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/cuneusCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "IPCd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sdl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sdm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_frontalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_frontalLobe",
+  "name": "frontal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/frontalLobe"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_hippocampus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/hippocampalFormation"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_insula.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "insula lobe"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_insula",
+  "name": "insula",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insula"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_insularCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Insula",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/insularCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_isthmusCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ICC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/isthmusOfCingulateCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_lateralVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/lateralVisualArea"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ITCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "SPCm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_midCingulateCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_occipitalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "occipital region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_occipitalLobe",
+  "name": "occipital lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalLobe"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_orbito-FrontalCortex.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "orbito-frontal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_orbito-FrontalCortex",
+  "name": "orbito-frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/orbitofrontalCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_pallidum.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/pallidum"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_parietalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "parietal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_parietalLobe",
+  "name": "parietal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/parietalLobe"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_posteriorCingulateCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PCC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/posteriorCingulateCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_puttamen.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/putamen"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrd",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pfrdli",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pfrdls",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ITCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCrm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/anteromedialVisualArea"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MTCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "STCr",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PMrv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFrvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorParietalCortex.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "SPC",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/superiorParietalCortex"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_superiorVisualCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VCs",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_temporalLobe.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": [
+    "temporal region"
+  ],
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarsAtlas_temporalLobe",
+  "name": "temporal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/temporalLobe"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_thalamus.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": null,
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": {
+    "@id": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalPlusVentralThalamus"
+  }
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "IPCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralMotorCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Mv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Sv",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFCvl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarsAtlas/MarsAtlas_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFCvm",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_accumbens.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_amygdala.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_anteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_caudate.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_cuneus.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_hippocampus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_insularCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_isthmusCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_lateralVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_midCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_pallidum.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_posteriorCingulateCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_puttamen.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_superiorVisualCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_thalamus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_Colin27-MNI_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralMotorCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_Colin27-MNI/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "11": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_Colin27-MNI_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "Colin27-MNI",
+  "versionInnovation": "This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_cortical-model/MarsAtlas_cortical-model_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_cortical-model_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "cortical model",
+  "versionInnovation": "This is the first version of this cortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_accumbens.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_accumbens",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "226",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "258",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_accumbens",
+  "name": "accumbens",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_amygdala.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_amygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "218",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "254",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_amygdala",
+  "name": "amygdala",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_anteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ACC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "140",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_anteriorCingulateCortex",
+  "name": "anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsolateralPrefrontalCortex",
+  "name": "caudal dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFcdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalDorsomedialPrefrontalCortex",
+  "name": "caudal dorsomedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCcm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "101",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMedialVisualCortex",
+  "name": "caudal medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalMiddleTemporalCortex",
+  "name": "caudal middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCc",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudalSuperiorTemporalCortex",
+  "name": "caudal superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_caudate.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_caudate",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "211",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "250",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_caudate",
+  "name": "caudate",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_cuneus.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_cuneus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Cu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_cuneus",
+  "name": "cuneus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsalInferiorParietalCortex",
+  "name": "dorsal inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralMotorCortex",
+  "name": "dorsolateral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralPremotorCortex",
+  "name": "dorsolateral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsolateralSomatosensoryCortex",
+  "name": "dorsolateral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialMotorCortex",
+  "name": "dorsomedial motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialPremotorCortex",
+  "name": "dorsomedial premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sdm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_dorsomedialSomatosensoryCortex",
+  "name": "dorsomedial somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_hippocampus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_hippocampus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "217",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "253",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_hippocampus",
+  "name": "hippocampus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_insularCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Insula",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "141",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_insula"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_insularCortex",
+  "name": "insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_isthmusCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ICC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_isthmusCingulateCortex",
+  "name": "isthmus cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_lateralVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "102",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_lateralVisualCortex",
+  "name": "lateral visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialInferiorTemporalCortex",
+  "name": "medial inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialParietalCortex",
+  "name": "medial parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPCm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_medialSuperiorParietalCortex",
+  "name": "medial superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_midCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_midCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_midCingulateCortex",
+  "name": "mid cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_pallidum.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_pallidum",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "213",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "252",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_pallidum",
+  "name": "pallidum",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_posteriorCingulateCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PCC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_cingularCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_posteriorCingulateCortex",
+  "name": "posterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_puttamen.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_puttamen",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "212",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "251",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_puttamen",
+  "name": "puttamen",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrd",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsalPrefrontalCortex",
+  "name": "rostral dorsal prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdli",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralInferiorPrefrontalCortex",
+  "name": "rostral dorsolateral inferior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pfrdls",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralDorsolateralSuperiorPrefrontalCortex",
+  "name": "rostral dorsolateral superior prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ITCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralInferiorTemporalCortex",
+  "name": "rostral inferior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialPrefrontalCortex",
+  "name": "rostral medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMedialVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCrm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMedialVisualCortex",
+  "name": "rostral medial visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MTCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralMiddleTemporalCortex",
+  "name": "rostral middle temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STCr",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "110",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_temporalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralSuperiorTemporalCortex",
+  "name": "rostral superior temporal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PMrv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "125",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentralPremotorCortex",
+  "name": "rostral ventral premotor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFrvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_rostralVentrolateralPrefrontalCortex",
+  "name": "rostral ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "SPC",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorParietalCortex",
+  "name": "superior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_superiorVisualCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VCs",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_occipitalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_superiorVisualCortex",
+  "name": "superior visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_thalamus.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_thalamus",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": null,
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "210",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "249",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": null,
+  "lookupLabel": "MarsAtlas_subcortical-extension_thalamus",
+  "name": "thalamus",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is the first version of this subcortical parcellation area."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralInferiorParietalCortex",
+  "name": "ventral inferior parietal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralMotorCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Mv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_frontalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralMotorCortex",
+  "name": "ventral motor cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "137",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralOrbitoFrontalCortex",
+  "name": "ventral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Sv",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_parietalLobe"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralSomatosensoryCortex",
+  "name": "ventral somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "138",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventralmedialOrbitoFrontalCortex",
+  "name": "ventralmedial orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OFCvl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "136",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventrolateralOrbitoFrontalCortex",
+  "name": "ventrolateral orbito frontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+

--- a/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarsAtlas_subcortical-extension/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFCvm",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "139",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/right"
+        }
+      ],
+      "preferredVisualization": null,
+      "specification": null,
+      "type": null
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarsAtlas_orbito-FrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarsAtlas_subcortical-extension_ventromedialPrefrontalCortex",
+  "name": "ventromedial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "subcortical extension",
+  "versionInnovation": "This is identical to/unchanged compared to its previous version."
+}
+


### PR DESCRIPTION
**Overview:** https://docs.google.com/presentation/d/1BgQfFLI6he-001FhLZ_Cfj1SgGcQhJdhgIWm1hmhgUQ/edit?usp=sharing (NOTE: names in jsonlds not identical to the ones in overview!) 

PR #257 is related to this (at_id remains the same either way) 

**General:** 
- 3 BAVs:
     - 1st from 2016 - 'cortical model': parcellation scheme with 41 cortical PEVs (and 7 PEs representing lobes/regions for hierarchical grouping) 
     - 2nd from 2017 - 'subcortical extension': 1st parcellation scheme extended with 7 subcortical PEVs (no additional PEs)
     - 3rd from 2018 - 'Colin27-MNI': parcellation scheme (cortical + subcortical) applied to the Colin27 average brain in the MNI space
- BA(V) names, IDs & descriptions:
     - fullName: Marseille Atlas
     - shortName: MarsAtlas
     - abbreviation: MarsAtlas
     - versionIDs: 'cortical model', 'subcortical extension', 'Colin27-MNI'
     - description: The MarsAtlas is a model of cortical and/or subcortical parcellations and can be applied to any human brain volume files following T1 imaging. The model is implemented in the FreeSurfer software, and cortical and/or subcortical segmentations can be obtained through specific pipelines. When the MarsAtlas is applied to commonly used coordinate framework with a standard reference dataset in a common coordinate space, the output may act as a reference brain atlas.   
     - versionInnovations: describe version specific details
- PE(V)s:
     - all cortical PEVs + hierarchical grouping terms + all subcortical PEVs = 41 + 7 + 7 
     - hierarchical terms represent lobes/larger cortical regions (e.g., occipital lobe) 
     - subcortical regions do not have additional hierarchical terms (also: 'brain' does not exist as the highest level like some of the other atlases have) 
     - cortical PEVs and their corresponding PEs have same hierarchical PEs as parents, subcortical never have parents
     - some PEs have related UBERON terms (NOTE: linked UBERON term may not exist in repo yet, but I checked the PRs for #133 and they are included there) 
     - all PEVs have AtlasAnnotations, each has two - one per hemisphere with corresponding internal ID; 'Colin27-MNI' has additionally type 'annotationMask' (when parcellation schemes are applied, they always result in surfaces first but can be turned into masks (as was done for the 'Colin27-MNI' version), therefore we cannot state one or the other for the PEVs of the parcellation schemes)
     - versionInnovations: 
          - 1st set of cortical PEVs: This is the first version of this cortical parcellation area.
          - 2nd set of cortical PEVs: This is identical to/unchanged compared to its previous version. 
          - 1st set of subcortical PEVs: This is the first version of this subcortical parcellation area.
          - Colin27-MNI set of PEVs: This is the delineated parcellation area in Colin27-MNI following the MarsAtlas parcellation scheme.

**Questions/Noteworthy:**
- see #22: @AhmetNSimsek provided some content there
     - we may want to add the colors for the 'Colin27-MNI' version (if those are the ones originally provided by the authors) 
     - they are organizing the PEVs differently though (one annotation per PEV, thus, one PEV for left and one for right with a PE representing the generally term as parent for the two) 
- BAV/digitalIDs are the DOIs of the related publication (meaning the Colin27-MNI version does not have one), there is nothing else available; is that ok?
- copyrights exists, should we add it?
- could add qualitativeRelationAssessments between cortical PEVs of the 1st and 2nd version (aka 'identical'); would this be useful?
- not sure about the 'howToCite' descirpitons for each BAV, the one for BA was impossible to write; what should I do here? 
- none of the BAV have licenses, what should we do about that?
- BAV releaseDates are the publication dates of the related articles, ok? 