### PR TITLE
BrainAtlasVersion instances update (accord. to updated atlas types)

### DIFF
--- a/instances/latest/brainAtlasVersions/AAL1/AAL1_SPM12-v4.jsonld
+++ b/instances/latest/brainAtlasVersions/AAL1/AAL1_SPM12-v4.jsonld
@@ -178,7 +178,7 @@
   "shortName": "AAL Atlas 1",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "SPM12, v4",

--- a/instances/latest/brainAtlasVersions/AMBA/AMBA_CCFv3-2015.jsonld
+++ b/instances/latest/brainAtlasVersions/AMBA/AMBA_CCFv3-2015.jsonld
@@ -3902,7 +3902,7 @@
   "shortName": "Allen Mouse Brain Atlas",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "CCFv3, 2015",

--- a/instances/latest/brainAtlasVersions/AMBA/AMBA_CCFv3-2017.jsonld
+++ b/instances/latest/brainAtlasVersions/AMBA/AMBA_CCFv3-2017.jsonld
@@ -4022,7 +4022,7 @@
   "shortName": "Allen Mouse Brain Atlas",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "CCFv3, 2017",

--- a/instances/latest/brainAtlasVersions/BA-human/BA-human_1909.jsonld
+++ b/instances/latest/brainAtlasVersions/BA-human/BA-human_1909.jsonld
@@ -192,7 +192,7 @@
   "shortName": "Brodmann Areas (human)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationScheme"
+    "@id": "https://openminds.om-i.org/instances/atlasType/parcellationModel"
   },
   "usedSpecimen": null,
   "versionIdentifier": "1909",

--- a/instances/latest/brainAtlasVersions/DWMA/DWMA_2018.jsonld
+++ b/instances/latest/brainAtlasVersions/DWMA/DWMA_2018.jsonld
@@ -75,7 +75,9 @@
   "repository": null,
   "shortName": "Deep White Matter Atlas",
   "supportChannel": null,
-  "type": null,
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/probabilisticAtlas"
+  },
   "usedSpecimen": null,
   "versionIdentifier": "2018",
   "versionInnovation": "This is the first released version of this brain atlas."

--- a/instances/latest/brainAtlasVersions/JBA/JBA_v2.9-BigBrain.jsonld
+++ b/instances/latest/brainAtlasVersions/JBA/JBA_v2.9-BigBrain.jsonld
@@ -142,7 +142,7 @@
     "julich-brain@fz-juelich.de"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v2.9, BigBrain",

--- a/instances/latest/brainAtlasVersions/JBA/JBA_v3.0-BigBrain.jsonld
+++ b/instances/latest/brainAtlasVersions/JBA/JBA_v3.0-BigBrain.jsonld
@@ -144,7 +144,7 @@
     "julich-brain@fz-juelich.de"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3.0, BigBrain",

--- a/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.1-BigBrain.jsonld
+++ b/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.1-BigBrain.jsonld
@@ -144,7 +144,7 @@
     "julich-brain@fz-juelich.de"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3.0.1, BigBrain",

--- a/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.2-BigBrain.jsonld
+++ b/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.2-BigBrain.jsonld
@@ -144,7 +144,7 @@
     "julich-brain@fz-juelich.de"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3.0.2, BigBrain",

--- a/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.3-BigBrain.jsonld
+++ b/instances/latest/brainAtlasVersions/JBA/JBA_v3.0.3-BigBrain.jsonld
@@ -144,7 +144,7 @@
     "julich-brain@fz-juelich.de"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3.0.3, BigBrain",

--- a/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Bregma-LIA.jsonld
+++ b/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Bregma-LIA.jsonld
@@ -2901,7 +2901,7 @@
   "shortName": "Paxinos and Watson's Stereotaxic Rat Brain Atlas (Coronal)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "6th ed. (Bregma, LIA)",

--- a/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Bregma-RIA.jsonld
+++ b/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Bregma-RIA.jsonld
@@ -2901,7 +2901,7 @@
   "shortName": "Paxinos and Watson's Stereotaxic Rat Brain Atlas (Coronal)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "6th ed. (Bregma, RIA)",

--- a/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Interaural-LSA.jsonld
+++ b/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Interaural-LSA.jsonld
@@ -2901,7 +2901,7 @@
   "shortName": "Paxinos and Watson's Stereotaxic Rat Brain Atlas (Coronal)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "6th ed. (Interaural, LSA)",

--- a/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Interaural-RSA.jsonld
+++ b/instances/latest/brainAtlasVersions/PW-RBSC-cor/PW-RBSC-cor_6th-ed-Interaural-RSA.jsonld
@@ -2901,7 +2901,7 @@
   "shortName": "Paxinos and Watson's Stereotaxic Rat Brain Atlas (Coronal)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "6th ed. (Interaural, RSA)",

--- a/instances/latest/brainAtlasVersions/SWMA/SWMA_2018.jsonld
+++ b/instances/latest/brainAtlasVersions/SWMA/SWMA_2018.jsonld
@@ -237,7 +237,9 @@
   "repository": null,
   "shortName": "Superficial White Matter Atlas",
   "supportChannel": null,
-  "type": null,
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/probabilisticAtlas"
+  },
   "usedSpecimen": null,
   "versionIdentifier": "2018",
   "versionInnovation": "This is the first released version of this brain atlas."

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-kong17n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-kong17n.jsonld
@@ -40,7 +40,7 @@
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "2018, FSL-MNI152, kong17n",

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-yeo17n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-yeo17n.jsonld
@@ -40,7 +40,7 @@
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "2018, FSL-MNI152, yeo17n",

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-yeo7n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-FSL-MNI152-yeo7n.jsonld
@@ -40,7 +40,7 @@
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "2018, FSL-MNI152, yeo7n",

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-kong17n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-kong17n.jsonld
@@ -42,7 +42,7 @@
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "2018, fsLR32k, kong17n",

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-yeo17n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-yeo17n.jsonld
@@ -41,7 +41,9 @@
   "repository": null,
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
-  "type": null,
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
+  },
   "usedSpecimen": null,
   "versionIdentifier": "2018, fsLR32k, yeo17n",
   "versionInnovation": null

--- a/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-yeo7n.jsonld
+++ b/instances/latest/brainAtlasVersions/Schaefer-400p/Schaefer-400p_2018-fsLR32k-yeo7n.jsonld
@@ -42,7 +42,7 @@
   "shortName": "Schaefer Atlas (400p)",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "2018, fsLR32k, yeo7n",

--- a/instances/latest/brainAtlasVersions/SwansonBM/SwansonBM_3rd-ed.jsonld
+++ b/instances/latest/brainAtlasVersions/SwansonBM/SwansonBM_3rd-ed.jsonld
@@ -3524,7 +3524,7 @@
   "shortName": "Swanson's Brain Maps",
   "supportChannel": null,
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "3rd ed.",

--- a/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v1.01.jsonld
+++ b/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v1.01.jsonld
@@ -280,7 +280,7 @@
     "https://www.nitrc.org/forum/forum.php?forum_id=9174"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v1.01",

--- a/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v2.jsonld
+++ b/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v2.jsonld
@@ -297,7 +297,7 @@
     "https://www.nitrc.org/forum/forum.php?forum_id=9174"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v2",

--- a/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v3.01.jsonld
+++ b/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v3.01.jsonld
@@ -414,7 +414,7 @@
     "https://www.nitrc.org/forum/forum.php?forum_id=9174"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3.01",

--- a/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v3.jsonld
+++ b/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v3.jsonld
@@ -414,7 +414,7 @@
     "https://www.nitrc.org/forum/forum.php?forum_id=9174"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v3",

--- a/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v4.jsonld
+++ b/instances/latest/brainAtlasVersions/WHSSDatlas/WHSSDatlas_v4.jsonld
@@ -729,7 +729,7 @@
     "https://www.nitrc.org/forum/forum.php?forum_id=9174"
   ],
   "type": {
-    "@id": "https://openminds.om-i.org/instances/atlasType/deterministicAtlas"
+    "@id": "https://openminds.om-i.org/instances/atlasType/discreteAtlas"
   },
   "usedSpecimen": null,
   "versionIdentifier": "v4",

