### PR TITLE
Fix autopopulation for terminologies/terminology across versions

### DIFF
--- a/.github/workflows/autopopulation.yml
+++ b/.github/workflows/autopopulation.yml
@@ -91,6 +91,9 @@ jobs:
           
                   # Generate instance only if the target directory exists
                   if [ -d "$MAIN_FOLDER/$VERSION/$FILE_MODULE/" ]; then
+                    if [[ "$FILE_MODULE" == "terminologies/terminology" ]] && [[ ! -e "$TARGET_FILE" ]]; then
+                      echo "Skipping $TARGET_FILE: terminology file does not exist in $VERSION."
+                    fi
                     echo "Generating instance from $FILE to $TARGET_FILE."
                     python .github/scripts/sync_instances.py "$FILE" "$TARGET_FILE" "$VERSION"
                   else


### PR DESCRIPTION
The autopopulation pipeline populates currently the other versions for terminologies/terminology such as https://github.com/openMetadataInitiative/openMINDS_instances/commit/a1fc601abbbd6a8d551175b2e76473a3f70436c3. The code should prevent this behavior when the corresponding files do not already exist in the other versions.