### PR TITLE
Typo fix in some ContentTypes

### DIFF
--- a/instances/latest/contentTypes/application_vnd.meshview+json.jsonld
+++ b/instances/latest/contentTypes/application_vnd.meshview+json.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.meshview+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.meshview+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "Coordinate triplets for display of point clouds in MeshView (RRID:SCR_017222)",

--- a/instances/latest/contentTypes/application_vnd.webalign.waln.jsonld
+++ b/instances/latest/contentTypes/application_vnd.webalign.waln.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.webalign.waln+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.webalign.waln+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "WebAlign waln is a JSON-based content type containing the linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), and the actual linear image registration in the form of 3D vector triplets per image (optional).",

--- a/instances/latest/contentTypes/application_vnd.webwarp.wwrp.jsonld
+++ b/instances/latest/contentTypes/application_vnd.webwarp.wwrp.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.webwarp.wwrp+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.webwarp.wwrp+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "WebWarp wwrp is a JSON-based content type containing the linear and optionally non-linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), the linear image registration in the form of 3D vector triplets per image (optional), and the non-linear image registration in form of a list of 2D deformation vectors per image (optional).",

--- a/instances/v3.0/contentTypes/application_vnd.meshview+json.jsonld
+++ b/instances/v3.0/contentTypes/application_vnd.meshview+json.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.meshview+json",
+  "@id": "https://openminds.ebrains.eu/instances/contentType/application_vnd.meshview+json",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
   "dataType": null,
   "description": "Coordinate triplets for display of point clouds in MeshView (RRID:SCR_017222)",

--- a/instances/v3.0/contentTypes/application_vnd.webalign.waln.jsonld
+++ b/instances/v3.0/contentTypes/application_vnd.webalign.waln.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.webalign.waln+json",
+  "@id": "https://openminds.ebrains.eu/instances/contentType/application_vnd.webalign.waln+json",
   "@type": "https://openminds.ebrains.eu/controlledTerms/ContentType",
   "dataType": null,
   "description": "WebAlign waln is a JSON-based content type containing the linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), and the actual linear image registration in the form of 3D vector triplets per image (optional).",

--- a/instances/v3.0/contentTypes/application_vnd.webwarp.wwrp.jsonld
+++ b/instances/v3.0/contentTypes/application_vnd.webwarp.wwrp.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.webwarp.wwrp+json",
+  "@id": "https://openminds.ebrains.eu/instances/contentType/application_vnd.webwarp.wwrp+json",
   "@type": "https://openminds.ebrains.eu/controlledTerms/ContentType",
   "dataType": null,
   "description": "WebWarp wwrp is a JSON-based content type containing the linear and optionally non-linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), the linear image registration in the form of 3D vector triplets per image (optional), and the non-linear image registration in form of a list of 2D deformation vectors per image (optional).",

--- a/instances/v4.0/contentTypes/application_vnd.meshview+json.jsonld
+++ b/instances/v4.0/contentTypes/application_vnd.meshview+json.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.meshview+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.meshview+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "Coordinate triplets for display of point clouds in MeshView (RRID:SCR_017222)",

--- a/instances/v4.0/contentTypes/application_vnd.webalign.waln.jsonld
+++ b/instances/v4.0/contentTypes/application_vnd.webalign.waln.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.webalign.waln+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.webalign.waln+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "WebAlign waln is a JSON-based content type containing the linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), and the actual linear image registration in the form of 3D vector triplets per image (optional).",

--- a/instances/v4.0/contentTypes/application_vnd.webwarp.wwrp.jsonld
+++ b/instances/v4.0/contentTypes/application_vnd.webwarp.wwrp.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.webwarp.wwrp+json",
+  "@id": "https://openminds.om-i.org/instances/contentType/application_vnd.webwarp.wwrp+json",
   "@type": "https://openminds.om-i.org/types/ContentType",
   "dataType": null,
   "description": "WebWarp wwrp is a JSON-based content type containing the linear and optionally non-linear image registration information for multiple tissue section images to a standard atlas space. It contains complete metadata for a collection of deepzoom images (mandatory), their storage location (mandatory), identifier of the standard atlas space (mandatory), the linear image registration in the form of 3D vector triplets per image (optional), and the non-linear image registration in form of a list of 2D deformation vectors per image (optional).",


### PR DESCRIPTION
@majpuc reported that these content types did not show up in the EBRAINS KG. I found a typo in their at_id which probably caused them to not be pulled.