--- a/instances/v4.0/brainAtlasVersions/MarmosetNMA/MarmosetNMA_v1.jsonld
+++ b/instances/v4.0/brainAtlasVersions/MarmosetNMA/MarmosetNMA_v1.jsonld
@@ -1,0 +1,407 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/brainAtlasVersion/MarmosetNMA_v1",
+  "@type": "https://openminds.om-i.org/types/BrainAtlasVersion",
+  "abbreviation": "MarmosetNMA",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "author": null,
+  "coordinateSpace": {
+    "@id": "https://openminds.om-i.org/instances/commonCoordinateSpaceVersion/MarmosetNMT_v1"
+  },
+  "copyright": null,
+  "custodian": null,
+  "description": null,
+  "digitalIdentifier": null,
+  "fullDocumentation": {
+    "@id": "https://www.marmosetbrain.org/nencki_monash_template"
+  },
+  "fullName": "Marmoset Nencki-Monash Probabilistic Cytoarchitectonic Brain Atlas",
+  "funding": null,
+  "hasTerminology": {
+    "@type": "https://openminds.om-i.org/types/ParcellationTerminologyVersion",
+    "dataLocation": null,
+    "hasEntity": [
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_agranularInsularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_amygdalopiriformTransitionArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area10OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area11OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexLateralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13aOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13bOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexCaudalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexRostralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexDorsointermediatePart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23OfCortexVentralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23aOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23bOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23cOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24aOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24bOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24cOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24dOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area25OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29a-cOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29dOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area30OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area31OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortexVentralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area35OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area36OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3aOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3bOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area45OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexDorsalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexVentralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexLateralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexOrbitalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartC"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartsAAndB"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsocaudalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsorostralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartA"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartB"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8OfCortexCaudalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexDorsalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexVentralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8bOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area9OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_areas1And2OfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexAnterolateralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudolateralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudomedialArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexMiddleLateralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexPrimaryArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralParabelt"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostromedialArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporal"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_dysgranularInsularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_entorhinalCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_granularInsularCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_gustatoryCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_insularProisocortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialIntraparietalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalPeriallocortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalProisocortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexLateralPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPE"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPECaudalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPF"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPFG"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPG"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPGMedialPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreasPGaAndIPa"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_piriformCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_primaryVisualCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_proisocorticalMotorRegion"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_prostriateArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_retroinsularArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_superiorTemporalRostralArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE1"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE2"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE3"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTEOccipitalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTF"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTFOccipitalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTH"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTL"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTLOccipitalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalProisocortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporoparietalTransitionalArea"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporopolarProisocortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea2"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3A"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4TransitionalPart"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea5"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6"
+      },
+      {
+        "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6A"
+      }
+    ],
+    "ontologyIdentifier": null
+  },
+  "homepage": "https://www.marmosetbrain.org/",
+  "howToCite": "Majka, P., Bednarek, S., Chan, J. M., Jermakow, N., Liu, C., Saworska, G., Worthy, K. H., Silva, A. C., Wójcik, D. K., & Rosa, M. G. P. (2021). Histology-Based Average Template of the Marmoset Cortex With Probabilistic Localization of Cytoarchitectural Areas. NeuroImage, 226, 117625. https://doi.org/10.1016/j.neuroimage.2020.117625.",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": {
+    "@id": "https://openminds.om-i.org/instances/licenses/CC-BY-4.0"
+  },
+  "majorVersionIdentifier": null,
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1016/j.neuroimage.2020.117625"
+    }
+  ],
+  "releaseDate": "2021-02-01",
+  "repository": null,
+  "shortName": "Marmoset Nencki-Monash Atlas",
+  "supportChannel": [
+    "support@marmosetbrain.org"
+  ],
+  "type": {
+    "@id": "https://openminds.om-i.org/instances/atlasType/probabilisticAtlas"
+  },
+  "usedSpecimen": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this atlas."
+}

--- a/instances/v4.0/commonCoordinateSpaceVersions/MarmosetNMT/MarmosetNMT_v1.jsonld
+++ b/instances/v4.0/commonCoordinateSpaceVersions/MarmosetNMT/MarmosetNMT_v1.jsonld
@@ -1,0 +1,50 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/commonCoordinateSpaceVersion/MarmosetNMT_v1",
+  "@type": "https://openminds.om-i.org/types/CommonCoordinateSpaceVersion",
+  "abbreviation": "MarmosetNMT",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "anatomicalAxesOrientation": {
+    "@id": "https://openminds.om-i.org/instances/anatomicalAxesOrientation/LPI"
+  },
+  "author": null,
+  "axesOrigin": null,
+  "copyright": null,
+  "custodian": null,
+  "defaultImage": null,
+  "description": "The Nencki-Monash (NM) template v1.0 (2020) represents a computational morphological average of selected gender-balanced young adult brains of the Common Marmoset monkey (Callithrix jacchus), derived from 3D reconstructions based on Nissl-stained serial sections.",
+  "fullDocumentation": {
+    "@id": "https://www.marmosetbrain.org/nencki_monash_template/"
+  },
+  "fullName": "The Marmoset Nencki-Monash Template in Stereotaxic Coordinates",
+  "funding": null,
+  "homepage": "https://www.marmosetbrain.org/nencki_monash_template",
+  "howToCite": "Majka, P., Bednarek, S., Chan, J. M., Jermakow, N., Liu, C., Saworska, G., Worthy, K. H., Silva, A. C., Wójcik, D. K., & Rosa, M. G. P. (2021). Histology-Based Average Template of the Marmoset Cortex With Probabilistic Localization of Cytoarchitectural Areas. NeuroImage, 226, 117625. https://doi.org/10.1016/j.neuroimage.2020.117625.",
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": {
+    "@id": "https://openminds.om-i.org/instances/licenses/CC-BY-4.0"
+  },
+  "nativeUnit": {
+    "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/millimeter"
+  },
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": [
+    {
+      "@id": "https://doi.org/10.1016/j.neuroimage.2020.117625"
+    }
+  ],
+  "releaseDate": "2021-02-01",
+  "repository": null,
+  "shortName": "Marmoset Nencki-Monash Template",
+  "supportChannel": null,
+  "usedSpecimen": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of average histology."
+}

