### PR TITLE
Fix #306

### DIFF
--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Accent.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Accent.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Accent",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Accent",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Accent' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Blues.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Blues.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Blues",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Blues",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Blues' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.BrBG.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.BrBG.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.BrBG",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.BrBG",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'BrBG' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.BuGn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.BuGn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.BuGn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.BuGn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'BuGn' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.BuPu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.BuPu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.BuPu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.BuPu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'BuPu' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.CMRmap.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.CMRmap.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.CMRmap",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.CMRmap",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'CMRmap' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Dark2.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Dark2.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Dark2",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Dark2",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Dark2' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.GnBu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.GnBu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.GnBu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.GnBu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'GnBu' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Greens.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Greens.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Greens",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greens",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Greens' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Greys.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Greys.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Greys",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Greys' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.OrRd.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.OrRd.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.OrRd",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.OrRd",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'OrRd' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Oranges.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Oranges.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Oranges",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Oranges",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Oranges' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PRGn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PRGn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PRGn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PRGn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PRGn' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Paired.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Paired.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Paired",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Paired",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Paired' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Pastel1.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Pastel1.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Pastel1",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Pastel1",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Pastel1' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Pastel2.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Pastel2.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Pastel2",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Pastel2",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Pastel2' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PiYG.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PiYG.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PiYG",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PiYG",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PiYG' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PuBu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PuBu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PuBu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PuBu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PuBu' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PuBuGn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PuBuGn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PuBuGn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PuBuGn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PuBuGn' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PuOr.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PuOr.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PuOr",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PuOr",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PuOr' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.PuRd.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.PuRd.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.PuRd",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.PuRd",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'PuRd' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Purples.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Purples.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Purples",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Purples",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Purples' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.RdBu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.RdBu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.RdBu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.RdBu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'RdBu' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.RdGy.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.RdGy.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.RdGy",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.RdGy",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'RdGy' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.RdPu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.RdPu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.RdPu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.RdPu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'RdPu' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.RdYlBu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.RdYlBu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.RdYlBu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.RdYlBu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'RdYlBu' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.RdYlGn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.RdYlGn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.RdYlGn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.RdYlGn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'RdYlGn' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Reds.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Reds.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Reds",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Reds",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Reds' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Set1.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Set1.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Set1",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Set1",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Set1' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Set2.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Set2.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Set2",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Set2",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Set2' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Set3.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Set3.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Set3",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Set3",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Set3' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Spectral.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Spectral.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Spectral",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Spectral",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Spectral' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.Wistia.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.Wistia.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.Wistia",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Wistia",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'Wistia' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.YlGn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.YlGn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.YlGn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.YlGn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'YlGn' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.YlGnBu.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.YlGnBu.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.YlGnBu",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.YlGnBu",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'YlGnBu' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.YlOrBr.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.YlOrBr.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.YlOrBr",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.YlOrBr",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'YlOrBr' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.YlOrRd.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.YlOrRd.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.YlOrRd",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.YlOrRd",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'YlOrRd' is a sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.afmhot.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.afmhot.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.afmhot",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.afmhot",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'afmhot' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.autumn.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.autumn.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.autumn",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.autumn",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'autumn' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.binary.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.binary.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.binary",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.binary",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'binary' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.bone.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.bone.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.bone",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.bone",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'bone' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.brg.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.brg.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.brg",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.brg",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'brg' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.bwr.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.bwr.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.bwr",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.bwr",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'bwr' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.cividis.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.cividis.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.cividis",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.cividis",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'cividis' is a perceptually uniform sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.cool.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.cool.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.cool",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.cool",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'cool' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.coolwarm.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.coolwarm.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.coolwarm",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.coolwarm",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'coolwarm' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.copper.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.copper.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.copper",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.copper",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'copper' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.cubehelix.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.cubehelix.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.cubehelix",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.cubehelix",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'cubehelix' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.flag.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.flag.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.flag",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.flag",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'flag' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_earth.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_earth.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_earth",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_earth",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_earth' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_gray.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_gray.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_gray",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_gray",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_gray' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_heat.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_heat.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_heat",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_heat",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_heat' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_ncar.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_ncar.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_ncar",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_ncar",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_ncar' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_rainbow.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_rainbow.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_rainbow",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_rainbow",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_rainbow' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_stern.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_stern.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_stern",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_stern",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_stern' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_yarg.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gist_yarg.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gist_yarg",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gist_yarg",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gist_yarg' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gnuplot.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gnuplot.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gnuplot",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gnuplot",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gnuplot' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gnuplot2.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gnuplot2.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gnuplot2",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gnuplot2",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gnuplot2' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.gray.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.gray.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.gray",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.gray",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'gray' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.hot.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.hot.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.hot",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.hot",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'hot' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.hsv.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.hsv.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.hsv",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.hsv",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'hsv' is a cyclic colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.inferno.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.inferno.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.inferno",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.inferno",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'inferno' is a perceptually uniform sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.jet.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.jet.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.jet",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.jet",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'jet' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.magma.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.magma.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.magma",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.magma",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'magma' is a perceptually uniform sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.nipy_spectral.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.nipy_spectral.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.nipy_spectral",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.nipy_spectral",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'nipy_spectral' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.ocean.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.ocean.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.ocean",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.ocean",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'ocean' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.pink.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.pink.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.pink",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.pink",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'pink' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.plasma.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.plasma.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.plasma",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.plasma",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'plasma' is a perceptually uniform sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.prism.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.prism.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.prism",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.prism",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'prism' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.rainbow.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.rainbow.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.rainbow",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.rainbow",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'rainbow' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.seismic.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.seismic.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.seismic",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.seismic",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'seismic' is a diverging colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.spring.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.spring.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.spring",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.spring",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'spring' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.summer.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.summer.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.summer",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.summer",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'summer' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.tab10.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.tab10.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.tab10",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.tab10",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'tab10' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.tab20",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.tab20",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'tab20' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20b.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20b.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.tab20b",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.tab20b",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'tab20b' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20c.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.tab20c.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.tab20c",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.tab20c",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'tab20c' is a qualitative colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.terrain.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.terrain.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.terrain",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.terrain",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'terrain' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.turbo.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.turbo.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.turbo",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.turbo",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'turbo' is a miscellaneous colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.twilight.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.twilight.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.twilight",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.twilight",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'twilight' is a cyclic colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.twilight_shifted.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.twilight_shifted.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.twilight_shifted",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.twilight_shifted",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'twilight_shifted' is a cyclic colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.viridis.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.viridis.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.viridis",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.viridis",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'viridis' is a perceptually uniform sequential colormap of the Python plotting library Matplotlib.",
   "description": null,

--- a/instances/latest/terminologies/colormap/matplotlib.colormaps.winter.jsonld
+++ b/instances/latest/terminologies/colormap/matplotlib.colormaps.winter.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@vocab": "https://openminds.om-i.org/props/"
   },
-  "@id": "https://openminds.om-i.org/instances/actionStatusType/matplotlib.colormaps.winter",
+  "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.winter",
   "@type": "https://openminds.om-i.org/types/Colormap",
   "definition": "The colormap 'winter' is a sequential (type 2) colormap of the Python plotting library Matplotlib.",
   "description": null,


### PR DESCRIPTION
Replaces "https://openminds.om-i.org/instances/actionStatusType" by "https://openminds.om-i.org/instances/colormap" in https://github.com/openMetadataInitiative/openMINDS_instances/tree/main/instances/latest/terminologies/colormap