### PR TITLE
Structural vs. functional MRI split (additional updates)

### DIFF
--- a/instances/latest/terminologies/technique/functionalMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/functionalMagneticResonanceImaging.jsonld
@@ -11,6 +11,7 @@
   "name": "functional magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
   "synonym": [
-    "fMRI"
+    "fMRI",
+    "functional MRI"
   ]
 }

--- a/instances/latest/terminologies/technique/highFieldFunctionalMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/highFieldFunctionalMagneticResonanceImaging.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/technique/highFieldFunctionalMagneticResonanceImaging",
   "@type": "https://openminds.om-i.org/types/Technique",
-  "definition": null,
+  "definition": "A magnetic resonance imaging technique that generates multiple images over time of some physiological processes of a specimen typically employing a magnetic field strength of 3 Tesla (or higher but below 7 Tesla).",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "high-field functional magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "HF fMRI",
+    "HF functional magnetic resonance imaging",
+    "HF functional MRI",
+    "high-field fMRI",
+    "high-field functional MRI"
+  ]
 }

--- a/instances/latest/terminologies/technique/highFieldMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/highFieldMagneticResonanceImaging.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/technique/highFieldMagneticResonanceImaging",
   "@type": "https://openminds.om-i.org/types/Technique",
-  "definition": null,
+  "definition": "Any medical imaging technique that typically uses a magnetic field strength of 3 Tesla (or higher but below 7 Tesla) to generate images of a specimen based on the principle of nuclear magnetic resonance.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "high-field magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "HF MRI",
+    "high-field MRI",
+    "HF magnetic resonance imaging",
+    "HF unspecified magnetic resonance imaging",
+    "high-field unspecified magnetic resonance imaging"
+  ]
 }

--- a/instances/latest/terminologies/technique/highFieldStructuralMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/highFieldStructuralMagneticResonanceImaging.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/technique/highFieldStructuralMagneticResonanceImaging",
+  "@type": "https://openminds.om-i.org/types/Technique",
+  "definition": "A magnetic resonance imaging technique that typically uses a magnetic field strength of 3 Tesla (or higher but below 7 Tesla) to generate images with static information of the scanned body.",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "high-field structural magnetic resonance imaging",
+  "preferredOntologyIdentifier": null,
+  "synonym": [
+    "HF sMRI",
+    "HF structural MRI",
+    "HF structural magnetic resonance imaging",
+    "high-field structural MRI",
+    "HF MRI",
+    "high-field MRI",
+    "HF magnetic resonance imaging",
+    "high-field magnetic resonance imaging"
+  ]
+}

--- a/instances/latest/terminologies/technique/quantitativeMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/quantitativeMagneticResonanceImaging.jsonld
@@ -11,6 +11,7 @@
   "name": "quantitative magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
   "synonym": [
-    "qMRI"
+    "qMRI",
+    "quantitative MRI"
   ]
 }

--- a/instances/latest/terminologies/technique/structuralMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/structuralMagneticResonanceImaging.jsonld
@@ -12,6 +12,7 @@
   "preferredOntologyIdentifier": null,
   "synonym": [
     "sMRI",
+    "structural MRI",
     "MRI",
     "magnetic resonance imaging"
   ]

--- a/instances/latest/terminologies/technique/ultraHighFieldFunctionalMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/ultraHighFieldFunctionalMagneticResonanceImaging.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/technique/ultraHighFieldFunctionalMagneticResonanceImaging",
   "@type": "https://openminds.om-i.org/types/Technique",
-  "definition": "'Ultra high-field functional magnetic resonance imaging' comprises all functional MRI techniques conducted with a MRI scanner with a magnetic field strength equal or above 7 Tesla.",
+  "definition": "A magnetic resonance imaging technique that generates multiple images over time of some physiological processes of a specimen typically employing a magnetic field strength of 7 Tesla (or higher).",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "ultra high-field functional magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "UHF fMRI",
+    "UHF functional magnetic resonance imaging",    
+    "UHF functional MRI",
+    "ultra high-field fMRI",
+    "ultra high-field functional MRI"
+  ]
 }

--- a/instances/latest/terminologies/technique/ultraHighFieldMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/ultraHighFieldMagneticResonanceImaging.jsonld
@@ -4,11 +4,17 @@
   },
   "@id": "https://openminds.om-i.org/instances/technique/ultraHighFieldMagneticResonanceImaging",
   "@type": "https://openminds.om-i.org/types/Technique",
-  "definition": "'Ultra high-field magnetic resonance imaging' comprises all structural MRI techniques conducted with a MRI scanner with a magnetic field strength equal or above 7 Tesla.",
+  "definition": "Any medical imaging technique that typically uses a magnetic field strength of 7 Tesla (or higher) to generate images of a specimen based on the principle of nuclear magnetic resonance.",
   "description": null,
   "interlexIdentifier": null,
   "knowledgeSpaceLink": null,
   "name": "ultra high-field magnetic resonance imaging",
   "preferredOntologyIdentifier": null,
-  "synonym": null
+  "synonym": [
+    "UHF MRI",
+    "UHF magnetic resonance imaging",
+    "UHF unspecified magnetic resonance imaging",
+    "ultra high-field MRI",
+    "ultra high-field unspecified magnetic resonance imaging"
+  ]
 }

--- a/instances/latest/terminologies/technique/ultraHighFieldStructuralMagneticResonanceImaging.jsonld
+++ b/instances/latest/terminologies/technique/ultraHighFieldStructuralMagneticResonanceImaging.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/technique/ultraHighFieldStructuralMagneticResonanceImaging",
+  "@type": "https://openminds.om-i.org/types/Technique",
+  "definition": "A magnetic resonance imaging technique that typically uses a magnetic field strength of 7 Tesla (or higher) to generate images with static information of the scanned body.",
+  "description": null,
+  "interlexIdentifier": null,
+  "knowledgeSpaceLink": null,
+  "name": "ultra high-field structural magnetic resonance imaging",
+  "preferredOntologyIdentifier": null,
+  "synonym": [
+    "UHF sMRI",
+    "UHF structural MRI",
+    "ultra high-field structural MRI",
+    "UHF structural magnetic resonance imaging",
+    "UHF MRI",
+    "ultra high-field MRI",
+    "UHF magnetic resonance imaging",
+    "ultra high-field magnetic resonance imaging"
+  ]
+}


### PR DESCRIPTION
#128 

I used our existing definitions and synonyms for MRI techniques to create the new ones and added some additional synonyms to existing terms (also, very convenient to see them in this PR but this was just a bonus). 

The general idea was:
(s)MRI: "... uses strong magnetic fields, magnetic field gradients, and radio waves to generate ..."
high-field (s)MRI: "... typically uses a magnetic field strength of 3 Tesla (or higher but below 7 Tesla) to generate ..."
ultra high-field (s)MRI: "... typically uses a magnetic field strength of 7 Tesla (or higher) to generate ..."

fMRI: "A magnetic resonance imaging technique that generates ..."
high-field fMRI: "A magnetic resonance imaging technique that generates ... typically employing a magnetic field strength of 3 Tesla (or higher but below 7 Tesla)."
ultra high-field fMRI: "A magnetic resonance imaging technique that generates ... typically employing a magnetic field strength of 7 Tesla (or higher)."