### PR TITLE
Extending JBA PEs with UBERON terms

### DIFF
--- a/instances/latest/parcellationEntities/JBA/JBA_AcbL.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_AcbL.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_AcbM.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_AcbM.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-25.25a.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-25.25a.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-25.25p.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-25.25p.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-25.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-25.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-33.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-33.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-3a.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-3a.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-3b.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-3b.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-44.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-44.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-45.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-45.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-4a.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-4a.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-4p.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-4p.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-5Ci.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-5Ci.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-5L.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-5L.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-5M.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-5M.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-6d1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-6d1.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-6d2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-6d2.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-6d3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-6d3.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-6ma.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-6ma.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-6mp.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-6mp.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-7A.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-7A.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-7M.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-7M.jsonld
@@ -61,3 +61,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-7P.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-7P.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-7PC.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-7PC.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-8d1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-8d1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-8d2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-8d2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-8v1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-8v1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-8v2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-8v2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-CoS1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-CoS1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-FG1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-FG1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-FG2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-FG2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-FG3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-FG3.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-FG4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-FG4.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo3.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo4.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo5.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo6.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fo7.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fo7.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fp1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fp1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Fp2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Fp2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFJ1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFJ1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFJ2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFJ2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFS1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFS1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFS2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFS2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFS3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFS3.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-IFS4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-IFS4.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ia.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ia.jsonld
@@ -46,3 +46,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ia1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ia1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ia2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ia2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ia3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ia3.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id10.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id10.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id2.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id3.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id4.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id5.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id6.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id7.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id7.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id8.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id8.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Id9.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Id9.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ig1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ig1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ig2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ig2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ig3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ig3.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-MFG1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-MFG1.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-MFG2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-MFG2.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP3.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP4.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP5.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP6.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP7.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP7.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP8.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP8.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-OP9.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-OP9.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PF.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PF.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PFcm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PFcm.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PFm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PFm.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PFop.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PFop.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PFt.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PFt.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PGa.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PGa.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-PGp.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-PGp.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ph1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ph1.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ph2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ph2.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-Ph3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-Ph3.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-SFS1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-SFS1.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-SFS2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-SFS2.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-STS1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-STS1.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-STS2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-STS2.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.0.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.0.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-1.2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-2.1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-2.1.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-2.2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-2.2.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TE-3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TE-3.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TI.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TI.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TPJ.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TPJ.jsonld
@@ -43,3 +43,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-TeI.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-TeI.jsonld
@@ -64,3 +64,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-a29.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-a29.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-a30.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-a30.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP3.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP4.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP5.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP6.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP7.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP7.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hIP8.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hIP8.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc1.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc2.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc3d.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc3d.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc3v.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc3v.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4d.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4d.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4la.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4la.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4lp.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4lp.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4v.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc4v.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc5.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hOc6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hOc6.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-hPO1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-hPO1.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-i29.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-i29.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-i30.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-i30.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.p24a.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.p24a.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.p24b.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24ab.p24b.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pd24cd.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pd24cd.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pd24cv.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pd24cv.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pv24c.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p24c.pv24c.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p29.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p29.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p30.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p30.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-p32.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-p32.jsonld
@@ -70,3 +70,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-s24.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-s24.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-s24.s24a.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-s24.s24a.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-s24.s24b.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-s24.s24b.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Area-s32.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Area-s32.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_BST.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_BST.jsonld
@@ -41,5 +41,6 @@
   "lookupLabel": "JBA_BST",
   "name": "BST (Bed Nucleus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/bedNucleusOfStriaTerminalis"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CA.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CA.jsonld
@@ -25,3 +25,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CA1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CA1.jsonld
@@ -65,5 +65,6 @@
   "lookupLabel": "JBA_CA1",
   "name": "CA1 (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/CA1FieldOfHippocampus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CA2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CA2.jsonld
@@ -65,5 +65,6 @@
   "lookupLabel": "JBA_CA2",
   "name": "CA2 (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/CA2FieldOfHippocampus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CA3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CA3.jsonld
@@ -65,5 +65,6 @@
   "lookupLabel": "JBA_CA3",
   "name": "CA3 (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/CA3FieldOfHippocampus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.jsonld
@@ -41,5 +41,6 @@
   "lookupLabel": "JBA_CGL",
   "name": "CGL (Metathalamus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/lateralGeniculateBody"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam1.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam1.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam2.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam2.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam3.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam3.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam4.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam5.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam5.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGL.lam6.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGL.lam6.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMd.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMd.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMm.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMv.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGM.CGMv.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CGM.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CGM.jsonld