--- a/instances/v4.0/commonCoordinateSpaceVersions/P-MarmosetBSC-corT/P-MarmosetBSC-corT_v2012-Interaural-LSA.jsonld
+++ b/instances/v4.0/commonCoordinateSpaceVersions/P-MarmosetBSC-corT/P-MarmosetBSC-corT_v2012-Interaural-LSA.jsonld
@@ -1,0 +1,45 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/commonCoordinateSpaceVersion/P-MarmosetBSC-corT_v2012-Interaural-LSA",
+  "@type": "https://openminds.om-i.org/types/CommonCoordinateSpaceVersion",
+  "abbreviation": "P-MarmosetBSC-corT",
+  "accessibility": {
+    "@id": "https://openminds.om-i.org/instances/productAccessibility/freeAccess"
+  },
+  "anatomicalAxesOrientation": {
+    "@id": "https://openminds.om-i.org/instances/anatomicalAxesOrientation/LSA"
+  },
+  "author": null,
+  "axesOrigin": null,
+  "copyright": null,
+  "custodian": null,
+  "defaultImage": null,
+  "description": "This coordinate space of the coronal plates from Paxinos et al. 'Marmoset Brain in Stereotaxic Coordinates' uses the midpoint of the interaural line as its origin. The coordinates of the origin in the physical coordinate system of the marmoset brain could not be determined from the information provided in the atlas publication. This coordinate space has LSA orientation (X, Y, Z axes are oriented towards left, superior and anterior, respectively). This was obtained by combining information provided in the pdf version of the 1st edition: (1) \"In the common marmoset, the horizontal zero plane is defined as the plane passing thorough the lower margin of the orbit and the center of the external auditory meatus (Figure B). The anteroposterior zero plane is defined as the plane perpendicular to the horizontal zero plane which passes the centers of the external auditory meati. The left-right zero plane is the midsagittal plane [...].\" (quoted from chapter 'Introduction', subsection 'Histology', page IX). (2) Based on Figure C (chapter 'Introduction', subsection 'Histology', page X), the fiducial marks were made on the right hemisphere of the marmoset brain. These are visible in some of the photographic plates (e.g., Figure 187a) identifying the left hemisphere as delineated one. Thus, the coordinate system is oriented towards the left since the marmoset's left hemisphere has been used to draw the atlas. A pdf version of the atlas can be accessed from https://r.marmosetbrain.org/Atlas+Small.pdf or https://www.researchgate.net/publication/335871101_PDF_of_The_Marmoset_Brain_in_Stereotaxic_Coordinates.",
+  "digitalIdentifier": null,
+  "fullDocumentation": {
+    "@id": "https://openminds.om-i.org/instances/ISBN/978-0-12-415818-4"
+  },
+  "fullName": "Paxinos et al. Coronal Template of the Marmoset Brain in Stereotaxic Coordinates",
+  "funding": null,
+  "homepage": "http://www.neura.edu.au/research/themes/paxinos-group",
+  "howToCite": null,
+  "isAlternativeVersionOf": null,
+  "isNewVersionOf": null,
+  "keyword": null,
+  "license": null,
+  "nativeUnit": {
+    "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/millimeter"
+  },
+  "ontologyIdentifier": null,
+  "otherContribution": null,
+  "relatedPublication": null,
+  "releaseDate": "2011-10-11",
+  "repository": null,
+  "shortName": "Paxinos et al. Stereotaxic Coronal Template (Marmoset Brain)",
+  "supportChannel": null,
+  "usedSpecimen": null,
+  "versionIdentifier": "v2012 (Interaural, LSA)",
+  "versionInnovation": "This is the first version of this stereotaxic coordinate system."
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_agranularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_agranularInsularCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_agranularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AI",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_agranularInsularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_agranularInsularCortex",
+  "name": "agranular insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_amygdalopiriformTransitionArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_amygdalopiriformTransitionArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_amygdalopiriformTransitionArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "APir",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateropallialPart"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_amygdalopiriformTransitionArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_amygdalopiriformTransitionArea",
+  "name": "amygdalopiriform transition area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_anteriorCingulateCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_anteriorCingulateCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ACC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_anteriorCingulateCortex",
+  "name": "Anterior cingulate cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_anteriorIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_anteriorIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AIP",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_anteriorIntraparietalAreaOfCortex",
+  "name": "anterior intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area10OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area10OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area10OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A10",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area10OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area10OfCortex",
+  "name": "area 10 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area11OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area11OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area11OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A11",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area11OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area11OfCortex",
+  "name": "area 11 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13OfCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13OfCortexLateralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area13OfCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A13L",
+  "alternateName": [
+    "area 13 of cortex, lateral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexLateralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area13OfCortexLateralPart",
+  "name": "area 13 of cortex lateral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13OfCortexMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area13OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A13M",
+  "alternateName": [
+    "area 13 of cortex, medial part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area13OfCortexMedialPart",
+  "name": "area 13 of cortex medial part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13aOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area13aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A13a",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13aOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area13aOfCortex",
+  "name": "area 13a of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area13bOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area13bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A13b",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13bOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area13bOfCortex",
+  "name": "area 13b of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area14OfCortexCaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area14OfCortexCaudalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area14OfCortexCaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A14C",
+  "alternateName": [
+    "area 14 of cortex, caudal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexCaudalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area14OfCortexCaudalPart",
+  "name": "area 14 of cortex caudal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area14OfCortexRostralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area14OfCortexRostralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area14OfCortexRostralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A14R",
+  "alternateName": [
+    "area 14 of cortex, rostral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexRostralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area14OfCortexRostralPart",
+  "name": "area 14 of cortex rostral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area19OfCortexDorsointermediatePart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area19OfCortexDorsointermediatePart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area19OfCortexDorsointermediatePart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A19DI",
+  "alternateName": [
+    "area 19 of cortex, dorsointermediate part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexDorsointermediatePart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area19OfCortexDorsointermediatePart",
+  "name": "area 19 of cortex dorsointermediate part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area19OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area19OfCortexMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area19OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A19M",
+  "alternateName": [
+    "area 19 of cortex, medial part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area19OfCortexMedialPart",
+  "name": "area 19 of cortex medial part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23OfCortexVentralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area23OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A23V",
+  "alternateName": [
+    "area 23 of cortex, ventral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23OfCortexVentralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area23OfCortexVentralPart",
+  "name": "area 23 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23aOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area23aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A23a",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23aOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area23aOfCortex",
+  "name": "area 23a of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23bOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area23bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A23b",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23bOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area23bOfCortex",
+  "name": "area 23b of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area23cOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area23cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A23c",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23cOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area23cOfCortex",
+  "name": "area 23c of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24aOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area24aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A24a",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24aOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area24aOfCortex",
+  "name": "area 24a of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24bOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area24bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A24b",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24bOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area24bOfCortex",
+  "name": "area 24b of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24cOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area24cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A24c",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24cOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area24cOfCortex",
+  "name": "area 24c of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24dOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area24dOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area24dOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A24d",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24dOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area24dOfCortex",
+  "name": "area 24d of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area25OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area25OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area25OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A25",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area25OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area25OfCortex",
+  "name": "area 25 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area29a-cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area29a-cOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area29a-cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A29a-c",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29a-cOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area29a-cOfCortex",
+  "name": "area 29a-c of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area29dOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area29dOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area29dOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A29d",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29dOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area29dOfCortex",
+  "name": "area 29d of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area30OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area30OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area30OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A30",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area30OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area30OfCortex",
+  "name": "area 30 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area31OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area31OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area31OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A31",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area31OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area31OfCortex",
+  "name": "area 31 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area32OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area32OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area32OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A32",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area32OfCortex",
+  "name": "area 32 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area32OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area32OfCortexVentralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area32OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A32V",
+  "alternateName": [
+    "area 32 of cortex, ventral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortexVentralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area32OfCortexVentralPart",
+  "name": "area 32 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area35OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area35OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area35OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A35",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area35OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area35OfCortex",
+  "name": "area 35 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area36OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area36OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area36OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A36",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area36OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area36OfCortex",
+  "name": "area 36 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area3aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area3aOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area3aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A3a",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3aOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area3aOfCortex",
+  "name": "area 3a of cortex (somatosensory)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area3bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area3bOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area3bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A3b",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3bOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area3bOfCortex",
+  "name": "area 3b of cortex (somatosensory)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area45OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area45OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area45OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A45",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area45OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area45OfCortex",
+  "name": "area 45 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area46OfCortexDorsalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area46OfCortexDorsalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area46OfCortexDorsalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A46D",
+  "alternateName": [
+    "area 46 of cortex, dorsal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexDorsalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area46OfCortexDorsalPart",
+  "name": "area 46 of cortex dorsal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area46OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area46OfCortexVentralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area46OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A46V",
+  "alternateName": [
+    "area 46 of cortex, ventral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexVentralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area46OfCortexVentralPart",
+  "name": "area 46 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexLateralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area47OfCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A47L(12L)",
+  "alternateName": [
+    "area 47 (old 12) of cortex, lateral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexLateralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area47OfCortexLateralPart",
+  "name": "area 47 (old 12) of cortex lateral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area47OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A47M(12M)",
+  "alternateName": [
+    "area 47 (old 12) of cortex, medial part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area47OfCortexMedialPart",
+  "name": "area 47 (old 12) of cortex medial part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexOrbitalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area47OfCortexOrbitalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area47OfCortexOrbitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A47O(12O)",
+  "alternateName": [
+    "area 47 (old 12) of cortex, orbital part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexOrbitalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area47OfCortexOrbitalPart",
+  "name": "area 47 (old 12) of cortex orbital part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area4OfCortexPartC.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area4OfCortexPartC.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area4OfCortexPartC",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A4c",
+  "alternateName": [
+    "area 4 of cortex, part c (primary motor)"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartC"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area4OfCortexPartC",
+  "name": "area 4 of cortex part c (primary motor)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area4OfCortexPartsAAndB.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area4OfCortexPartsAAndB.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area4OfCortexPartsAAndB",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A4ab",
+  "alternateName": [
+    "area 4 of cortex, parts a and b (primary motor)"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartsAAndB"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area4OfCortexPartsAAndB",
+  "name": "area 4 of cortex parts a and b (primary motor)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexDorsocaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexDorsocaudalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area6OfCortexDorsocaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A6DC",
+  "alternateName": [
+    "area 6 of cortex, dorsocaudal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsocaudalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area6OfCortexDorsocaudalPart",
+  "name": "area 6 of cortex dorsocaudal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexDorsorostralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexDorsorostralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area6OfCortexDorsorostralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A6DR",
+  "alternateName": [
+    "area 6 of cortex, dorsorostral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsorostralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area6OfCortexDorsorostralPart",
+  "name": "area 6 of cortex dorsorostral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area6OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A6M",
+  "alternateName": [
+    "area 6 of cortex, medial (supplementary motor) part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area6OfCortexMedialPart",
+  "name": "area 6 of cortex medial (supplementary motor) part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexVentralPartA.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexVentralPartA.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area6OfCortexVentralPartA",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A6Va",
+  "alternateName": [
+    "area 6 of cortex, ventral, part a"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartA"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area6OfCortexVentralPartA",
+  "name": "area 6 of cortex ventral part a",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexVentralPartB.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area6OfCortexVentralPartB.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area6OfCortexVentralPartB",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A6Vb",
+  "alternateName": [
+    "area 6 of cortex, ventral, part b"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartB"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area6OfCortexVentralPartB",
+  "name": "area 6 of cortex ventral part b",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8OfCortexCaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8OfCortexCaudalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area8OfCortexCaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A8C",
+  "alternateName": [
+    "area 8 of cortex, caudal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8OfCortexCaudalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area8OfCortexCaudalPart",
+  "name": "area 8 of cortex caudal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8aOfCortexDorsalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8aOfCortexDorsalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area8aOfCortexDorsalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A8aD",
+  "alternateName": [
+    "area 8a of cortex, dorsal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexDorsalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area8aOfCortexDorsalPart",
+  "name": "area 8a of cortex dorsal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8aOfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8aOfCortexVentralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area8aOfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A8aV",
+  "alternateName": [
+    "area 8a of cortex, ventral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexVentralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area8aOfCortexVentralPart",
+  "name": "area 8a of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area8bOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area8bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A8b",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8bOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area8bOfCortex",
+  "name": "area 8b of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area9OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_area9OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_area9OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A9",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area9OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_area9OfCortex",
+  "name": "area 9 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_areas1And2OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_areas1And2OfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_areas1And2OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "A1/2",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_areas1And2OfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_areas1And2OfCortex",
+  "name": "areas 1 and 2 of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AUD",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_auditoryCortex",
+  "name": "Auditory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexAnterolateralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexAnterolateralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexAnterolateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuAL",
+  "alternateName": [
+    "auditory cortex, anterolateral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexAnterolateralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexAnterolateralArea",
+  "name": "auditory cortex anterolateral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudalParabeltArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudalParabeltArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexCaudalParabeltArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuCPB",
+  "alternateName": [
+    "auditory cortex, caudal parabelt area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexCaudalParabeltArea",
+  "name": "auditory cortex caudal parabelt area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudolateralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudolateralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexCaudolateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuCL",
+  "alternateName": [
+    "auditory cortex, caudolateral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudolateralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexCaudolateralArea",
+  "name": "auditory cortex caudolateral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudomedialArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexCaudomedialArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexCaudomedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuCM",
+  "alternateName": [
+    "auditory cortex, caudomedial area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudomedialArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexCaudomedialArea",
+  "name": "auditory cortex caudomedial area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexMiddleLateralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexMiddleLateralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexMiddleLateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuML",
+  "alternateName": [
+    "auditory cortex, middle lateral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexMiddleLateralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexMiddleLateralArea",
+  "name": "auditory cortex middle lateral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexPrimaryArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexPrimaryArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexPrimaryArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuA1",
+  "alternateName": [
+    "auditory cortex, primary area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexPrimaryArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexPrimaryArea",
+  "name": "auditory cortex primary area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuR",
+  "alternateName": [
+    "auditory cortex, rostral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostralArea",
+  "name": "auditory cortex rostral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostralParabelt.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostralParabelt.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostralParabelt",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuRPB",
+  "alternateName": [
+    "auditory cortex, rostral parabelt"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralParabelt"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostralParabelt",
+  "name": "auditory cortex rostral parabelt",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostromedialArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostromedialArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostromedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuRM",
+  "alternateName": [
+    "auditory cortex, rostromedial area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostromedialArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostromedialArea",
+  "name": "auditory cortex rostromedial area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporal.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporal.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostrotemporal",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuRT",
+  "alternateName": [
+    "auditory cortex, rostrotemporal"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporal"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostrotemporal",
+  "name": "auditory cortex rostrotemporal",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporalLateralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporalLateralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostrotemporalLateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuRTL",
+  "alternateName": [
+    "auditory cortex, rostrotemporal lateral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostrotemporalLateralArea",
+  "name": "auditory cortex rostrotemporal lateral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporalMedialArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_auditoryCortexRostrotemporalMedialArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortexRostrotemporalMedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "AuRTM",
+  "alternateName": [
+    "auditory cortex, rostrotemporal medial area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_auditoryCortexRostrotemporalMedialArea",
+  "name": "auditory cortex rostrotemporal medial area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_brain.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_brain.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_brain",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Brain",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": null,
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_brain",
+  "name": "Brain",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dorsalPallium.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dorsalPallium.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "DPal",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_dorsalPallium",
+  "name": "Dorsal pallium",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dorsolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dorsolateralPrefrontalCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "DLP",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_dorsolateralPrefrontalCortex",
+  "name": "Dorsolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dysgranularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_dysgranularInsularCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dysgranularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "DI",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_dysgranularInsularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_dysgranularInsularCortex",
+  "name": "dysgranular insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_entorhinalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_entorhinalCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_entorhinalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Ent",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_entorhinalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_entorhinalCortex",
+  "name": "entorhinal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_fundusOfSuperiorTemporalSulcusAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "FST",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_fundusOfSuperiorTemporalSulcusAreaOfCortex",
+  "name": "fundus of superior temporal sulcus area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_granularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_granularInsularCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_granularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "GI",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_granularInsularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_granularInsularCortex",
+  "name": "granular insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_gustatoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_gustatoryCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_gustatoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Gu",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_gustatoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_gustatoryCortex",
+  "name": "gustatory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_insularCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_insularCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "INS",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_insularCortex",
+  "name": "Insular cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_insularProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_insularProisocortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "IPro",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_insularProisocortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_insularProisocortex",
+  "name": "insular proisocortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "LIT",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_lateralAndInferiorTemporalCorticalRegion",
+  "name": "Lateral and inferior temporal cortical region",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateralIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "LIP",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_lateralIntraparietalAreaOfCortex",
+  "name": "lateral intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateropallialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_lateropallialPart.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateropallialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "LatPal",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_lateropallialPart",
+  "name": "Lateropallial part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MIP",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialIntraparietalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_medialIntraparietalAreaOfCortex",
+  "name": "medial intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialPrefrontalCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MPC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_medialPrefrontalCortex",
+  "name": "Medial prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialSuperiorTemporalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_medialSuperiorTemporalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialSuperiorTemporalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "MST",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_medialSuperiorTemporalAreaOfCortex",
+  "name": "medial superior temporal area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_motorAndPremotorCorticalRegions.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_motorAndPremotorCorticalRegions.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PRM",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_motorAndPremotorCorticalRegions",
+  "name": "Motor and premotor cortical regions",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_occipito-parietalTransitionalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_occipito-parietalTransitionalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_occipito-parietalTransitionalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OPt",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_occipito-parietalTransitionalAreaOfCortex",
+  "name": "occipito-parietal transitional area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalFrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalFrontalCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OFC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_orbitalFrontalCortex",
+  "name": "Orbital frontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalPeriallocortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalPeriallocortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalPeriallocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OPAl",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalPeriallocortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_orbitalPeriallocortex",
+  "name": "orbital periallocortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_orbitalProisocortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "OPro",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalProisocortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_orbitalProisocortex",
+  "name": "orbital proisocortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_pallialAmygdala.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_pallialAmygdala.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallialAmygdala",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PalAmyg",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_pallialAmygdala",
+  "name": "Pallial amygdala",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_pallium.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_pallium.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallium",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pal",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_telencephalon"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_pallium",
+  "name": "Pallium",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parainsularCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parainsularCortexLateralPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parainsularCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PaIL",
+  "alternateName": [
+    "parainsular cortex, lateral part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexLateralPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parainsularCortexLateralPart",
+  "name": "parainsular cortex lateral part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parainsularCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parainsularCortexMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parainsularCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PaIM",
+  "alternateName": [
+    "parainsular cortex, medial part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parainsularCortexMedialPart",
+  "name": "parainsular cortex medial part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPE.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPE.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPE",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PE",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPE"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPE",
+  "name": "parietal area PE",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPECaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPECaudalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPECaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PEC",
+  "alternateName": [
+    "parietal area PE, caudal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPECaudalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPECaudalPart",
+  "name": "parietal area PE caudal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPF.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPF.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPF",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PF",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPF"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPF",
+  "name": "parietal area PF (cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPFG.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPFG.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPFG",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PFG",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPFG"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPFG",
+  "name": "parietal area PFG (cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPG.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPG.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPG",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PG",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPG"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPG",
+  "name": "parietal area PG",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPGMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreaPGMedialPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreaPGMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PGM",
+  "alternateName": [
+    "parietal area PG, medial part (cortex)"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPGMedialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreaPGMedialPart",
+  "name": "parietal area PG medial part (cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreasPGaAndIPa.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_parietalAreasPGaAndIPa.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_parietalAreasPGaAndIPa",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PGa/IPa(FSTv)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreasPGaAndIPa"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_parietalAreasPGaAndIPa",
+  "name": "parietal areas PGa and IPa (fundus of superior temporal ventral area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_piriformCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_piriformCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_piriformCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "Pir",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralPallium"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_piriformCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_piriformCortex",
+  "name": "piriform cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PCR",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions",
+  "name": "Posterior cingulate medial and retrosplenial cortical regions",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_posteriorParietalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_posteriorParietalCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "PPC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_posteriorParietalCortex",
+  "name": "Posterior parietal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_primaryVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_primaryVisualCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_primaryVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V1",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_primaryVisualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_primaryVisualCortex",
+  "name": "primary visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_proisocorticalMotorRegion.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_proisocorticalMotorRegion.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_proisocorticalMotorRegion",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ProM(PrCO)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_proisocorticalMotorRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_proisocorticalMotorRegion",
+  "name": "proisocortical motor region (precentral opercular cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_prosencephalon.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_prosencephalon.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_prosencephalon",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ProCeph",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_brain"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_prosencephalon",
+  "name": "Prosencephalon",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_prostriateArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_prostriateArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_prostriateArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ProSt",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_prostriateArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_prostriateArea",
+  "name": "prostriate area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_retroinsularArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_retroinsularArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_retroinsularArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "ReI",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_retroinsularArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_retroinsularArea",
+  "name": "retroinsular area (cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexExternalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexExternalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_secondarySomatosensoryCortexExternalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "S2E",
+  "alternateName": [
+    "secondary somatosensory cortex, external part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_secondarySomatosensoryCortexExternalPart",
+  "name": "secondary somatosensory cortex external part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexInternalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexInternalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_secondarySomatosensoryCortexInternalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "S2I",
+  "alternateName": [
+    "secondary somatosensory cortex, internal part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_secondarySomatosensoryCortexInternalPart",
+  "name": "secondary somatosensory cortex internal part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexParietalRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexParietalRostralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_secondarySomatosensoryCortexParietalRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "S2PR",
+  "alternateName": [
+    "secondary somatosensory cortex, parietal rostral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_secondarySomatosensoryCortexParietalRostralArea",
+  "name": "secondary somatosensory cortex parietal rostral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexParietalVentralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_secondarySomatosensoryCortexParietalVentralArea.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_secondarySomatosensoryCortexParietalVentralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "S2PV",
+  "alternateName": [
+    "secondary somatosensory cortex, parietal ventral area"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_secondarySomatosensoryCortexParietalVentralArea",
+  "name": "secondary somatosensory cortex parietal ventral area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_somatosensoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_somatosensoryCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "SSC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_somatosensoryCortex",
+  "name": "Somatosensory cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_superiorTemporalRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_superiorTemporalRostralArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_superiorTemporalRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "STR",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_superiorTemporalRostralArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_superiorTemporalRostralArea",
+  "name": "superior temporal rostral area (cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_telencephalon.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_telencephalon.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_telencephalon",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TelCeph",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_prosencephalon"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_telencephalon",
+  "name": "Telencephalon",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE1.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE1.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTE1",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TE1",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE1"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTE1",
+  "name": "temporal area TE1 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE2.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE2.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTE2",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TE2",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE2"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTE2",
+  "name": "temporal area TE2 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE3.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTE3.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTE3",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TE3",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE3"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTE3",
+  "name": "temporal area TE3 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTEOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTEOccipitalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTEOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TEO",
+  "alternateName": [
+    "temporal area TE, occipital part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTEOccipitalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTEOccipitalPart",
+  "name": "temporal area TE occipital part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTF.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTF.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTF",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TF",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTF"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTF",
+  "name": "temporal area TF",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTFOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTFOccipitalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTFOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TFO",
+  "alternateName": [
+    "temporal area TF, occipital part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTFOccipitalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTFOccipitalPart",
+  "name": "temporal area TF occipital part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTH.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTH.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTH",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TH",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTH"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTH",
+  "name": "temporal area TH",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTL.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTL.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTL",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TL",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTL"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTL",
+  "name": "temporal area TL",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTLOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalAreaTLOccipitalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalAreaTLOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TLO",
+  "alternateName": [
+    "temporal area TL, occipital part"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTLOccipitalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalAreaTLOccipitalPart",
+  "name": "temporal area TL occipital part",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporalProisocortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporalProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TPro",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalProisocortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporalProisocortex",
+  "name": "temporal proisocortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporo-parieto-occipitalAssociationArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporo-parieto-occipitalAssociationArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporo-parieto-occipitalAssociationArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TPO(STP)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporo-parieto-occipitalAssociationArea",
+  "name": "temporo-parieto-occipital association area (superior temporal polysensory cortex)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporoparietalTransitionalArea.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporoparietalTransitionalArea.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporoparietalTransitionalArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TPt",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporoparietalTransitionalArea"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporoparietalTransitionalArea",
+  "name": "temporoparietal transitional area",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporopolarProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_temporopolarProisocortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_temporopolarProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "TPPro",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporopolarProisocortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_temporopolarProisocortex",
+  "name": "temporopolar proisocortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralAreasOfTheTemporalLobe.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralAreasOfTheTemporalLobe.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VTC",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_ventralAreasOfTheTemporalLobe",
+  "name": "Ventral areas of the temporal lobe",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VIP",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_ventralIntraparietalAreaOfCortex",
+  "name": "ventral intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralPallium.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventralPallium.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralPallium",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VPal",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_pallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_ventralPallium",
+  "name": "Ventral pallium",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventrolateralPrefrontalCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_ventrolateralPrefrontalCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VLP",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_ventrolateralPrefrontalCortex",
+  "name": "Ventrolateral prefrontal cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea2.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea2.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea2",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V2",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea2"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea2",
+  "name": "visual area 2",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea3.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea3.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea3",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V3(VLP)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea3",
+  "name": "visual area 3 (ventrolateral posterior area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea3A.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea3A.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea3A",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V3A(DA)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3A"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea3A",
+  "name": "visual area 3A (dorsoanterior area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea4.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea4.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea4",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V4(VLA)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea4",
+  "name": "visual area 4 (ventrolatereral anterior area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea4TransitionalPart.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea4TransitionalPart.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea4TransitionalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V4T(MTC)",
+  "alternateName": [
+    "visual area 4, transitional part (middle temporal crescent)"
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4TransitionalPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea4TransitionalPart",
+  "name": "visual area 4 transitional part (middle temporal crescent)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea5.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea5.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea5",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V5(MT)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea5"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea5",
+  "name": "visual area 5 (middle temporal area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea6.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea6.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea6",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V6(DM)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea6",
+  "name": "visual area 6 (dorsomedial area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea6A.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualArea6A.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualArea6A",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "V6A(PPM)",
+  "alternateName": null,
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "hasVersion": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6A"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_visualArea6A",
+  "name": "visual area 6A (posterior parietal medial area)",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualCortex.jsonld
+++ b/instances/v4.0/parcellationEntities/MarmosetNMA/MarmosetNMA_visualCortex.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntity",
+  "abbreviation": "VIS",
+  "alternateName": [
+    null
+  ],
+  "definition": null,
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsalPallium"
+    }
+  ],
+  "hasVersion": null,
+  "lookupLabel": "MarmosetNMA_visualCortex",
+  "name": "Visual cortex",
+  "ontologyIdentifier": null,
+  "relatedUBERONTerm": null
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_agranularInsularCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_agranularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AI",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "50",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "50",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E95900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_agranularInsularCortex",
+  "name": "agranular insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_amygdalopiriformTransitionArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_amygdalopiriformTransitionArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "APir",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "52",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "52",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#00FF26"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateropallialPart"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_amygdalopiriformTransitionArea",
+  "name": "amygdalopiriform transition area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AIP",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "51",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "51",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FEFF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_anteriorIntraparietalAreaOfCortex",
+  "name": "anterior intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area10OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area10OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A10",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "2",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF6D3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area10OfCortex",
+  "name": "area 10 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area11OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area11OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A11",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "3",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9BF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area11OfCortex",
+  "name": "area 11 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexLateralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A13L",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 13 of cortex, lateral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "4",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9CF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area13OfCortexLateralPart",
+  "name": "area 13 of cortex lateral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13OfCortexMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A13M",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 13 of cortex, medial part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "5",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFC700"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area13OfCortexMedialPart",
+  "name": "area 13 of cortex medial part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13aOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A13a",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "6",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D4A800"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area13aOfCortex",
+  "name": "area 13a of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area13bOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area13bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A13b",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "7",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9BC00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area13bOfCortex",
+  "name": "area 13b of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexCaudalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexCaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A14C",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 14 of cortex, caudal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "8",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E99400"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area14OfCortexCaudalPart",
+  "name": "area 14 of cortex caudal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area14OfCortexRostralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area14OfCortexRostralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A14R",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 14 of cortex, rostral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "9",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9B759"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area14OfCortexRostralPart",
+  "name": "area 14 of cortex rostral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexDorsointermediatePart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexDorsointermediatePart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A19DI",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 19 of cortex, dorsointermediate part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "10",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D1FF85"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area19OfCortexDorsointermediatePart",
+  "name": "area 19 of cortex dorsointermediate part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area19OfCortexMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area19OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A19M",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 19 of cortex, medial part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "11",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#93EF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area19OfCortexMedialPart",
+  "name": "area 19 of cortex medial part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23OfCortexVentralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A23V",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 23 of cortex, ventral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "12",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFE73B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area23OfCortexVentralPart",
+  "name": "area 23 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23aOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A23a",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "13",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFF6B2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area23aOfCortex",
+  "name": "area 23a of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23bOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A23b",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "14",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EFDC3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area23bOfCortex",
+  "name": "area 23b of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area23cOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area23cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A23c",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "15",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DFD576"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area23cOfCortex",
+  "name": "area 23c of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24aOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A24a",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "16",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFB3B2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area24aOfCortex",
+  "name": "area 24a of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24bOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A24b",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "17",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DF0800"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area24bOfCortex",
+  "name": "area 24b of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24cOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A24c",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "18",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF6359"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area24cOfCortex",
+  "name": "area 24c of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area24dOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area24dOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A24d",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "19",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF1600"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_anteriorCingulateCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area24dOfCortex",
+  "name": "area 24d of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area25OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area25OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A25",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "20",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFE6B2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area25OfCortex",
+  "name": "area 25 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29a-cOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29a-cOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A29a-c",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "21",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DFD13B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area29a-cOfCortex",
+  "name": "area 29a-c of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area29dOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area29dOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A29d",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "22",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EFE676"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area29dOfCortex",
+  "name": "area 29d of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area30OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area30OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A30",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "23",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFEF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area30OfCortex",
+  "name": "area 30 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area31OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area31OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A31",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "24",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFF876"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area31OfCortex",
+  "name": "area 31 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A32",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "25",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFB100"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area32OfCortex",
+  "name": "area 32 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area32OfCortexVentralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area32OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A32V",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 32 of cortex, ventral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "26",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFCF59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_medialPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area32OfCortexVentralPart",
+  "name": "area 32 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area35OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area35OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A35",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "27",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#4ED400"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area35OfCortex",
+  "name": "area 35 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area36OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area36OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A36",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "28",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A0E976"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area36OfCortex",
+  "name": "area 36 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3aOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3aOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A3a",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "29",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#CAFF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area3aOfCortex",
+  "name": "area 3a of cortex (somatosensory)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area3bOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area3bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A3b",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "30",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D8FF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area3bOfCortex",
+  "name": "area 3b of cortex (somatosensory)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area45OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area45OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A45",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "31",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#72E900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area45OfCortex",
+  "name": "area 45 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexDorsalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexDorsalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A46D",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 46 of cortex, dorsal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "32",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E99676"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area46OfCortexDorsalPart",
+  "name": "area 46 of cortex dorsal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area46OfCortexVentralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area46OfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A46V",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 46 of cortex, ventral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "33",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF9D76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area46OfCortexVentralPart",
+  "name": "area 46 of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexLateralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A47L(12L)",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 47 (old 12) of cortex, lateral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "34",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D6FFB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area47OfCortexLateralPart",
+  "name": "area 47 (old 12) of cortex lateral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A47M(12M)",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 47 (old 12) of cortex, medial part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "35",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#73FF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area47OfCortexMedialPart",
+  "name": "area 47 (old 12) of cortex medial part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area47OfCortexOrbitalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area47OfCortexOrbitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A47O(12O)",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 47 (old 12) of cortex, orbital part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "36",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A0FF59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area47OfCortexOrbitalPart",
+  "name": "area 47 (old 12) of cortex orbital part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartC.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartC",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A4c",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 4 of cortex, part c (primary motor)"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "38",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#C8E900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area4OfCortexPartC",
+  "name": "area 4 of cortex part c (primary motor)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area4OfCortexPartsAAndB.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area4OfCortexPartsAAndB",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A4ab",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 4 of cortex, parts a and b (primary motor)"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "37",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EDFF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area4OfCortexPartsAAndB",
+  "name": "area 4 of cortex parts a and b (primary motor)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsocaudalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsocaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A6DC",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 6 of cortex, dorsocaudal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "39",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E0FF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area6OfCortexDorsocaudalPart",
+  "name": "area 6 of cortex dorsocaudal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexDorsorostralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexDorsorostralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A6DR",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 6 of cortex, dorsorostral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "40",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#B0D400"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area6OfCortexDorsorostralPart",
+  "name": "area 6 of cortex dorsorostral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A6M",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 6 of cortex, medial (supplementary motor) part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "41",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D0FF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area6OfCortexMedialPart",
+  "name": "area 6 of cortex medial (supplementary motor) part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartA.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartA",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A6Va",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 6 of cortex, ventral, part a"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "42",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "42",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#C8E93B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area6OfCortexVentralPartA",
+  "name": "area 6 of cortex ventral part a",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area6OfCortexVentralPartB.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area6OfCortexVentralPartB",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A6Vb",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 6 of cortex, ventral, part b"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "43",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "43",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EFFFB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area6OfCortexVentralPartB",
+  "name": "area 6 of cortex ventral part b",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8OfCortexCaudalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8OfCortexCaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A8C",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 8 of cortex, caudal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "44",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "44",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D0E976"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_motorAndPremotorCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area8OfCortexCaudalPart",
+  "name": "area 8 of cortex caudal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexDorsalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexDorsalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A8aD",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 8a of cortex, dorsal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "45",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "45",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E96F3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area8aOfCortexDorsalPart",
+  "name": "area 8a of cortex dorsal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8aOfCortexVentralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8aOfCortexVentralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A8aV",
+  "additionalRemarks": null,
+  "alternateName": [
+    "area 8a of cortex, ventral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "46",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "46",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFCAB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area8aOfCortexVentralPart",
+  "name": "area 8a of cortex ventral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area8bOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area8bOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A8b",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "47",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "47",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF5300"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area8bOfCortex",
+  "name": "area 8b of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_area9OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_area9OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A9",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "48",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "48",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E95000"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_dorsolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_area9OfCortex",
+  "name": "area 9 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_areas1And2OfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_areas1And2OfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "A1/2",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "1",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#BDE93B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_areas1And2OfCortex",
+  "name": "areas 1 and 2 of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexAnterolateralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexAnterolateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuAL",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, anterolateral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "55",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "55",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EF472C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexAnterolateralArea",
+  "name": "auditory cortex anterolateral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudalParabeltArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuCPB",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, caudal parabelt area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "58",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "58",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF4D2C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexCaudalParabeltArea",
+  "name": "auditory cortex caudal parabelt area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudolateralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudolateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuCL",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, caudolateral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "56",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "56",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EF6E59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexCaudolateralArea",
+  "name": "auditory cortex caudolateral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexCaudomedialArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexCaudomedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuCM",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, caudomedial area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "57",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "57",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EF2300"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexCaudomedialArea",
+  "name": "auditory cortex caudomedial area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexMiddleLateralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexMiddleLateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuML",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, middle lateral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "59",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "59",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF2900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexMiddleLateralArea",
+  "name": "auditory cortex middle lateral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexPrimaryArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexPrimaryArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuA1",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, primary area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "54",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "54",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DF1C00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexPrimaryArea",
+  "name": "auditory cortex primary area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuR",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "60",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "60",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DF7059"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostralArea",
+  "name": "auditory cortex rostral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostralParabelt.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostralParabelt",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuRPB",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostral parabelt"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "62",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "62",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#CF4A2C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostralParabelt",
+  "name": "auditory cortex rostral parabelt",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostromedialArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostromedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuRM",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostromedial area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "61",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "61",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DF9585"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostromedialArea",
+  "name": "auditory cortex rostromedial area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporal.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporal",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuRT",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostrotemporal"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "63",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "63",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF7959"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostrotemporal",
+  "name": "auditory cortex rostrotemporal",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuRTL",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostrotemporal lateral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "64",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "64",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EF9A85"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostrotemporalLateralArea",
+  "name": "auditory cortex rostrotemporal lateral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "AuRTM",
+  "additionalRemarks": null,
+  "alternateName": [
+    "auditory cortex, rostrotemporal medial area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "65",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "65",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#CF2B00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_auditoryCortexRostrotemporalMedialArea",
+  "name": "auditory cortex rostrotemporal medial area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_dysgranularInsularCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_dysgranularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "DI",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "67",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "67",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9A476"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_dysgranularInsularCortex",
+  "name": "dysgranular insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_entorhinalCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_entorhinalCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Ent",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "70",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "70",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#50E900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_entorhinalCortex",
+  "name": "entorhinal cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "FST",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "71",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "71",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#99DF2C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_fundusOfSuperiorTemporalSulcusAreaOfCortex",
+  "name": "fundus of superior temporal sulcus area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_granularInsularCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_granularInsularCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "GI",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "72",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "72",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D45600"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_granularInsularCortex",
+  "name": "granular insular cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_gustatoryCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_gustatoryCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Gu",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "73",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "73",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFDB3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_gustatoryCortex",
+  "name": "gustatory cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_insularProisocortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_insularProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "IPro",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "75",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "75",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFD2B2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_insularProisocortex",
+  "name": "insular proisocortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_lateralIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "LIP",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "76",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "76",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DDDF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_lateralIntraparietalAreaOfCortex",
+  "name": "lateral intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MIP",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "79",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "79",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EAEF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_medialIntraparietalAreaOfCortex",
+  "name": "medial intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "MST",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "81",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "81",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A9DF59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_medialSuperiorTemporalAreaOfCortex",
+  "name": "medial superior temporal area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OPt",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "85",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "85",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E6EF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_occipito-parietalTransitionalAreaOfCortex",
+  "name": "occipito-parietal transitional area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalPeriallocortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalPeriallocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OPAl",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "83",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "83",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFE876"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_orbitalPeriallocortex",
+  "name": "orbital periallocortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_orbitalProisocortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_orbitalProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "OPro",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "84",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "84",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFF3B2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_orbitalFrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_orbitalProisocortex",
+  "name": "orbital proisocortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexLateralPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexLateralPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PaIL",
+  "additionalRemarks": null,
+  "alternateName": [
+    "parainsular cortex, lateral part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "96",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "96",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF6E00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parainsularCortexLateralPart",
+  "name": "parainsular cortex lateral part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parainsularCortexMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parainsularCortexMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PaIM",
+  "additionalRemarks": null,
+  "alternateName": [
+    "parainsular cortex, medial part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "97",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "97",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFB376"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parainsularCortexMedialPart",
+  "name": "parainsular cortex medial part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPE.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPE",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PE",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "87",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "87",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9EF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPE",
+  "name": "parietal area PE",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPECaudalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPECaudalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PEC",
+  "additionalRemarks": null,
+  "alternateName": [
+    "parietal area PE, caudal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "88",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "88",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D2DF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPECaudalPart",
+  "name": "parietal area PE caudal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPF.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPF",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PF",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "89",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "89",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#D4DF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPF",
+  "name": "parietal area PF (cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPFG.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPFG",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PFG",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "90",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "90",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#F0FF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPFG",
+  "name": "parietal area PFG (cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPG.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPG",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PG",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "91",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "91",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#F8FFB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPG",
+  "name": "parietal area PG",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreaPGMedialPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreaPGMedialPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PGM",
+  "additionalRemarks": null,
+  "alternateName": [
+    "parietal area PG, medial part (cortex)"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "92",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "92",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DFD600"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreaPGMedialPart",
+  "name": "parietal area PG medial part (cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_parietalAreasPGaAndIPa.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_parietalAreasPGaAndIPa",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "PGa/IPa(FSTv)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "93",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "93",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF9E3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_parietalAreasPGaAndIPa",
+  "name": "parietal areas PGa and IPa (fundus of superior temporal ventral area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_piriformCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_piriformCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "Pir",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "100",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "100",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#00FFA5"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralPallium"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_piriformCortex",
+  "name": "piriform cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_primaryVisualCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_primaryVisualCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V1",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "126",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#BBFF59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_primaryVisualCortex",
+  "name": "primary visual cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_proisocorticalMotorRegion.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_proisocorticalMotorRegion",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ProM(PrCO)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "103",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#94E959"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventrolateralPrefrontalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_proisocorticalMotorRegion",
+  "name": "proisocortical motor region (precentral opercular cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_prostriateArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_prostriateArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ProSt",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "104",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#EFE700"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorCingulateMedialAndRetrosplenialCorticalRegions"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_prostriateArea",
+  "name": "prostriate area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_retroinsularArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_retroinsularArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "ReI",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "105",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E98B3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_retroinsularArea",
+  "name": "retroinsular area (cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "S2E",
+  "additionalRemarks": null,
+  "alternateName": [
+    "secondary somatosensory cortex, external part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "106",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E8FFB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_secondarySomatosensoryCortexExternalPart",
+  "name": "secondary somatosensory cortex external part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "S2I",
+  "additionalRemarks": null,
+  "alternateName": [
+    "secondary somatosensory cortex, internal part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "107",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#C5E976"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_secondarySomatosensoryCortexInternalPart",
+  "name": "secondary somatosensory cortex internal part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "S2PR",
+  "additionalRemarks": null,
+  "alternateName": [
+    "secondary somatosensory cortex, parietal rostral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "108",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#9DE900"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_secondarySomatosensoryCortexParietalRostralArea",
+  "name": "secondary somatosensory cortex parietal rostral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "S2PV",
+  "additionalRemarks": null,
+  "alternateName": [
+    "secondary somatosensory cortex, parietal ventral area"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "109",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A7FF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_somatosensoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_secondarySomatosensoryCortexParietalVentralArea",
+  "name": "secondary somatosensory cortex parietal ventral area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_superiorTemporalRostralArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_superiorTemporalRostralArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "STR",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "111",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF9F85"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_superiorTemporalRostralArea",
+  "name": "superior temporal rostral area (cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE1.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE1",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TE1",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "112",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9963B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTE1",
+  "name": "temporal area TE1 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE2.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE2",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TE2",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "113",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E9B476"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTE2",
+  "name": "temporal area TE2 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTE3.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTE3",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TE3",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "114",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E98000"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTE3",
+  "name": "temporal area TE3 (inferior temporal cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTEOccipitalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTEOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TEO",
+  "additionalRemarks": null,
+  "alternateName": [
+    "temporal area TE, occipital part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "115",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFDDB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTEOccipitalPart",
+  "name": "temporal area TE occipital part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTF.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTF",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TF",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "116",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#CBFFB2"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTF",
+  "name": "temporal area TF",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTFOccipitalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTFOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TFO",
+  "additionalRemarks": null,
+  "alternateName": [
+    "temporal area TF, occipital part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "117",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#51FF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTFOccipitalPart",
+  "name": "temporal area TF occipital part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTH.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTH",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TH",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "118",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#71E93B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTH",
+  "name": "temporal area TH",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTL.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTL",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TL",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "119",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#75FF3B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTL",
+  "name": "temporal area TL",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalAreaTLOccipitalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalAreaTLOccipitalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TLO",
+  "additionalRemarks": null,
+  "alternateName": [
+    "temporal area TL, occipital part"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "120",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#9DFF76"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_ventralAreasOfTheTemporalLobe"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalAreaTLOccipitalPart",
+  "name": "temporal area TL occipital part",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporalProisocortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporalProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TPro",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "123",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF973B"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_insularCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporalProisocortex",
+  "name": "temporal proisocortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TPO(STP)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "121",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FFC576"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporo-parieto-occipitalAssociationArea",
+  "name": "temporo-parieto-occipital association area (superior temporal polysensory cortex)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporoparietalTransitionalArea.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporoparietalTransitionalArea",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TPt",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "124",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#DF542C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_auditoryCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporoparietalTransitionalArea",
+  "name": "temporoparietal transitional area",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_temporopolarProisocortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_temporopolarProisocortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "TPPro",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "122",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#FF9700"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_lateralAndInferiorTemporalCorticalRegion"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_temporopolarProisocortex",
+  "name": "temporopolar proisocortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_ventralIntraparietalAreaOfCortex",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "VIP",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "135",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#E6FF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_posteriorParietalCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_ventralIntraparietalAreaOfCortex",
+  "name": "ventral intraparietal area of cortex",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea2.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea2",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V2",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "127",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#C3EF85"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea2",
+  "name": "visual area 2",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V3(VLP)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "128",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#80DF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea3",
+  "name": "visual area 3 (ventrolateral posterior area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea3A.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea3A",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V3A(DA)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "129",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A4FF2C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea3A",
+  "name": "visual area 3A (dorsoanterior area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V4(VLA)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "130",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#8EFF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea4",
+  "name": "visual area 4 (ventrolatereral anterior area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea4TransitionalPart.jsonld
@@ -1,0 +1,88 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea4TransitionalPart",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V4T(MTC)",
+  "additionalRemarks": null,
+  "alternateName": [
+    "visual area 4, transitional part (middle temporal crescent)"
+  ],
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "131",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#98EF2C"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea4TransitionalPart",
+  "name": "visual area 4 transitional part (middle temporal crescent)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea5.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea5",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V5(MT)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "132",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#B6DF85"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea5",
+  "name": "visual area 5 (middle temporal area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V6(DM)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "133",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#A9EF59"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea6",
+  "name": "visual area 6 (dorsomedial area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}

--- a/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
+++ b/instances/v4.0/parcellationEntityVersions/MarmosetNMA_v1/MarmosetNMA_v1_visualArea6A.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.om-i.org/props/"
+  },
+  "@id": "https://openminds.om-i.org/instances/parcellationEntityVersion/MarmosetNMA_v1_visualArea6A",
+  "@type": "https://openminds.om-i.org/types/ParcellationEntityVersion",
+  "abbreviation": "V6A(PPM)",
+  "additionalRemarks": null,
+  "alternateName": null,
+  "correctedName": null,
+  "hasAnnotation": [
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/probabalisticAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/colormap/matplotlib.colormaps.Greys"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    },
+    {
+      "@type": "https://openminds.om-i.org/types/AtlasAnnotation",
+      "anchorPoint": null,
+      "criteria": null,
+      "criteriaQualityType": {
+        "@id": "https://openminds.om-i.org/instances/criteriaQualityType/processive"
+      },
+      "criteriaType": {
+        "@id": "https://openminds.om-i.org/instances/annotationCriteriaType/deterministicAnnotation"
+      },
+      "inspiredBy": null,
+      "internalIdentifier": "134",
+      "laterality": [
+        {
+          "@id": "https://openminds.om-i.org/instances/laterality/left"
+        }
+      ],
+      "preferredVisualization": {
+        "@type": "https://openminds.om-i.org/types/ViewerSpecification",
+        "additionalRemarks": null,
+        "anchorPoint": null,
+        "cameraPosition": null,
+        "preferredDisplayColor": {
+          "@id": "https://openminds.om-i.org/instances/singleColor/#6DCF00"
+        }
+      },
+      "specification": null,
+      "type": {
+        "@id": "https://openminds.om-i.org/instances/annotationType/annotationMask"
+      }
+    }
+  ],
+  "hasParent": [
+    {
+      "@id": "https://openminds.om-i.org/instances/parcellationEntity/MarmosetNMA_visualCortex"
+    }
+  ],
+  "lookupLabel": "MarmosetNMA_v1_visualArea6A",
+  "name": "visual area 6A (posterior parietal medial area)",
+  "ontologyIdentifier": null,
+  "relationAssessment": null,
+  "versionIdentifier": "v1",
+  "versionInnovation": "This is the first version of this parcellation entity."
+}


### PR DESCRIPTION
see #123 
and related PR #344 

I found 3 versions that were lacking the atlas type: 
- DWMA: only one version registered; probabilistic atlas according to [project description](https://search.kg.ebrains.eu/instances/38bd5c89-5bad-4bd1-b348-a4708166eb60)
- SWMA: only one version registered; probabilistic atlas according to [project description](https://search.kg.ebrains.eu/instances/Project/487e71f4-4fd7-4a77-9308-dd845e9494b7)
- Schaefer: affected 'Schaefer_400p_2018-fsLR32k-yeo17n'; other registered versions had type from before; assumed that this one is also a discrete atlas like the other registered versions
