### PR TITLE
Fix autopopulation pipeline

### DIFF
--- a/.github/workflows/autopopulation.yml
+++ b/.github/workflows/autopopulation.yml
@@ -84,30 +84,24 @@ jobs:
           
               # Iterate over existing versions in the instances directory
               for VERSION in $(ls "$MAIN_FOLDER"); do
-          
-                # Skip processing if the version matches the modified file's version
                 if [ "$VERSION" != "$FILE_VERSION" ]; then
                   TARGET_FILE="$MAIN_FOLDER/$VERSION/$FILE_MODULE/$FILE_NAME"
-          
-                  # Generate instance only if the target directory exists
-                  if [ -d "$MAIN_FOLDER/$VERSION/$FILE_MODULE/" ]; then
-                    if [[ "$FILE_MODULE" == "terminologies/terminology" ]] && [[ ! -e "$TARGET_FILE" ]]; then
-                      echo "Skipping $TARGET_FILE: terminology file does not exist in $VERSION."
-                      continue
-                    fi
+                  TOP_LEVEL_DIR=$(echo "$FILE_MODULE" | cut -d'/' -f1)
+              
+                  # Target file does not exist in instances/VERSION/terminologies/terminology
+                  if [[ "$FILE_MODULE" == "terminologies/terminology" ]] && [[ ! -e "$TARGET_FILE" ]]; then
+                    echo "Skipping $TARGET_FILE: terminology file does not exist in $VERSION."
+                  # Folder does not exist in instances/VERSION/terminologies/
+                  elif [[ "$FILE_MODULE" == terminologies/* ]] && [[ ! -d "$MAIN_FOLDER/$VERSION/$FILE_MODULE/" ]]; then
+                    echo "Skipping $FILE_MODULE: folder does not exist in $VERSION."
+                  # Top-level folder exists in instances/VERSION/
+                  elif [ -d "$MAIN_FOLDER/$VERSION/$TOP_LEVEL_DIR/" ]; then
+                    mkdir -p "$MAIN_FOLDER/$VERSION/$FILE_MODULE/"
                     echo "Generating instance from $FILE to $TARGET_FILE."
                     python .github/scripts/sync_instances.py "$FILE" "$TARGET_FILE" "$VERSION"
+                  # Top-level folder not in instances/VERSION/
                   else
-                    # Folder does not exist
-                    if [[ "$FILE_MODULE" == terminologies/* ]]; then
-                      echo "Skipping $FILE_MODULE (the folder does not exist in $VERSION)."
-                      echo "Skipping the generation of $FILE to $TARGET_FILE."
-                    else
-                      echo "Creating missing folder(s) for $FILE_MODULE in $VERSION."
-                      mkdir -p "$MAIN_FOLDER/$VERSION/$FILE_MODULE/"
-                      echo "Generating instance from $FILE to $TARGET_FILE."
-                      python .github/scripts/sync_instances.py "$FILE" "$TARGET_FILE" "$VERSION"
-                    fi
+                    echo "Skipping $FILE_MODULE: top-level folder does not exist in $VERSION."
                   fi
                 fi
               done

--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ If you want to contribute please follow our :arrow_right: [**contribution guidel
 
 Explore the coverage statistics for the openMINDS instance library :arrow_right: [**openMINDS instance library coverage**][instance-library-coverage]
 
+## Autopopulation
+
+The autopopulation workflow synchronizes instance files across versions when a `.jsonld` file is added or modified on `main`. The file must be modified in exactly one version per push for triggering the autopopulation.
+
+> To skip autopopulation for a specific push or merge, include `[ci skip-autopopulate]` in the commit message.
+
+### Propagation rules
+
+| Case | Behavior |
+|------|----------|
+| Target file exists | File is updated |
+| `terminologies/terminology/*` — target file does not exist | Skipped |
+| `terminologies/*` — target folder does not exist | Skipped |
+| Top-level folder does not exist in target version | Skipped |
+| Top-level folder exists, subfolder does not | Subfolder is created and file is propagated |
+| Same file modified in multiple versions in a single push | Skipped for all versions |
+| File is moved or renamed | Not propagated ⚠️ |
+
+### Property synchronization behavior
+
+| Case | Behavior |
+|------|----------|
+| Property exists in source and is valid for target version | Propagated |
+| Property exists in source but not valid for target version | Ignored |
+| Property exists in target but not in source | Left untouched |
+| Property has the same name but different usage across versions | Propagated ⚠️ |
+
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [contribution-url]: https://openminds-documentation.readthedocs.io/en/latest/shared/contribution_guidelines.html

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The autopopulation workflow synchronizes instance files across versions when a `
 | Top-level folder does not exist in target version          | Skipped |
 | Top-level folder exists, subfolder does not                | Subfolder is created and file is propagated |
 | Same file modified in multiple versions in a single push   | Skipped for all versions |
-| File is moved, renamed  or deleted                         | Not propagated ⚠️ |
+| File is moved, renamed or deleted                          | Not propagated ⚠️ |
 
 ### Property synchronization behavior
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ The autopopulation workflow synchronizes instance files across versions when a `
 
 ### Propagation rules
 
-| Case | Behavior |
-|------|----------|
-| Target file exists | File is updated |
+| Case                                                       | Behavior |
+|------------------------------------------------------------|----------|
+| Target file exists                                         | File is updated |
 | `terminologies/terminology/*` — target file does not exist | Skipped |
-| `terminologies/*` — target folder does not exist | Skipped |
-| Top-level folder does not exist in target version | Skipped |
-| Top-level folder exists, subfolder does not | Subfolder is created and file is propagated |
-| Same file modified in multiple versions in a single push | Skipped for all versions |
-| File is moved or renamed | Not propagated ⚠️ |
+| `terminologies/*` — target folder does not exist           | Skipped |
+| Top-level folder does not exist in target version          | Skipped |
+| Top-level folder exists, subfolder does not                | Subfolder is created and file is propagated |
+| Same file modified in multiple versions in a single push   | Skipped for all versions |
+| File is moved, renamed  or deleted                         | Not propagated ⚠️ |
 
 ### Property synchronization behavior
 


### PR DESCRIPTION
During autopopulation, top-level folders such as Accessibilities and AnatomicalAtlases were incorrectly created across all versions, even when they didn't exist in the target version
The population logic now skips top-level folders that do not exist in the target version.

Note: Subfolders of an existing top-level folder (such as a new subfolder under AnatomicalAtlasVersions) will still be created as expected.