@@ -41,5 +41,6 @@
   "lookupLabel": "JBA_CGM",
   "name": "CGM (Metathalamus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/medialGeniculateBody"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CM.AAA.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CM.AAA.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CM.Ce.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CM.Ce.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CM.Me.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CM.Me.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_CM.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_CM.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Ch-123.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Ch-123.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Ch-4.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Ch-4.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_DG.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_DG.jsonld
@@ -71,5 +71,6 @@
   "lookupLabel": "JBA_DG",
   "name": "DG (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/dentateGyrusOfHippocampalFormation"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Dorsal-Dentate-Nucleus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Dorsal-Dentate-Nucleus.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Entorhinal-Cortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Entorhinal-Cortex.jsonld
@@ -71,5 +71,6 @@
   "lookupLabel": "JBA_Entorhinal-Cortex",
   "name": "Entorhinal Cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/entorhinalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Fastigial-Nucleus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Fastigial-Nucleus.jsonld
@@ -71,5 +71,6 @@
   "lookupLabel": "JBA_Fastigial-Nucleus",
   "name": "Fastigial Nucleus (Cerebellum)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/fastigialNucleus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-I.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-I.jsonld
@@ -58,3 +58,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-II.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-II.jsonld
@@ -58,3 +58,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Occipital.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Occipital.jsonld
@@ -58,3 +58,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal-I.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal-I.jsonld
@@ -37,3 +37,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal-II.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal-II.jsonld
@@ -37,3 +37,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Frontal-to-Temporal.jsonld
@@ -40,3 +40,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_FuCd.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_FuCd.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_FuP.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_FuP.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_HATA.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_HATA.jsonld
@@ -71,5 +71,6 @@
   "lookupLabel": "JBA_HATA",
   "name": "HATA (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/amygdalohippocampalTransitionArea"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_HC-Transsubiculum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_HC-Transsubiculum.jsonld
@@ -52,3 +52,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_HeschlsGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_HeschlsGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_HeschlsGyrus",
   "name": "Heschl’s gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/transverseGyrusOfHeschl"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_IF.ice.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_IF.ice.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_IF.iol.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_IF.iol.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_IF.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_IF.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_IF.ld.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_IF.ld.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Interposed-Nucleus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Interposed-Nucleus.jsonld
@@ -71,5 +71,6 @@
   "lookupLabel": "JBA_Interposed-Nucleus",
   "name": "Interposed Nucleus (Cerebellum)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cerebellumInterpositusNucleus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_LB.Bl.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_LB.Bl.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_LB.Bm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_LB.Bm.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_LB.La.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_LB.La.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_LB.Pl.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_LB.Pl.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_LB.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_LB.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_MF.icm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_MF.icm.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_MF.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_MF.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_MF.lm.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_MF.lm.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_SF.AHi.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_SF.AHi.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_SF.APir.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_SF.APir.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_SF.VCo.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_SF.VCo.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_SF.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_SF.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_STN.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_STN.jsonld
@@ -29,5 +29,6 @@
   "lookupLabel": "JBA_STN",
   "name": "STN (Subthalamus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/subthalamicNucleus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Subiculum.PaS.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Subiculum.PaS.jsonld
@@ -50,5 +50,6 @@
   "lookupLabel": "JBA_Subiculum.PaS",
   "name": "Subiculum.PaS (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/parasubiculum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Subiculum.PreS.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Subiculum.PreS.jsonld
@@ -50,5 +50,6 @@
   "lookupLabel": "JBA_Subiculum.PreS",
   "name": "Subiculum.PreS (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/presubiculum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Subiculum.ProS.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Subiculum.ProS.jsonld
@@ -52,3 +52,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Subiculum.Sub.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Subiculum.Sub.jsonld
@@ -52,3 +52,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Subiculum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Subiculum.jsonld
@@ -38,5 +38,6 @@
   "lookupLabel": "JBA_Subiculum",
   "name": "Subiculum (Hippocampus)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/subiculum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Temporal-to-Parietal.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Temporal-to-Parietal.jsonld
@@ -58,3 +58,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Terminal-islands.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Terminal-islands.jsonld
@@ -31,3 +31,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Tuberculum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Tuberculum.jsonld
@@ -28,3 +28,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_VP.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_VP.jsonld
@@ -29,5 +29,6 @@
   "lookupLabel": "JBA_VP",
   "name": "VP (Ventral Pallidum)",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/ventralPallidum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_VTM.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_VTM.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_Ventral-Dentate-Nucleus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_Ventral-Dentate-Nucleus.jsonld
@@ -73,3 +73,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_agranularInsula.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_agranularInsula.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_agranularInsula",
   "name": "agranular insula",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/agranularInsularCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_amygdala.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_amygdala.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_amygdala",
   "name": "amygdala",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/amygdala"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_amygdaloidGroups.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_amygdaloidGroups.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_basalForebrain.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_basalForebrain.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_basalForebrain",
   "name": "basal forebrain",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/basalForebrain"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_basalGanglia.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_basalGanglia.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_basalGanglia",
   "name": "basal ganglia",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/collectionOfBasalGanglia"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_brain.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_brain.jsonld
@@ -12,5 +12,6 @@
   "lookupLabel": "JBA_brain",
   "name": "brain",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/brain"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_cerebellarNuclei.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_cerebellarNuclei.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_cerebellarNuclei",
   "name": "cerebellar nuclei",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cerebellarNuclearComplex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_cerebellum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_cerebellum.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_cerebellum",
   "name": "cerebellum",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cerebellum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_cerebralCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_cerebralCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_cerebralCortex",
   "name": "cerebral cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cerebralCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_cerebralNuclei.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_cerebralNuclei.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_cerebralNuclei",
   "name": "cerebral nuclei",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cerebralNuclei"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_cingulateGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_cingulateGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_cingulateGyrus",
   "name": "cingulate gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/cingulateGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_collateralSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_collateralSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_collateralSulcus",
   "name": "collateral sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/collateralSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_dentateNucleus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_dentateNucleus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_dentateNucleus",
   "name": "dentate nucleus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/dentateNucleus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_diencephalon.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_diencephalon.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_diencephalon",
   "name": "diencephalon",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/diencephalon"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_dorsalOccipitalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_dorsalOccipitalCortex.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_dorsalPrecentralGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_dorsalPrecentralGyrus.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_dysgranularInsula.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_dysgranularInsula.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_fiberMasses.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_fiberMasses.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_frontalCingulateGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_frontalCingulateGyrus.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_frontalLobe.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_frontalLobe.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_frontalLobe",
   "name": "frontal lobe",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/frontalLobe"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_frontalOperculum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_frontalOperculum.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_frontalOperculum",
   "name": "frontal operculum",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/frontalOperculum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_frontalPole.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_frontalPole.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_frontalPole",
   "name": "frontal pole",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/frontalPole"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_fronto-marginalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_fronto-marginalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_fronto-marginalSulcus",
   "name": "fronto-marginal sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/frontomarginalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_fusiformGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_fusiformGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_fusiformGyrus",
   "name": "fusiform gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/fusiformGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_granularInsula.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_granularInsula.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_granularInsula",
   "name": "granular insula",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/granularInsularCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_hippocampalFormation.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_hippocampalFormation.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_hippocampalFormation",
   "name": "hippocampal formation",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/hippocampalFormation"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_inferiorFrontalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_inferiorFrontalGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_inferiorFrontalGyrus",
   "name": "inferior frontal gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorFrontalGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_inferiorFrontalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_inferiorFrontalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_inferiorFrontalSulcus",
   "name": "inferior frontal sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorFrontalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_inferiorParietalLobule.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_inferiorParietalLobule.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_inferiorParietalLobule",
   "name": "inferior parietal lobule",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/inferiorParietalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_insula.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_insula.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_insula",
   "name": "insula",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/insula"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_intraparietalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_intraparietalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_intraparietalSulcus",
   "name": "intraparietal sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/intraparietalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_lateralOccipitalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_lateralOccipitalCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_lateralOccipitalCortex",
   "name": "lateral occipital cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/lateralOccipitalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_lateralOrbitofrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_lateralOrbitofrontalCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_lateralOrbitofrontalCortex",
   "name": "lateral orbitofrontal cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/lateralOrbitalFrontalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_limbicLobe.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_limbicLobe.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_limbicLobe",
   "name": "limbic lobe",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/limbicLobe"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_magnocellularGroup.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_magnocellularGroup.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_medialOrbitofrontalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_medialOrbitofrontalCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_medialOrbitofrontalCortex",
   "name": "medial orbitofrontal cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/medialOrbitalFrontalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_mesialPrecentralGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_mesialPrecentralGyrus.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_metathalamus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_metathalamus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_metathalamus",
   "name": "metathalamus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/metathalamus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_metencephalon.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_metencephalon.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_metencephalon",
   "name": "metencephalon",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/metencephalon"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_middleFrontalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_middleFrontalGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_middleFrontalGyrus",
   "name": "middle frontal gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/middleFrontalGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_occipitalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_occipitalCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_occipitalCortex",
   "name": "occipital cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_occipitalLobe.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_occipitalLobe.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_occipitalLobe",
   "name": "occipital lobe",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/occipitalLobe"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_olfactoryCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_olfactoryCortex.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_olfactoryCortex",
   "name": "olfactory cortex",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/olfactoryCortex"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_parahippocampalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_parahippocampalGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_parahippocampalGyrus",
   "name": "parahippocampal gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/parahippocampalGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_parietalLobe.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_parietalLobe.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_parietalLobe",
   "name": "parietal lobe",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/parietalLobe"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_parietalOperculum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_parietalOperculum.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_parietalOperculum",
   "name": "parietal operculum",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/parietalOperculum"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_parieto-occipitalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_parieto-occipitalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_parieto-occipitalSulcus",
   "name": "parieto-occipital sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/parietoOccipitalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_postcentralGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_postcentralGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_postcentralGyrus",
   "name": "postcentral gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/postcentralGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_posteriorMedialSuperiorFrontalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_posteriorMedialSuperiorFrontalGyrus.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_precentralGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_precentralGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_precentralGyrus",
   "name": "precentral gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/precentralGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_retrosplenialPart.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_retrosplenialPart.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_sublenticularPart.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_sublenticularPart.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_subthalamus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_subthalamus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_subthalamus",
   "name": "subthalamus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/ventralThalamus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_superiorFrontalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_superiorFrontalGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_superiorFrontalGyrus",
   "name": "superior frontal gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/superiorFrontalGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_superiorFrontalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_superiorFrontalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_superiorFrontalSulcus",
   "name": "superior frontal sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/superiorFrontalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_superiorParietalLobule.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_superiorParietalLobule.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_superiorTemporalGyrus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_superiorTemporalGyrus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_superiorTemporalGyrus",
   "name": "superior temporal gyrus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/superiorTemporalGyrus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_superiorTemporalSulcus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_superiorTemporalSulcus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_superiorTemporalSulcus",
   "name": "superior temporal sulcus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/superiorTemporalSulcus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_telencephalon.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_telencephalon.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_telencephalon",
   "name": "telencephalon",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/telencephalon"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_temporalInsula.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_temporalInsula.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_temporalLobe.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_temporalLobe.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_temporalLobe",
   "name": "temporal lobe",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/temporalLobe"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_temporo-parietalJunction.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_temporo-parietalJunction.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_thalamus.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_thalamus.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_thalamus",
   "name": "thalamus",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/dorsalPlusVentralThalamus"
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_ventralOccipitalCortex.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_ventralOccipitalCortex.jsonld
@@ -18,3 +18,4 @@
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }
+

--- a/instances/latest/parcellationEntities/JBA/JBA_ventralStriatum.jsonld
+++ b/instances/latest/parcellationEntities/JBA/JBA_ventralStriatum.jsonld
@@ -16,5 +16,6 @@
   "lookupLabel": "JBA_ventralStriatum",
   "name": "ventral striatum",
   "ontologyIdentifier": null,
-  "relatedUBERONTerm": null
+  "relatedUBERONTerm": "https://openminds.om-i.org/instances/UBERONParcellation/ventralStriatum"
 }
+


### PR DESCRIPTION
I've added this (indirectly) in the SANDS article (one example presents this as available data in the instances) and would like to have the data behind it publicly available before submitting the paper. 
Therefore, I extracted the existing list of PEs and assigned suitable UBERON terms. These terms were assigned purely on sematic relation (i.e., PE name == UBERO name or one of its exact synonyms). I took the liberty to add a few more terms to JBA PEs that were abbreviated (e.g., JBA_STN was assigned "UBERONParcellation/subthalamicNucleus"). 

@lzehl, feel free to assign somebody else to review this PR (e.g., somebody involved in developing the atlas)

Note: I made a PR for one missing UBERON term (#393), but I already linked its future at_id here. 